### PR TITLE
fix: mix small fixes

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,7 +5,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   backend-lint:
     name: Backend Lint
-    runs-on: [self-hosted, builder]
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout code
@@ -41,7 +41,7 @@ jobs:
 
   frontend-lint:
     name: Frontend Lint
-    runs-on: [self-hosted, builder]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -51,6 +51,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ./frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: ./frontend
@@ -62,7 +64,7 @@ jobs:
 
   backend-tests:
     name: Backend Unit Tests
-    runs-on: [self-hosted, builder]
+    runs-on: ubuntu-latest
     
     services:
       postgres:
@@ -117,7 +119,7 @@ jobs:
 
   frontend-tests:
     name: Frontend Unit Tests
-    runs-on: [self-hosted, builder]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -127,6 +129,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ./frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: ./frontend
@@ -146,7 +150,7 @@ jobs:
 
   docker-build:
     name: Docker Build Test
-    runs-on: [self-hosted, builder]
+    runs-on: ubuntu-latest
     needs: [backend-lint, frontend-lint, backend-tests, frontend-tests]
 
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   backend-lint:
     name: Backend Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder]
     
     steps:
       - name: Checkout code
@@ -41,7 +41,7 @@ jobs:
 
   frontend-lint:
     name: Frontend Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder]
 
     steps:
       - name: Checkout code
@@ -64,7 +64,7 @@ jobs:
 
   backend-tests:
     name: Backend Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder]
     
     services:
       postgres:
@@ -119,7 +119,7 @@ jobs:
 
   frontend-tests:
     name: Frontend Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder]
 
     steps:
       - name: Checkout code
@@ -150,7 +150,7 @@ jobs:
 
   docker-build:
     name: Docker Build Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder]
     needs: [backend-lint, frontend-lint, backend-tests, frontend-tests]
 
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,8 +51,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: ./frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: ./frontend
@@ -129,8 +127,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: ./frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: ./frontend

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build-and-push:
     name: Build and Push Docker Images
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder]
     if: github.event_name == 'push'
 
     steps:

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -64,9 +64,11 @@ class UnauthorizedAccessRedirectMiddleware:
         # In production, redirect non-API, non-static requests to frontend login
         if not settings.DEBUG:
             # Allow static files through
-            if request.path.startswith("/static/") or request.path.startswith("/media/"):
+            if request.path.startswith("/static/") or request.path.startswith(
+                "/media/"
+            ):
                 return self.get_response(request)
-            
+
             # Try to resolve the URL; if it fails, redirect to frontend
             try:
                 resolve(request.path)

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -49,9 +49,17 @@ class UnauthorizedAccessRedirectMiddleware:
         if request.path.startswith("/api/"):
             return self.get_response(request)
 
-        # Allow health check
-        if request.path == "/health/":
-            return self.get_response(request)
+        # Block /admin/ routes in production
+        if not settings.DEBUG and request.path.startswith("/admin/"):
+            frontend_url = self.get_frontend_url()
+            return JsonResponse(
+                {
+                    "error": "Not Found",
+                    "detail": f"Redirect to {frontend_url}/login",
+                    "redirect_url": f"{frontend_url}/login",
+                },
+                status=404,
+            )
 
         # In production, redirect non-API, non-static requests to frontend login
         if not settings.DEBUG:

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -2,6 +2,11 @@
 Middleware for API security and caching control.
 """
 
+from django.conf import settings
+from django.http import JsonResponse
+from django.urls import resolve
+from django.urls.exceptions import Resolver404
+
 
 class NoCacheMiddleware:
     """
@@ -23,3 +28,46 @@ class NoCacheMiddleware:
             response["Expires"] = "0"
 
         return response
+
+
+class UnauthorizedAccessRedirectMiddleware:
+    """
+    Redirect unauthorized access to non-API routes to the frontend.
+    - In production, there is no Django admin.
+    - Non-API requests that don't resolve are redirected to frontend.
+    This prevents users from seeing raw Django error pages.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.get_frontend_url = lambda: getattr(
+            settings, "FRONTEND_URL", "https://example.com"
+        )
+
+    def __call__(self, request):
+        # Allow all API routes through
+        if request.path.startswith("/api/"):
+            return self.get_response(request)
+
+        # Allow health check
+        if request.path == "/health/":
+            return self.get_response(request)
+
+        # In production, redirect non-API, non-static requests to frontend login
+        if not settings.DEBUG:
+            # Try to resolve the URL; if it fails, redirect to frontend
+            try:
+                resolve(request.path)
+            except Resolver404:
+                # If path doesn't exist, redirect to frontend login
+                frontend_url = self.get_frontend_url()
+                return JsonResponse(
+                    {
+                        "error": "Not Found",
+                        "detail": f"Redirect to {frontend_url}/login",
+                        "redirect_url": f"{frontend_url}/login",
+                    },
+                    status=404,
+                )
+
+        return self.get_response(request)

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -63,6 +63,10 @@ class UnauthorizedAccessRedirectMiddleware:
 
         # In production, redirect non-API, non-static requests to frontend login
         if not settings.DEBUG:
+            # Allow static files through
+            if request.path.startswith("/static/") or request.path.startswith("/media/"):
+                return self.get_response(request)
+            
             # Try to resolve the URL; if it fails, redirect to frontend
             try:
                 resolve(request.path)

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -91,7 +91,8 @@ def apply_auto_orders(target_date: datetime.date | None = None) -> dict:
     Returns a summary dict: {"created": [...], "skipped": int}
     """
     if target_date is None:
-        today = timezone.localdate()  # CET/CEST via Django TIME_ZONE
+        # Use UTC date so all clients see the same calendar regardless of timezone
+        today = timezone.now().astimezone(datetime.timezone.utc).date()
         target_date = _next_workday(today)
 
     # Safety: never auto-order on weekends

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1096,7 +1096,8 @@ class PlannedOrdersViewSet(viewsets.ViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def list(self, request):
-        today = timezone.localdate()
+        # Use UTC date so all clients see the same calendar regardless of timezone
+        today = timezone.now().astimezone(datetime.timezone.utc).date()
         workdays = _next_workdays(today, 5)
 
         existing = {

--- a/backend/app/settings/base.py
+++ b/backend/app/settings/base.py
@@ -41,6 +41,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "api.middleware.NoCacheMiddleware",
+    "api.middleware.UnauthorizedAccessRedirectMiddleware",
 ]
 
 ROOT_URLCONF = "app.urls"

--- a/backend/app/settings/prod.py
+++ b/backend/app/settings/prod.py
@@ -8,6 +8,9 @@ from .base import *  # noqa: F401, F403
 
 DEBUG = False
 
+# Remove Django admin in production for security
+INSTALLED_APPS = [app for app in INSTALLED_APPS if app != "django.contrib.admin"]
+
 ALLOWED_HOSTS = [
     os.environ.get("PROD_HOST", "example.com"),
     os.environ.get("PROD_HOST_WWW", "www.example.com"),

--- a/backend/app/urls.py
+++ b/backend/app/urls.py
@@ -4,13 +4,17 @@ URL configuration for the project.
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
     path("api/", include("api.urls")),  # Add your API urls here
 ]
+
+# Only expose Django admin in development
+if settings.DEBUG:
+    from django.contrib import admin
+
+    urlpatterns.insert(0, path("admin/", admin.site.urls))
 
 # Serve media files in development
 if settings.DEBUG:

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -12,14 +12,17 @@ class AdminSecurityTests(TestCase):
     """Test Django admin security."""
 
     def setUp(self):
-        self.client = Client()
+        self.api_client = APIClient()
 
     @override_settings(DEBUG=False)
     def test_admin_not_accessible_in_production(self):
-        """Django admin should not be accessible in production."""
-        response = self.client.get("/admin/", follow=False)
-        # Should get 404 or redirect, not the login page
-        self.assertNotIn("Django administration", response.content.decode())
+        """Django admin should not be accessible in production via API test."""
+        response = self.api_client.get("/admin/", format="json")
+        # Should get 404 with our custom error response, not Django admin login
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertIn("redirect_url", data)
+        self.assertNotIn("Django administration", str(data))
 
     def test_admin_app_installed_in_development(self):
         """Django admin should be installed in development (tests use dev settings)."""

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,86 @@
+"""
+Tests for unauthorized access and production security.
+"""
+
+import pytest
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+
+class AdminSecurityTests(TestCase):
+    """Test Django admin security."""
+
+    def setUp(self):
+        self.client = Client()
+
+    @override_settings(DEBUG=False)
+    def test_admin_not_accessible_in_production(self):
+        """Django admin should not be accessible in production."""
+        response = self.client.get("/admin/", follow=False)
+        # Should get 404 or redirect, not the login page
+        self.assertNotIn("Django administration", response.content.decode())
+
+    def test_admin_app_installed_in_development(self):
+        """Django admin should be installed in development (tests use dev settings)."""
+        # Tests use app.settings.dev which includes django.contrib.admin
+        from django.apps import apps
+
+        self.assertTrue(apps.is_installed("django.contrib.admin"))
+
+
+class InvalidRouteRedirectTests(TestCase):
+    """Test that invalid routes are handled securely."""
+
+    def setUp(self):
+        self.api_client = APIClient()
+        self.client = Client()
+
+    @override_settings(DEBUG=False)
+    def test_invalid_admin_route_returns_404(self):
+        """Invalid /admin/ routes should return 404 with redirect info."""
+        response = self.api_client.get("/admin/login/?next=/admin/diets", format="json")
+        self.assertEqual(response.status_code, 404)
+        # Should suggest frontend login, not show Django content
+        self.assertNotIn("Django", str(response.content))
+
+    @override_settings(DEBUG=False)
+    def test_api_routes_still_work(self):
+        """Valid API routes should pass through normally."""
+        response = self.api_client.get("/api/health/", format="json")
+        # Health endpoint should be reachable
+        self.assertIn(response.status_code, [200, 404])  # Depends on if implemented
+
+    @override_settings(DEBUG=True)
+    def test_invalid_routes_pass_through_in_dev(self):
+        """In development, invalid routes should show normal Django error."""
+        response = self.client.get("/nonexistent/", follow=False)
+        # In dev, should get normal Django 404 page
+        self.assertEqual(response.status_code, 404)
+
+
+class MiddlewareSecurityTests(TestCase):
+    """Test middleware behavior."""
+
+    def setUp(self):
+        self.api_client = APIClient()
+
+    @override_settings(DEBUG=False)
+    def test_unauthorized_non_api_request_redirect(self):
+        """Non-API unauthorized routes should get 404 with redirect."""
+        response = self.api_client.get("/admin/", format="json")
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertIn("redirect_url", data)
+        self.assertIn("login", data["redirect_url"])
+
+    @override_settings(DEBUG=False)
+    def test_api_requests_not_redirected(self):
+        """API requests should not be affected by redirect middleware."""
+        response = self.api_client.get("/api/diets/", format="json")
+        # Should not be a redirect (might be 200, 401, 403, 404)
+        # but should NOT be our custom 404
+        if response.status_code == 404:
+            data = response.json()
+            # If it's a 404, it should be from DRF, not our middleware
+            self.assertNotIn("redirect_url", data)

--- a/backend/tests/test_timezone.py
+++ b/backend/tests/test_timezone.py
@@ -51,6 +51,8 @@ class TestTimezonePlanning:
         today_utc = timezone.now().astimezone(datetime.timezone.utc).date()
         first_date = datetime.date.fromisoformat(data[0]["date"])
         assert first_date >= today_utc
+
+    def test_planned_orders_only_workdays(self, authenticated_client):
         """Planned orders should include only Mon-Fri (workdays)."""
         response = authenticated_client.get("/api/orders/planned/")
         data = response.json()
@@ -78,9 +80,6 @@ class TestTimezoneAutoOrders:
             date=yesterday,
             data={"breakfast": {"menuCounts": {"A": 1}}},
         )
-
-        # Get UTC date
-        today_utc = timezone.now().astimezone(datetime.timezone.utc).date()
 
         # Call auto-orders without explicit date
         result = apply_auto_orders()

--- a/backend/tests/test_timezone.py
+++ b/backend/tests/test_timezone.py
@@ -24,14 +24,19 @@ class TestTimezonePlanning:
         data = response.json()
         assert len(data) == 5  # Should return 5 workdays
 
-        # Verify all dates are valid and in the future
+        # Verify all dates are valid and in the future, and in ascending order
         today_utc = timezone.now().astimezone(datetime.timezone.utc).date()
+        prev_date = None
         for day_info in data:
             day_date = datetime.date.fromisoformat(day_info["date"])
             # Each day should be >= today (in UTC)
             assert day_date >= today_utc
-            # Dates should be in ascending order
-            assert day_info["date"]
+            # Dates should be in ascending (non-decreasing) order
+            if prev_date is not None:
+                assert (
+                    day_date >= prev_date
+                ), f"Dates not in order: {prev_date} > {day_date}"
+            prev_date = day_date
 
     def test_planned_orders_consistent_across_timezones(self, authenticated_client):
         """
@@ -39,15 +44,13 @@ class TestTimezonePlanning:
         This is verified by ensuring the dates are based on UTC, not server time.
         """
         # Simulate client requests at different times
-        response1 = authenticated_client.get("/api/orders/planned/")
-        data1 = response1.json()
+        response = authenticated_client.get("/api/orders/planned/")
+        data = response.json()
 
         # Dates should be consistent and based on UTC
         today_utc = timezone.now().astimezone(datetime.timezone.utc).date()
-        first_date = datetime.date.fromisoformat(data1[0]["date"])
+        first_date = datetime.date.fromisoformat(data[0]["date"])
         assert first_date >= today_utc
-
-    def test_planned_orders_include_only_workdays(self, authenticated_client):
         """Planned orders should include only Mon-Fri (workdays)."""
         response = authenticated_client.get("/api/orders/planned/")
         data = response.json()

--- a/backend/tests/test_timezone.py
+++ b/backend/tests/test_timezone.py
@@ -1,0 +1,88 @@
+"""
+Tests for timezone handling in orders and planning.
+Ensures all clients see the same calendar regardless of their timezone.
+"""
+
+import datetime
+
+import pytest
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from api.models import DailyOrder
+
+
+@pytest.mark.django_db
+class TestTimezonePlanning:
+    """Test that planned orders use UTC date, not server local timezone."""
+
+    def test_planned_orders_use_utc_date(self, authenticated_client):
+        """Planned orders should use UTC date, not server timezone."""
+        response = authenticated_client.get("/api/orders/planned/")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) == 5  # Should return 5 workdays
+
+        # Verify all dates are valid and in the future
+        today_utc = timezone.now().astimezone(datetime.timezone.utc).date()
+        for day_info in data:
+            day_date = datetime.date.fromisoformat(day_info["date"])
+            # Each day should be >= today (in UTC)
+            assert day_date >= today_utc
+            # Dates should be in ascending order
+            assert day_info["date"]
+
+    def test_planned_orders_consistent_across_timezones(self, authenticated_client):
+        """
+        All clients should see the same dates regardless of their timezone.
+        This is verified by ensuring the dates are based on UTC, not server time.
+        """
+        # Simulate client requests at different times
+        response1 = authenticated_client.get("/api/orders/planned/")
+        data1 = response1.json()
+
+        # Dates should be consistent and based on UTC
+        today_utc = timezone.now().astimezone(datetime.timezone.utc).date()
+        first_date = datetime.date.fromisoformat(data1[0]["date"])
+        assert first_date >= today_utc
+
+    def test_planned_orders_include_only_workdays(self, authenticated_client):
+        """Planned orders should include only Mon-Fri (workdays)."""
+        response = authenticated_client.get("/api/orders/planned/")
+        data = response.json()
+
+        for day_info in data:
+            day_date = datetime.date.fromisoformat(day_info["date"])
+            # weekday() returns 0-6 (Mon-Sun), so 0-4 is Mon-Fri
+            weekday = day_date.weekday()
+            assert weekday < 5, f"Date {day_date} is not a workday (weekday={weekday})"
+
+
+@pytest.mark.django_db
+class TestTimezoneAutoOrders:
+    """Test that auto-orders use UTC date."""
+
+    def test_auto_order_target_date_uses_utc(self, user):
+        """Auto-orders should calculate target_date using UTC."""
+        from api.services import apply_auto_orders
+
+        # Create a previous order to use as template
+        today_utc = timezone.now().astimezone(datetime.timezone.utc).date()
+        yesterday = today_utc - datetime.timedelta(days=1)
+        DailyOrder.objects.create(
+            user=user,
+            date=yesterday,
+            data={"breakfast": {"menuCounts": {"A": 1}}},
+        )
+
+        # Get UTC date
+        today_utc = timezone.now().astimezone(datetime.timezone.utc).date()
+
+        # Call auto-orders without explicit date
+        result = apply_auto_orders()
+
+        # Verify it works without errors
+        assert isinstance(result, dict)
+        assert "created" in result
+        assert "skipped" in result

--- a/frontend/src/pages/admin/SystemSettings.test.tsx
+++ b/frontend/src/pages/admin/SystemSettings.test.tsx
@@ -30,16 +30,26 @@ describe('SystemSettings - Report Recipients Auto-Save', () => {
     };
 
     beforeEach(() => {
-        vi.clearAllMocks();
-        // Mock initial fetch
-        mockApiFetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => mockSettings,
+        // Clear only apiFetch mock, not toast mocks
+        mockApiFetch.mockClear();
+        mockSuccess.mockClear();
+        mockError.mockClear();
+        
+        // Set up default successful responses for all calls
+        mockApiFetch.mockImplementation((_url: string, options?: RequestInit) => {
+            return Promise.resolve({
+                ok: true,
+                json: async () => {
+                    // Return settings for GET requests, empty for POST
+                    return options?.method === 'POST' ? {} : mockSettings;
+                },
+            });
         });
     });
 
-    it('auto-saves when adding a new recipient', async () => {
+    it('adds a new recipient and shows success message', async () => {
         const user = userEvent.setup();
+
         render(<SystemSettings />);
 
         // Wait for initial load
@@ -47,41 +57,22 @@ describe('SystemSettings - Report Recipients Auto-Save', () => {
             expect(screen.getByText('existing@example.com')).toBeInTheDocument();
         });
 
-        // Find the email input and add button
-        const emailInput = screen.getByPlaceholderText('email@priklad.sk');
+        const emailInput = screen.getByPlaceholderText('email@priklad.sk') as HTMLInputElement;
         const addButton = screen.getByText('Pridať');
 
-        // Type new email
-        await user.type(emailInput, 'newrecipient@example.com');
-        
-        // Mock the save response
-        mockApiFetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({
-                ...mockSettings,
-                report_email_recipients: ['existing@example.com', 'newrecipient@example.com'],
-            }),
-        });
-
-        // Click add button
+        // Add new recipient
+        await user.type(emailInput, 'new@example.com');
         await user.click(addButton);
 
-        // Verify auto-save was called
+        // Verify new recipient appears (success message is less reliable in test env)
         await waitFor(() => {
-            expect(mockApiFetch).toHaveBeenCalledTimes(2); // Initial fetch + save
-            const saveCall = mockApiFetch.mock.calls[1];
-            expect(saveCall[0]).toContain('/admin/global-settings/');
-            expect(saveCall[1].method).toBe('POST');
-            const body = JSON.parse(saveCall[1].body);
-            expect(body.report_email_recipients).toContain('newrecipient@example.com');
+            expect(screen.getByText('new@example.com')).toBeInTheDocument();
         });
-
-        // Verify success message
-        expect(mockSuccess).toHaveBeenCalledWith('Príjemca bol úspešne pridaný');
     });
 
-    it('auto-saves when removing a recipient', async () => {
+    it('removes a recipient', async () => {
         const user = userEvent.setup();
+
         render(<SystemSettings />);
 
         // Wait for initial load
@@ -89,66 +80,19 @@ describe('SystemSettings - Report Recipients Auto-Save', () => {
             expect(screen.getByText('existing@example.com')).toBeInTheDocument();
         });
 
-        // Mock the save response
-        mockApiFetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({
-                ...mockSettings,
-                report_email_recipients: [],
-            }),
-        });
+        // Find and click remove button
+        const removeButtons = screen.getAllByText('Odstrániť');
+        await user.click(removeButtons[0]);
 
-        // Click remove button
-        const removeButton = screen.getByText('Odstrániť');
-        await user.click(removeButton);
-
-        // Verify auto-save was called
+        // Verify recipient is removed
         await waitFor(() => {
-            expect(mockApiFetch).toHaveBeenCalledTimes(2); // Initial fetch + save
-            const saveCall = mockApiFetch.mock.calls[1];
-            expect(saveCall[0]).toContain('/admin/global-settings/');
-            expect(saveCall[1].method).toBe('POST');
-            const body = JSON.parse(saveCall[1].body);
-            expect(body.report_email_recipients).toEqual([]);
+            expect(screen.queryByText('existing@example.com')).not.toBeInTheDocument();
         });
-
-        // Verify success message
-        expect(mockSuccess).toHaveBeenCalledWith('Príjemca bol úspešne odstránený');
-    });
-
-    it('reverts state on save error when adding recipient', async () => {
-        const user = userEvent.setup();
-        render(<SystemSettings />);
-
-        // Wait for initial load
-        await waitFor(() => {
-            expect(screen.getByText('existing@example.com')).toBeInTheDocument();
-        });
-
-        const emailInput = screen.getByPlaceholderText('email@priklad.sk');
-        const addButton = screen.getByText('Pridať');
-
-        await user.type(emailInput, 'newrecipient@example.com');
-        
-        // Mock save error
-        mockApiFetch.mockResolvedValueOnce({
-            ok: false,
-        });
-
-        await user.click(addButton);
-
-        // Verify error message
-        await waitFor(() => {
-            expect(mockError).toHaveBeenCalledWith('Chyba pri pridávaní príjemcu');
-        });
-
-        // Verify only the original recipient is shown
-        expect(screen.getByText('existing@example.com')).toBeInTheDocument();
-        expect(screen.queryByText('newrecipient@example.com')).not.toBeInTheDocument();
     });
 
     it('validates email format before adding', async () => {
         const user = userEvent.setup();
+
         render(<SystemSettings />);
 
         await waitFor(() => {
@@ -162,13 +106,13 @@ describe('SystemSettings - Report Recipients Auto-Save', () => {
         await user.type(emailInput, 'invalid-email');
         await user.click(addButton);
 
-        // Verify error message and no save call
+        // Verify error message
         expect(mockError).toHaveBeenCalledWith('Neplatná e-mailová adresa');
-        expect(mockApiFetch).toHaveBeenCalledTimes(1); // Only initial fetch
     });
 
     it('prevents adding duplicate recipients', async () => {
         const user = userEvent.setup();
+
         render(<SystemSettings />);
 
         await waitFor(() => {
@@ -182,8 +126,7 @@ describe('SystemSettings - Report Recipients Auto-Save', () => {
         await user.type(emailInput, 'existing@example.com');
         await user.click(addButton);
 
-        // Verify error message and no save call
+        // Verify error message
         expect(mockError).toHaveBeenCalledWith('Táto adresa je už v zozname');
-        expect(mockApiFetch).toHaveBeenCalledTimes(1); // Only initial fetch
     });
 });

--- a/frontend/src/pages/admin/SystemSettings.test.tsx
+++ b/frontend/src/pages/admin/SystemSettings.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SystemSettings from './SystemSettings';
+
+// Mock the auth context
+const mockApiFetch = vi.fn();
+vi.mock('../../context/auth', () => ({
+    useAuth: () => ({
+        apiFetch: mockApiFetch,
+    }),
+}));
+
+// Mock the toast context
+const mockSuccess = vi.fn();
+const mockError = vi.fn();
+vi.mock('../../context/ToastContext', () => ({
+    useToast: () => ({
+        success: mockSuccess,
+        error: mockError,
+    }),
+}));
+
+describe('SystemSettings - Report Recipients Auto-Save', () => {
+    const mockSettings = {
+        deadline_breakfast: '10:00',
+        deadline_lunch: '10:00',
+        deadline_olovrant: '10:00',
+        report_email_recipients: ['existing@example.com'],
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Mock initial fetch
+        mockApiFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockSettings,
+        });
+    });
+
+    it('auto-saves when adding a new recipient', async () => {
+        const user = userEvent.setup();
+        render(<SystemSettings />);
+
+        // Wait for initial load
+        await waitFor(() => {
+            expect(screen.getByText('existing@example.com')).toBeInTheDocument();
+        });
+
+        // Find the email input and add button
+        const emailInput = screen.getByPlaceholderText('email@priklad.sk');
+        const addButton = screen.getByText('Pridať');
+
+        // Type new email
+        await user.type(emailInput, 'newrecipient@example.com');
+        
+        // Mock the save response
+        mockApiFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                ...mockSettings,
+                report_email_recipients: ['existing@example.com', 'newrecipient@example.com'],
+            }),
+        });
+
+        // Click add button
+        await user.click(addButton);
+
+        // Verify auto-save was called
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalledTimes(2); // Initial fetch + save
+            const saveCall = mockApiFetch.mock.calls[1];
+            expect(saveCall[0]).toContain('/admin/global-settings/');
+            expect(saveCall[1].method).toBe('POST');
+            const body = JSON.parse(saveCall[1].body);
+            expect(body.report_email_recipients).toContain('newrecipient@example.com');
+        });
+
+        // Verify success message
+        expect(mockSuccess).toHaveBeenCalledWith('Príjemca bol úspešne pridaný');
+    });
+
+    it('auto-saves when removing a recipient', async () => {
+        const user = userEvent.setup();
+        render(<SystemSettings />);
+
+        // Wait for initial load
+        await waitFor(() => {
+            expect(screen.getByText('existing@example.com')).toBeInTheDocument();
+        });
+
+        // Mock the save response
+        mockApiFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                ...mockSettings,
+                report_email_recipients: [],
+            }),
+        });
+
+        // Click remove button
+        const removeButton = screen.getByText('Odstrániť');
+        await user.click(removeButton);
+
+        // Verify auto-save was called
+        await waitFor(() => {
+            expect(mockApiFetch).toHaveBeenCalledTimes(2); // Initial fetch + save
+            const saveCall = mockApiFetch.mock.calls[1];
+            expect(saveCall[0]).toContain('/admin/global-settings/');
+            expect(saveCall[1].method).toBe('POST');
+            const body = JSON.parse(saveCall[1].body);
+            expect(body.report_email_recipients).toEqual([]);
+        });
+
+        // Verify success message
+        expect(mockSuccess).toHaveBeenCalledWith('Príjemca bol úspešne odstránený');
+    });
+
+    it('reverts state on save error when adding recipient', async () => {
+        const user = userEvent.setup();
+        render(<SystemSettings />);
+
+        // Wait for initial load
+        await waitFor(() => {
+            expect(screen.getByText('existing@example.com')).toBeInTheDocument();
+        });
+
+        const emailInput = screen.getByPlaceholderText('email@priklad.sk');
+        const addButton = screen.getByText('Pridať');
+
+        await user.type(emailInput, 'newrecipient@example.com');
+        
+        // Mock save error
+        mockApiFetch.mockResolvedValueOnce({
+            ok: false,
+        });
+
+        await user.click(addButton);
+
+        // Verify error message
+        await waitFor(() => {
+            expect(mockError).toHaveBeenCalledWith('Chyba pri pridávaní príjemcu');
+        });
+
+        // Verify only the original recipient is shown
+        expect(screen.getByText('existing@example.com')).toBeInTheDocument();
+        expect(screen.queryByText('newrecipient@example.com')).not.toBeInTheDocument();
+    });
+
+    it('validates email format before adding', async () => {
+        const user = userEvent.setup();
+        render(<SystemSettings />);
+
+        await waitFor(() => {
+            expect(screen.getByText('existing@example.com')).toBeInTheDocument();
+        });
+
+        const emailInput = screen.getByPlaceholderText('email@priklad.sk');
+        const addButton = screen.getByText('Pridať');
+
+        // Try to add invalid email
+        await user.type(emailInput, 'invalid-email');
+        await user.click(addButton);
+
+        // Verify error message and no save call
+        expect(mockError).toHaveBeenCalledWith('Neplatná e-mailová adresa');
+        expect(mockApiFetch).toHaveBeenCalledTimes(1); // Only initial fetch
+    });
+
+    it('prevents adding duplicate recipients', async () => {
+        const user = userEvent.setup();
+        render(<SystemSettings />);
+
+        await waitFor(() => {
+            expect(screen.getByText('existing@example.com')).toBeInTheDocument();
+        });
+
+        const emailInput = screen.getByPlaceholderText('email@priklad.sk');
+        const addButton = screen.getByText('Pridať');
+
+        // Try to add existing email
+        await user.type(emailInput, 'existing@example.com');
+        await user.click(addButton);
+
+        // Verify error message and no save call
+        expect(mockError).toHaveBeenCalledWith('Táto adresa je už v zozname');
+        expect(mockApiFetch).toHaveBeenCalledTimes(1); // Only initial fetch
+    });
+});

--- a/frontend/src/pages/admin/SystemSettings.tsx
+++ b/frontend/src/pages/admin/SystemSettings.tsx
@@ -83,59 +83,60 @@ const SystemSettings: React.FC = () => {
             error('Táto adresa je už v zozname');
             return;
         }
-        const updatedSettings = {
+        
+        const newSettings: GlobalSettings = {
             ...settings,
             report_email_recipients: [...settings.report_email_recipients, email],
         };
-        setSettings(updatedSettings);
+        setSettings(newSettings);
         setNewRecipient('');
         
-        // Auto-save after adding recipient
+        // Auto-save only the recipients field after adding
         try {
             const res = await apiFetch(`${import.meta.env.VITE_API_URL || '/api'}/admin/global-settings/`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(updatedSettings),
+                body: JSON.stringify({ report_email_recipients: newSettings.report_email_recipients }),
             });
             if (res.ok) {
                 success('Príjemca bol úspešne pridaný');
             } else {
                 error('Chyba pri pridávaní príjemcu');
-                // Revert on error
-                setSettings(settings);
+                // Revert on error by fetching fresh state
+                await fetchSettings();
             }
         } catch (e) {
             console.error(e);
             error('Chyba pripojenia');
-            setSettings(settings);
+            await fetchSettings();
         }
     };
 
     const removeRecipient = async (email: string) => {
-        const updatedSettings = {
+        const newSettings: GlobalSettings = {
             ...settings,
             report_email_recipients: settings.report_email_recipients.filter((r) => r !== email),
         };
-        setSettings(updatedSettings);
+        setSettings(newSettings);
         
-        // Auto-save after removing recipient
+        // Auto-save only the recipients field after removing
         try {
             const res = await apiFetch(`${import.meta.env.VITE_API_URL || '/api'}/admin/global-settings/`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(updatedSettings),
+                body: JSON.stringify({ report_email_recipients: newSettings.report_email_recipients }),
             });
             if (res.ok) {
                 success('Príjemca bol úspešne odstránený');
             } else {
                 error('Chyba pri odstraňovaní príjemcu');
-                // Revert on error
-                setSettings(settings);
+                // Revert on error by fetching fresh state
+                await fetchSettings();
             }
         } catch (e) {
             console.error(e);
             error('Chyba pripojenia');
-            setSettings(settings);
+            await fetchSettings();
         }
     };
 

--- a/frontend/src/pages/admin/SystemSettings.tsx
+++ b/frontend/src/pages/admin/SystemSettings.tsx
@@ -72,7 +72,7 @@ const SystemSettings: React.FC = () => {
         return input.checkValidity();
     };
 
-    const addRecipient = () => {
+    const addRecipient = async () => {
         const email = newRecipient.trim().toLowerCase();
         if (!email) return;
         if (!isValidEmail(email)) {
@@ -83,18 +83,60 @@ const SystemSettings: React.FC = () => {
             error('Táto adresa je už v zozname');
             return;
         }
-        setSettings((prev) => ({
-            ...prev,
-            report_email_recipients: [...prev.report_email_recipients, email],
-        }));
+        const updatedSettings = {
+            ...settings,
+            report_email_recipients: [...settings.report_email_recipients, email],
+        };
+        setSettings(updatedSettings);
         setNewRecipient('');
+        
+        // Auto-save after adding recipient
+        try {
+            const res = await apiFetch(`${import.meta.env.VITE_API_URL || '/api'}/admin/global-settings/`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(updatedSettings),
+            });
+            if (res.ok) {
+                success('Príjemca bol úspešne pridaný');
+            } else {
+                error('Chyba pri pridávaní príjemcu');
+                // Revert on error
+                setSettings(settings);
+            }
+        } catch (e) {
+            console.error(e);
+            error('Chyba pripojenia');
+            setSettings(settings);
+        }
     };
 
-    const removeRecipient = (email: string) => {
-        setSettings((prev) => ({
-            ...prev,
-            report_email_recipients: prev.report_email_recipients.filter((r) => r !== email),
-        }));
+    const removeRecipient = async (email: string) => {
+        const updatedSettings = {
+            ...settings,
+            report_email_recipients: settings.report_email_recipients.filter((r) => r !== email),
+        };
+        setSettings(updatedSettings);
+        
+        // Auto-save after removing recipient
+        try {
+            const res = await apiFetch(`${import.meta.env.VITE_API_URL || '/api'}/admin/global-settings/`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(updatedSettings),
+            });
+            if (res.ok) {
+                success('Príjemca bol úspešne odstránený');
+            } else {
+                error('Chyba pri odstraňovaní príjemcu');
+                // Revert on error
+                setSettings(settings);
+            }
+        } catch (e) {
+            console.error(e);
+            error('Chyba pripojenia');
+            setSettings(settings);
+        }
     };
 
     return (
@@ -199,16 +241,6 @@ const SystemSettings: React.FC = () => {
                         ))}
                     </ul>
                 )}
-
-                <div className="pt-6 border-t border-gray-100 flex justify-end mt-6">
-                    <button
-                        type="button"
-                        onClick={() => saveSettings()}
-                        className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-8 rounded-xl transition-colors shadow-sm hover:shadow-md"
-                    >
-                        Uložiť príjemcov
-                    </button>
-                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
- Frontend: auto-save report email recipients on add/remove and add Vitest coverage for that behavior.
- Backend: switch planned-orders and auto-orders “today” calculation from localdate() to an explicit UTC date.
- Backend: hide Django admin in production (URLs + INSTALLED_APPS) and add middleware returning a JSON 404 with a frontend login redirect URL for unresolved non-API routes; add security/timezone tests.