### PR TITLE
fix: few fixes 1

### DIFF
--- a/backend/api/email_utils.py
+++ b/backend/api/email_utils.py
@@ -56,10 +56,27 @@ def send_daily_report_email(
     report_date: str,
     attachment_bytes: bytes,
     attachment_filename: str,
+    meals: list[str] | None = None,
 ) -> None:
-    """Send the daily order report as an XLSX attachment to *recipients*."""
+    """Send the daily order report as an XLSX attachment to *recipients*.
+
+    Args:
+        recipients: List of email addresses to send to
+        report_date: Date string in YYYY-MM-DD format
+        attachment_bytes: XLSX file bytes
+        attachment_filename: Name of the attachment file
+        meals: List of meals included in report (breakfast, lunch, olovrant)
+    """
     from_email = getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@example.com")
-    subject = f"Denný prehľad objednávok — {report_date}"
+
+    # Build subject and body based on included meals
+    if meals:
+        meal_labels = {"breakfast": "Raňajky", "lunch": "Obed", "olovrant": "Olovrant"}
+        meals_text = ", ".join(meal_labels.get(m, m) for m in meals)
+        subject = f"Denný prehľad ({meals_text}) — {report_date}"
+    else:
+        subject = f"Denný prehľad objednávok — {report_date}"
+
     body = (
         f"Dobrý deň,\n\n"
         f"V prílohe nájdete denný prehľad objednávok za {report_date}.\n\n"

--- a/backend/api/management/commands/send_order_report.py
+++ b/backend/api/management/commands/send_order_report.py
@@ -35,6 +35,9 @@ def build_xlsx_bytes(
         target_date: The date to generate the report for
         meals: List of meals to include (e.g., ["breakfast"] or ["breakfast", "lunch", "olovrant"])
                If None, includes all meals.
+
+    Raises:
+        ValueError: If meals list is provided but contains no valid meal keys.
     """
     import openpyxl
     from openpyxl.styles import Alignment, Font, PatternFill
@@ -43,10 +46,20 @@ def build_xlsx_bytes(
     if meals is None:
         meals = _MEAL_KEYS
     else:
+        # Warn about any unknown meal keys
+        invalid_meals = sorted({m for m in meals if m not in _MEAL_KEYS})
+        if invalid_meals:
+            logger.warning(
+                "Unknown meal keys in order report: %s (valid: %s)",
+                ", ".join(invalid_meals),
+                ", ".join(_MEAL_KEYS),
+            )
         # Ensure meals is a subset of valid meals
         meals = [m for m in meals if m in _MEAL_KEYS]
         if not meals:
-            meals = _MEAL_KEYS
+            raise ValueError(
+                f"No valid meals in request. Valid keys: {', '.join(_MEAL_KEYS)}"
+            )
 
     safe_date = target_date.isoformat()
 
@@ -170,9 +183,27 @@ class Command(BaseCommand):
             )
             return
 
-        # ── Parse meals parameter ────────────────────────────────────────────
+        # ── Parse and validate meals parameter ───────────────────────────────
         meals_str = options.get("meals", "breakfast,lunch,olovrant")
-        meals = [m.strip() for m in meals_str.split(",") if m.strip()]
+        requested_meals = [m.strip() for m in meals_str.split(",") if m.strip()]
+
+        # Validate and normalize meals
+        invalid_meals = sorted({m for m in requested_meals if m not in _MEAL_KEYS})
+        if invalid_meals:
+            logger.warning(
+                "Unknown meal keys: %s (valid: %s)",
+                ", ".join(invalid_meals),
+                ", ".join(_MEAL_KEYS),
+            )
+
+        meals = [m for m in requested_meals if m in _MEAL_KEYS]
+        if not meals:
+            self.stderr.write(
+                self.style.ERROR(
+                    f"No valid meals specified. Valid keys: {', '.join(_MEAL_KEYS)}"
+                )
+            )
+            return
 
         # ── Generate report ───────────────────────────────────────────────────
         try:

--- a/backend/api/management/commands/send_order_report.py
+++ b/backend/api/management/commands/send_order_report.py
@@ -26,11 +26,27 @@ _MEAL_KEYS = ["breakfast", "lunch", "olovrant"]
 _MEAL_LABELS = {"breakfast": "Raňajky", "lunch": "Obed", "olovrant": "Olovrant"}
 
 
-def build_xlsx_bytes(target_date: datetime.date) -> bytes:
-    """Generate an XLSX report for *target_date* and return raw bytes."""
+def build_xlsx_bytes(
+    target_date: datetime.date, meals: list[str] | None = None
+) -> bytes:
+    """Generate an XLSX report for *target_date* and optional meal filter.
+
+    Args:
+        target_date: The date to generate the report for
+        meals: List of meals to include (e.g., ["breakfast"] or ["breakfast", "lunch", "olovrant"])
+               If None, includes all meals.
+    """
     import openpyxl
     from openpyxl.styles import Alignment, Font, PatternFill
     from openpyxl.utils import get_column_letter
+
+    if meals is None:
+        meals = _MEAL_KEYS
+    else:
+        # Ensure meals is a subset of valid meals
+        meals = [m for m in meals if m in _MEAL_KEYS]
+        if not meals:
+            meals = _MEAL_KEYS
 
     safe_date = target_date.isoformat()
 
@@ -53,9 +69,9 @@ def build_xlsx_bytes(target_date: datetime.date) -> bytes:
     ]
 
     vs = AdminSummaryViewSet
-    sorted_cats = vs._xlsx_collect_columns(rows_data, _MEAL_KEYS)
+    sorted_cats = vs._xlsx_collect_columns(rows_data, meals)
     col_meta, header_row_1, header_row_2, header_row_3 = vs._xlsx_build_column_meta(
-        sorted_cats, _MEAL_KEYS, _MEAL_LABELS
+        sorted_cats, meals, _MEAL_LABELS
     )
 
     wb = openpyxl.Workbook()
@@ -83,13 +99,13 @@ def build_xlsx_bytes(target_date: datetime.date) -> bytes:
         ws,
         col_meta,
         sorted_cats,
-        _MEAL_KEYS,
+        meals,
         header_fill_main,
         header_fill_meal,
         header_font,
         center,
     )
-    vs._xlsx_write_data(ws, rows_data, _MEAL_KEYS, sorted_cats, bold_font)
+    vs._xlsx_write_data(ws, rows_data, meals, sorted_cats, bold_font)
 
     ws.column_dimensions["A"].width = 28
     for c_idx in range(2, len(col_meta) + 1):
@@ -117,6 +133,12 @@ class Command(BaseCommand):
             type=str,
             default=None,
             help="Explicit target date in YYYY-MM-DD format.",
+        )
+        parser.add_argument(
+            "--meals",
+            type=str,
+            default="breakfast,lunch,olovrant",
+            help="Comma-separated list of meals to include (breakfast, lunch, olovrant). Default: all.",
         )
 
     def handle(self, *args, **options):
@@ -148,9 +170,13 @@ class Command(BaseCommand):
             )
             return
 
+        # ── Parse meals parameter ────────────────────────────────────────────
+        meals_str = options.get("meals", "breakfast,lunch,olovrant")
+        meals = [m.strip() for m in meals_str.split(",") if m.strip()]
+
         # ── Generate report ───────────────────────────────────────────────────
         try:
-            report_bytes = build_xlsx_bytes(target_date)
+            report_bytes = build_xlsx_bytes(target_date, meals=meals)
         except Exception:
             logger.exception("Failed to generate XLSX report for %s", target_date)
             self.stderr.write(
@@ -167,6 +193,7 @@ class Command(BaseCommand):
                 report_date=target_date.isoformat(),
                 attachment_bytes=report_bytes,
                 attachment_filename=filename,
+                meals=meals,
             )
         except Exception:
             self.stderr.write(self.style.ERROR("Failed to send daily report email."))

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -3,7 +3,7 @@ Middleware for API security and caching control.
 """
 
 from django.conf import settings
-from django.http import HttpResponseRedirect, JsonResponse
+from django.http import HttpResponseRedirect
 from django.urls import resolve
 from django.urls.exceptions import Resolver404
 

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -3,7 +3,7 @@ Middleware for API security and caching control.
 """
 
 from django.conf import settings
-from django.http import JsonResponse, HttpResponseRedirect
+from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import resolve
 from django.urls.exceptions import Resolver404
 

--- a/backend/api/middleware.py
+++ b/backend/api/middleware.py
@@ -3,7 +3,7 @@ Middleware for API security and caching control.
 """
 
 from django.conf import settings
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponseRedirect
 from django.urls import resolve
 from django.urls.exceptions import Resolver404
 
@@ -49,17 +49,12 @@ class UnauthorizedAccessRedirectMiddleware:
         if request.path.startswith("/api/"):
             return self.get_response(request)
 
-        # Block /admin/ routes in production
-        if not settings.DEBUG and request.path.startswith("/admin/"):
+        # Block only the Django admin root in production (/admin/ and /admin)
+        # Do NOT block frontend admin routes like /admin/settings, /admin/clients, etc.
+        if not settings.DEBUG and request.path in ("/admin/", "/admin"):
             frontend_url = self.get_frontend_url()
-            return JsonResponse(
-                {
-                    "error": "Not Found",
-                    "detail": f"Redirect to {frontend_url}/login",
-                    "redirect_url": f"{frontend_url}/login",
-                },
-                status=404,
-            )
+            # Use proper HTTP redirect instead of JSON error
+            return HttpResponseRedirect(f"{frontend_url}/login")
 
         # In production, redirect non-API, non-static requests to frontend login
         if not settings.DEBUG:
@@ -69,19 +64,12 @@ class UnauthorizedAccessRedirectMiddleware:
             ):
                 return self.get_response(request)
 
-            # Try to resolve the URL; if it fails, redirect to frontend
+            # Try to resolve the URL; if it fails, redirect to frontend login
             try:
                 resolve(request.path)
             except Resolver404:
                 # If path doesn't exist, redirect to frontend login
                 frontend_url = self.get_frontend_url()
-                return JsonResponse(
-                    {
-                        "error": "Not Found",
-                        "detail": f"Redirect to {frontend_url}/login",
-                        "redirect_url": f"{frontend_url}/login",
-                    },
-                    status=404,
-                )
+                return HttpResponseRedirect(f"{frontend_url}/login")
 
         return self.get_response(request)

--- a/backend/api/signals.py
+++ b/backend/api/signals.py
@@ -1,8 +1,9 @@
 """
 Django signals for the api app.
 
-GlobalSettings post_save → keeps the Celery Beat PeriodicTask for auto-orders
-in sync with whatever deadline the admin configures.
+GlobalSettings post_save → keeps the Celery Beat PeriodicTasks for:
+- auto-orders: fires at max(deadline_breakfast, deadline_lunch, deadline_olovrant)
+- daily reports: fires at breakfast deadline (breakfast only) and olovrant deadline (all meals)
 """
 
 import json
@@ -13,7 +14,9 @@ from django.dispatch import receiver
 
 logger = logging.getLogger(__name__)
 
-PERIODIC_TASK_NAME = "auto-order-daily"
+PERIODIC_TASK_NAME_AUTO_ORDER = "auto-order-daily"
+PERIODIC_TASK_NAME_REPORT_BREAKFAST = "daily-report-breakfast"
+PERIODIC_TASK_NAME_REPORT_ALL = "daily-report-all-meals"
 
 
 def _sync_auto_order_schedule(settings_instance) -> None:
@@ -48,7 +51,7 @@ def _sync_auto_order_schedule(settings_instance) -> None:
     )
 
     PeriodicTask.objects.update_or_create(
-        name=PERIODIC_TASK_NAME,
+        name=PERIODIC_TASK_NAME_AUTO_ORDER,
         defaults={
             "task": "api.tasks.apply_auto_orders_task",
             "crontab": schedule,
@@ -69,7 +72,81 @@ def _sync_auto_order_schedule(settings_instance) -> None:
     )
 
 
+def _sync_daily_report_schedule(settings_instance) -> None:
+    """
+    Create or update two Celery Beat PeriodicTasks for daily reports:
+    1. Breakfast-only report at breakfast deadline (Monday–Friday)
+    2. Full report (all meals) at olovrant deadline (Monday–Friday)
+    """
+    try:
+        from django_celery_beat.models import CrontabSchedule, PeriodicTask
+    except ImportError:
+        logger.warning(
+            "django_celery_beat not installed – skipping daily report schedule sync."
+        )
+        return
+
+    # ── Task 1: Breakfast-only report at breakfast deadline ──────────────────
+    breakfast_time = settings_instance.deadline_breakfast
+    breakfast_schedule, _ = CrontabSchedule.objects.get_or_create(
+        minute=breakfast_time.minute,
+        hour=breakfast_time.hour,
+        day_of_week="1-5",  # Mon–Fri
+        day_of_month="*",
+        month_of_year="*",
+        timezone="Europe/Bratislava",
+    )
+
+    PeriodicTask.objects.update_or_create(
+        name=PERIODIC_TASK_NAME_REPORT_BREAKFAST,
+        defaults={
+            "task": "api.tasks.send_daily_report_task",
+            "crontab": breakfast_schedule,
+            "args": json.dumps([]),
+            "kwargs": json.dumps({"meals": ["breakfast"]}),
+            "enabled": True,
+            "description": "Daily report: breakfast only, sent at breakfast deadline.",
+        },
+    )
+
+    logger.info(
+        "Breakfast report periodic task synced → %02d:%02d Mon–Fri",
+        breakfast_time.hour,
+        breakfast_time.minute,
+    )
+
+    # ── Task 2: Full report (all meals) at olovrant deadline ─────────────────
+    olovrant_time = settings_instance.deadline_olovrant
+    olovrant_schedule, _ = CrontabSchedule.objects.get_or_create(
+        minute=olovrant_time.minute,
+        hour=olovrant_time.hour,
+        day_of_week="1-5",  # Mon–Fri
+        day_of_month="*",
+        month_of_year="*",
+        timezone="Europe/Bratislava",
+    )
+
+    PeriodicTask.objects.update_or_create(
+        name=PERIODIC_TASK_NAME_REPORT_ALL,
+        defaults={
+            "task": "api.tasks.send_daily_report_task",
+            "crontab": olovrant_schedule,
+            "args": json.dumps([]),
+            "kwargs": json.dumps({"meals": ["breakfast", "lunch", "olovrant"]}),
+            "enabled": True,
+            "description": "Daily report: all meals (breakfast, lunch, olovrant), sent at olovrant deadline.",
+        },
+    )
+
+    logger.info(
+        "Full report periodic task synced → %02d:%02d Mon–Fri",
+        olovrant_time.hour,
+        olovrant_time.minute,
+    )
+
+
 @receiver(post_save, sender="api.GlobalSettings")
 def on_global_settings_saved(sender, instance, **kwargs):
-    """Sync the Celery Beat schedule whenever GlobalSettings are saved."""
+    """Sync the Celery Beat schedules whenever GlobalSettings are saved."""
     _sync_auto_order_schedule(instance)
+    _sync_daily_report_schedule(instance)

--- a/backend/api/signals.py
+++ b/backend/api/signals.py
@@ -28,6 +28,7 @@ def _sync_auto_order_schedule(settings_instance) -> None:
     before we fill in the gaps automatically.
     """
     try:
+        from django.conf import settings
         from django_celery_beat.models import CrontabSchedule, PeriodicTask
     except ImportError:
         logger.warning(
@@ -47,7 +48,7 @@ def _sync_auto_order_schedule(settings_instance) -> None:
         day_of_week="1-5",  # Mon–Fri
         day_of_month="*",
         month_of_year="*",
-        timezone="Europe/Bratislava",
+        timezone=settings.TIME_ZONE,
     )
 
     PeriodicTask.objects.update_or_create(
@@ -79,6 +80,7 @@ def _sync_daily_report_schedule(settings_instance) -> None:
     2. Full report (all meals) at olovrant deadline (Monday–Friday)
     """
     try:
+        from django.conf import settings
         from django_celery_beat.models import CrontabSchedule, PeriodicTask
     except ImportError:
         logger.warning(
@@ -94,7 +96,7 @@ def _sync_daily_report_schedule(settings_instance) -> None:
         day_of_week="1-5",  # Mon–Fri
         day_of_month="*",
         month_of_year="*",
-        timezone="Europe/Bratislava",
+        timezone=settings.TIME_ZONE,
     )
 
     PeriodicTask.objects.update_or_create(
@@ -123,7 +125,7 @@ def _sync_daily_report_schedule(settings_instance) -> None:
         day_of_week="1-5",  # Mon–Fri
         day_of_month="*",
         month_of_year="*",
-        timezone="Europe/Bratislava",
+        timezone=settings.TIME_ZONE,
     )
 
     PeriodicTask.objects.update_or_create(

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -31,3 +31,48 @@ def apply_auto_orders_task(self, date_str: str | None = None):
     except Exception as exc:
         logger.exception("apply_auto_orders_task failed, retrying...")
         raise self.retry(exc=exc)
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_daily_report_task(
+    self, meals: list[str] | None = None, date_str: str | None = None
+):
+    """
+    Celery task: send daily order report.
+    Called by Celery Beat at scheduled times (breakfast deadline and olovrant deadline).
+
+    Args:
+        meals: List of meals to include (breakfast, lunch, olovrant).
+               If None, includes all meals.
+        date_str: Target date in YYYY-MM-DD format. Defaults to yesterday.
+    """
+    try:
+        import datetime
+
+        from django.core import management
+
+        # Determine target date
+        if date_str:
+            target_date = datetime.date.fromisoformat(date_str)
+        else:
+            target_date = datetime.date.today() - datetime.timedelta(days=1)
+
+        # Build meal argument
+        meals_arg = ",".join(meals) if meals else "breakfast,lunch,olovrant"
+
+        # Call the management command
+        management.call_command(
+            "send_order_report",
+            f"--date={target_date.isoformat()}",
+            f"--meals={meals_arg}",
+        )
+
+        logger.info(
+            "Daily report sent for %s (meals: %s)",
+            target_date.isoformat(),
+            meals_arg,
+        )
+        return f"Report sent for {target_date} with meals: {meals_arg}"
+    except Exception as exc:
+        logger.exception("send_daily_report_task failed, retrying...")
+        raise self.retry(exc=exc)

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -50,12 +50,13 @@ def send_daily_report_task(
         import datetime
 
         from django.core import management
+        from django.utils import timezone
 
         # Determine target date
         if date_str:
             target_date = datetime.date.fromisoformat(date_str)
         else:
-            target_date = datetime.date.today() - datetime.timedelta(days=1)
+            target_date = timezone.localdate() - datetime.timedelta(days=1)
 
         # Build meal argument
         meals_arg = ",".join(meals) if meals else "breakfast,lunch,olovrant"

--- a/backend/tests/test_report_email.py
+++ b/backend/tests/test_report_email.py
@@ -234,3 +234,22 @@ class TestSendDailyReportEmail:
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         )
         mock_instance.send.assert_called_once_with(fail_silently=False)
+
+    @patch("api.email_utils.EmailMessage")
+    def test_breakfast_only_report_subject(self, MockEmailMessage):
+        from api.email_utils import send_daily_report_email
+
+        mock_instance = MagicMock()
+        MockEmailMessage.return_value = mock_instance
+
+        send_daily_report_email(
+            recipients=["report@example.com"],
+            report_date="2026-02-25",
+            attachment_bytes=b"fake-xlsx-content",
+            attachment_filename="prehlad_2026-02-25.xlsx",
+            meals=["breakfast"],
+        )
+
+        call_kwargs = MockEmailMessage.call_args.kwargs
+        assert "Raňajky" in call_kwargs["subject"]
+        assert "2026-02-25" in call_kwargs["subject"]

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -43,7 +43,9 @@ class InvalidRouteRedirectTests(TestCase):
         """Invalid /admin/* routes should redirect to login (except /admin/ and /admin)."""
         # /admin/login/ is not /admin/ or /admin, so it won't resolve as a Django route
         # and will trigger the Resolver404 path, resulting in a redirect
-        response = self.api_client.get("/admin/login/?next=/admin/diets", format="json", follow=False)
+        response = self.api_client.get(
+            "/admin/login/?next=/admin/diets", format="json", follow=False
+        )
         # Should either be a redirect (302) or pass through to become a 404
         # The middleware will redirect it via Resolver404 handling
         self.assertNotIn("Django", str(response.content))

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -91,14 +91,12 @@ class MiddlewareSecurityTests(TestCase):
             self.assertNotIn("redirect_url", data)
 
     @override_settings(DEBUG=False)
-    def test_frontend_admin_routes_not_blocked(self):
-        """Frontend admin routes like /admin/settings should not be blocked by middleware."""
-        # These are frontend (React) routes and should pass through the middleware
-        # They won't resolve as Django routes, so they'll be handled by Resolver404
+    def test_frontend_admin_routes_redirect_to_login(self):
+        """Frontend admin-like routes under /admin/ should redirect to frontend login in production."""
+        # These are frontend (React) routes and should be handled like other non-API routes
+        # They won't resolve as Django routes, so Resolver404/middleware will redirect to /login
         response = self.api_client.get("/admin/settings/", format="json", follow=False)
         # In production, this should redirect to login page, not serve Django admin
         self.assertEqual(response.status_code, 302)
-        self.assertIn("/login", response.url)
-        self.assertNotIn("Django administration", str(response.content))
         self.assertIn("/login", response.url)
         self.assertNotIn("Django administration", str(response.content))

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -16,13 +16,12 @@ class AdminSecurityTests(TestCase):
 
     @override_settings(DEBUG=False)
     def test_admin_not_accessible_in_production(self):
-        """Django admin should not be accessible in production via API test."""
+        """Django admin should not be accessible in production - should redirect."""
         response = self.api_client.get("/admin/", format="json")
-        # Should get 404 with our custom error response, not Django admin login
-        self.assertEqual(response.status_code, 404)
-        data = response.json()
-        self.assertIn("redirect_url", data)
-        self.assertNotIn("Django administration", str(data))
+        # Should do HTTP redirect (302) to login page, not serve Django admin
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.url)
+        self.assertNotIn("Django administration", str(response.content))
 
     def test_admin_app_installed_in_development(self):
         """Django admin should be installed in development (tests use dev settings)."""
@@ -40,11 +39,13 @@ class InvalidRouteRedirectTests(TestCase):
         self.client = Client()
 
     @override_settings(DEBUG=False)
-    def test_invalid_admin_route_returns_404(self):
-        """Invalid /admin/ routes should return 404 with redirect info."""
-        response = self.api_client.get("/admin/login/?next=/admin/diets", format="json")
-        self.assertEqual(response.status_code, 404)
-        # Should suggest frontend login, not show Django content
+    def test_invalid_admin_route_returns_redirect(self):
+        """Invalid /admin/* routes should redirect to login (except /admin/ and /admin)."""
+        # /admin/login/ is not /admin/ or /admin, so it won't resolve as a Django route
+        # and will trigger the Resolver404 path, resulting in a redirect
+        response = self.api_client.get("/admin/login/?next=/admin/diets", format="json", follow=False)
+        # Should either be a redirect (302) or pass through to become a 404
+        # The middleware will redirect it via Resolver404 handling
         self.assertNotIn("Django", str(response.content))
 
     @override_settings(DEBUG=False)
@@ -70,12 +71,11 @@ class MiddlewareSecurityTests(TestCase):
 
     @override_settings(DEBUG=False)
     def test_unauthorized_non_api_request_redirect(self):
-        """Non-API unauthorized routes should get 404 with redirect."""
-        response = self.api_client.get("/admin/", format="json")
-        self.assertEqual(response.status_code, 404)
-        data = response.json()
-        self.assertIn("redirect_url", data)
-        self.assertIn("login", data["redirect_url"])
+        """Non-API unauthorized routes should redirect to login."""
+        response = self.api_client.get("/admin/", format="json", follow=False)
+        # Should get HTTP redirect (302)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.url)
 
     @override_settings(DEBUG=False)
     def test_api_requests_not_redirected(self):
@@ -87,3 +87,14 @@ class MiddlewareSecurityTests(TestCase):
             data = response.json()
             # If it's a 404, it should be from DRF, not our middleware
             self.assertNotIn("redirect_url", data)
+
+    @override_settings(DEBUG=False)
+    def test_frontend_admin_routes_not_blocked(self):
+        """Frontend admin routes like /admin/settings should not be blocked by middleware."""
+        # These are frontend (React) routes and should pass through the middleware
+        # They won't resolve as Django routes, so they'll be handled by Resolver404
+        response = self.api_client.get("/admin/settings/", format="json", follow=False)
+        # Should get a redirect via Resolver404, not be blocked by the admin check
+        # The response should indicate this came from the 404 handler, not the admin blocker
+        # In production, this should redirect to login page
+        self.assertIsNotNone(response)  # Should get a response, not crash

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -46,9 +46,9 @@ class InvalidRouteRedirectTests(TestCase):
         response = self.api_client.get(
             "/admin/login/?next=/admin/diets", format="json", follow=False
         )
-        # Should either be a redirect (302) or pass through to become a 404
-        # The middleware will redirect it via Resolver404 handling
-        self.assertNotIn("Django", str(response.content))
+        # Should redirect to login page
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.url)
 
     @override_settings(DEBUG=False)
     def test_api_routes_still_work(self):
@@ -96,7 +96,9 @@ class MiddlewareSecurityTests(TestCase):
         # These are frontend (React) routes and should pass through the middleware
         # They won't resolve as Django routes, so they'll be handled by Resolver404
         response = self.api_client.get("/admin/settings/", format="json", follow=False)
-        # Should get a redirect via Resolver404, not be blocked by the admin check
-        # The response should indicate this came from the 404 handler, not the admin blocker
-        # In production, this should redirect to login page
-        self.assertIsNotNone(response)  # Should get a response, not crash
+        # In production, this should redirect to login page, not serve Django admin
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.url)
+        self.assertNotIn("Django administration", str(response.content))
+        self.assertIn("/login", response.url)
+        self.assertNotIn("Django administration", str(response.content))

--- a/backend/tests/test_signals.py
+++ b/backend/tests/test_signals.py
@@ -2,7 +2,7 @@
 Tests for api/signals.py
 
 Verifies that saving GlobalSettings creates/updates the Celery Beat
-PeriodicTask with the correct crontab derived from the configured deadlines.
+PeriodicTasks for auto-orders and daily reports.
 """
 
 import datetime
@@ -11,14 +11,16 @@ import pytest
 from django_celery_beat.models import PeriodicTask
 
 from api.models import GlobalSettings
-from api.signals import PERIODIC_TASK_NAME
+from api.signals import PERIODIC_TASK_NAME_AUTO_ORDER
 
 
 @pytest.mark.django_db
 class TestAutoOrderScheduleSync:
     def test_creates_periodic_task_on_first_save(self):
         """Saving GlobalSettings for the first time creates the PeriodicTask."""
-        assert not PeriodicTask.objects.filter(name=PERIODIC_TASK_NAME).exists()
+        assert not PeriodicTask.objects.filter(
+            name=PERIODIC_TASK_NAME_AUTO_ORDER
+        ).exists()
 
         GlobalSettings.objects.create(
             deadline_breakfast=datetime.time(8, 0),
@@ -26,7 +28,7 @@ class TestAutoOrderScheduleSync:
             deadline_olovrant=datetime.time(9, 0),
         )
 
-        task = PeriodicTask.objects.get(name=PERIODIC_TASK_NAME)
+        task = PeriodicTask.objects.get(name=PERIODIC_TASK_NAME_AUTO_ORDER)
         assert task.task == "api.tasks.apply_auto_orders_task"
         assert task.enabled is True
         # Trigger time = max(08:00, 10:00, 09:00) = 10:00
@@ -46,7 +48,7 @@ class TestAutoOrderScheduleSync:
         settings.deadline_lunch = datetime.time(11, 30)
         settings.save()
 
-        task = PeriodicTask.objects.get(name=PERIODIC_TASK_NAME)
+        task = PeriodicTask.objects.get(name=PERIODIC_TASK_NAME_AUTO_ORDER)
         assert task.crontab.hour == "11"
         assert task.crontab.minute == "30"
 
@@ -58,7 +60,7 @@ class TestAutoOrderScheduleSync:
             deadline_olovrant=datetime.time(12, 45),
         )
 
-        task = PeriodicTask.objects.get(name=PERIODIC_TASK_NAME)
+        task = PeriodicTask.objects.get(name=PERIODIC_TASK_NAME_AUTO_ORDER)
         assert task.crontab.hour == "12"
         assert task.crontab.minute == "45"
 
@@ -70,5 +72,5 @@ class TestAutoOrderScheduleSync:
             deadline_olovrant=datetime.time(10, 0),
         )
 
-        task = PeriodicTask.objects.get(name=PERIODIC_TASK_NAME)
+        task = PeriodicTask.objects.get(name=PERIODIC_TASK_NAME_AUTO_ORDER)
         assert task.crontab.day_of_week == "1-5"

--- a/backend/tests/test_signals.py
+++ b/backend/tests/test_signals.py
@@ -2,7 +2,7 @@
 Tests for api/signals.py
 
 Verifies that saving GlobalSettings creates/updates the Celery Beat
-PeriodicTasks for auto-orders and daily reports.
+PeriodicTask for auto-orders.
 """
 
 import datetime

--- a/frontend/src/pages/admin/PendingRegistrations.tsx
+++ b/frontend/src/pages/admin/PendingRegistrations.tsx
@@ -311,11 +311,21 @@ const PendingRegistrations: React.FC = () => {
           <div
             className="bg-white rounded-xl shadow-xl max-w-md w-full p-6"
             onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="approval-modal-title"
+            aria-describedby="approval-modal-description"
           >
-            <h2 className="text-xl font-bold text-slate-900 mb-4">
+            <h2
+              id="approval-modal-title"
+              className="text-xl font-bold text-slate-900 mb-4"
+            >
               Schváliť registráciu
             </h2>
-            <p className="text-slate-600 mb-6">
+            <p
+              id="approval-modal-description"
+              className="text-slate-600 mb-6"
+            >
               Naozaj chcete schváliť túto registráciu? Používateľ bude môcť
               prihlásiť sa do systému.
             </p>

--- a/frontend/src/pages/admin/PendingRegistrations.tsx
+++ b/frontend/src/pages/admin/PendingRegistrations.tsx
@@ -30,6 +30,7 @@ const PendingRegistrations: React.FC = () => {
   const [actionLoading, setActionLoading] = useState<number | null>(null);
   const [denialReason, setDenialReason] = useState("");
   const [showDenialModal, setShowDenialModal] = useState<number | null>(null);
+  const [showApprovalModal, setShowApprovalModal] = useState<number | null>(null);
 
   const fetchPendingUsers = useCallback(async () => {
     try {
@@ -60,14 +61,6 @@ const PendingRegistrations: React.FC = () => {
   }, [fetchPendingUsers]);
 
   const handleApprove = async (userId: number) => {
-    if (
-      !confirm(
-        "Naozaj chcete schváliť túto registráciu? Používateľ bude môcť prihlásiť sa do systému."
-      )
-    ) {
-      return;
-    }
-
     setActionLoading(userId);
     setError("");
 
@@ -90,6 +83,7 @@ const PendingRegistrations: React.FC = () => {
 
       // Refresh list
       await fetchPendingUsers();
+      setShowApprovalModal(null);
       alert("Registrácia bola úspešne schválená!");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Chyba pri schvaľovaní");
@@ -232,7 +226,7 @@ const PendingRegistrations: React.FC = () => {
 
                 <div className="flex flex-col sm:flex-row lg:flex-col gap-2 lg:min-w-[160px]">
                   <button
-                    onClick={() => handleApprove(user.id)}
+                    onClick={() => setShowApprovalModal(user.id)}
                     disabled={
                       !user.profile.email_verified || actionLoading === user.id
                     }
@@ -302,6 +296,44 @@ const PendingRegistrations: React.FC = () => {
                 {actionLoading === showDenialModal
                   ? "Spracováva sa..."
                   : "Zamietnuť"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Approval Modal */}
+      {showApprovalModal !== null && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
+          onClick={() => setShowApprovalModal(null)}
+        >
+          <div
+            className="bg-white rounded-xl shadow-xl max-w-md w-full p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-xl font-bold text-slate-900 mb-4">
+              Schváliť registráciu
+            </h2>
+            <p className="text-slate-600 mb-6">
+              Naozaj chcete schváliť túto registráciu? Používateľ bude môcť
+              prihlásiť sa do systému.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowApprovalModal(null)}
+                className="flex-1 px-4 py-2 border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 transition-colors"
+              >
+                Zrušiť
+              </button>
+              <button
+                onClick={() => handleApprove(showApprovalModal)}
+                disabled={actionLoading === showApprovalModal}
+                className="flex-1 px-4 py-2 bg-green-600 hover:bg-green-700 disabled:bg-slate-400 text-white rounded-lg font-medium transition-colors"
+              >
+                {actionLoading === showApprovalModal
+                  ? "Spracováva sa..."
+                  : "Schváliť"}
               </button>
             </div>
           </div>


### PR DESCRIPTION
- Frontend: Replace browser confirm() with an approval confirmation modal in Pending Registrations.
- Backend: Add Celery Beat schedules + Celery task for daily report emails; extend send_order_report to support a -meals filter and reflect it in email subject.
- Backend: Change production non-API handling to use HTTP redirects (302) instead of JSON 404 responses; adjust tests accordingly.