### PR TITLE
feat(backend): enable database connection pooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
+CONN_MAX_AGE=600  # seconds; 0 disables persistent connections
 
 # Hosts (for staging/production)
 STAGING_HOST=staging.example.com

--- a/backend/app/settings/base.py
+++ b/backend/app/settings/base.py
@@ -71,6 +71,7 @@ DATABASES = {
         "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "postgres"),
         "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
         "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+        "CONN_MAX_AGE": int(os.environ.get("CONN_MAX_AGE", 600)),
     }
 }
 


### PR DESCRIPTION
💡 **What:**
- Added `CONN_MAX_AGE` to `DATABASES['default']` in `backend/app/settings/base.py`.
- Set default value to 600 seconds (10 minutes).
- Allowed override via `CONN_MAX_AGE` environment variable.

🎯 **Why:**
- Establishing a database connection is an expensive operation involving TCP handshake, authentication, and backend process startup.
- By enabling persistent connections, Django reuses existing connections for subsequent requests, significantly reducing latency for high-traffic applications.
- This is a recommended best practice for Django with PostgreSQL.

📊 **Measured Improvement:**
- **Baseline:** N/A (Local environment lacks PostgreSQL instance for benchmarking).
- **Projected Impact:** Based on Django documentation and general PostgreSQL performance characteristics, connection pooling can reduce request latency by tens of milliseconds per request, especially for simple queries where connection overhead is a significant portion of the total time.
- **Verification:** Verified that configuration is correctly applied and existing tests pass (using SQLite fallback).


---
*PR created automatically by Jules for task [7744636107322758335](https://jules.google.com/task/7744636107322758335) started by @magi-9*