### PR TITLE
perf: cache-async-celery

### DIFF
--- a/backend/api/cache_service.py
+++ b/backend/api/cache_service.py
@@ -119,22 +119,39 @@ def get_cache_stats() -> dict:
     Get cache hit/miss statistics and metrics (Redis only).
 
     Returns:
-        Dictionary with cache statistics, or empty dict if Redis is not available.
+        Dictionary with cache statistics, or empty dict if Redis is unavailable.
+
+    Works with both django-redis and Django's built-in RedisCache backends.
     """
-    # Relies on django-redis library's client interface for stable API access
     try:
-        # django-redis backend exposes cache.client which has get_client() method
-        client = cache.client  # type: ignore
-        if hasattr(client, "get_client"):
+        redis_client = None
+
+        # Try django-redis: cache.client.get_client()
+        client = getattr(cache, "client", None)
+        if client is not None and hasattr(client, "get_client"):
             redis_client = client.get_client()
-            info = redis_client.info()
-            return {
-                "connected": True,
-                "memory_used_mb": info.get("used_memory", 0) / (1024 * 1024),
-                "connected_clients": info.get("connected_clients", 0),
-                "total_commands_processed": info.get("total_commands_processed", 0),
-            }
-    except (AttributeError, Exception):  # noqa: BLE001
+        # For Django's built-in RedisCache, cache.client may be a redis client
+        elif client is not None and hasattr(client, "info"):
+            redis_client = client
+        # Some backends may expose get_client() directly on the cache
+        elif hasattr(cache, "get_client"):
+            redis_client = cache.get_client()  # type: ignore[call-arg]
+        # As last resort, treat the cache itself as a redis client if it has info()
+        elif hasattr(cache, "info"):
+            redis_client = cache  # type: ignore[assignment]
+
+        if redis_client is None or not hasattr(redis_client, "info"):
+            # Not a Redis cache or unsupported backend
+            return {}
+
+        info = redis_client.info()
+        return {
+            "connected": True,
+            "memory_used_mb": info.get("used_memory", 0) / (1024 * 1024),
+            "connected_clients": info.get("connected_clients", 0),
+            "total_commands_processed": info.get("total_commands_processed", 0),
+        }
+    except Exception:  # noqa: BLE001
+        # Redis unavailable or unexpected backend behavior
         pass
-    # Not a Redis cache or Redis unavailable
     return {}

--- a/backend/api/cache_service.py
+++ b/backend/api/cache_service.py
@@ -62,9 +62,10 @@ def set_cached(key: str, value: Any, timeout: Optional[int] = None) -> None:
     Args:
         key: The cache key.
         value: The value to cache.
-        timeout: TTL in seconds. If None, uses default timeout.
+        timeout: TTL in seconds. If None, uses cache backend's default.
     """
-    cache.set(key, value, timeout=timeout or 300)
+    # Pass timeout as-is to cache.set(); Django will handle None by using the backend default
+    cache.set(key, value, timeout=timeout)
 
 
 def delete_cached(key: str) -> None:
@@ -99,39 +100,41 @@ def clear_diet_list_cache() -> None:
 
 def clear_daily_stats_cache(date_str: Optional[str] = None) -> None:
     """
-    Clear the daily stats cache.
+    Clear the daily stats cache for a specific date.
 
     Args:
-        date_str: Optional specific date (YYYY-MM-DD). If None, clears all stats.
+        date_str: Specific date (YYYY-MM-DD). If None, no action is taken.
     """
     if date_str:
         delete_cached(get_daily_stats_cache_key(date_str))
     else:
-        # Clear all daily stats cache keys (pattern matching via cache backend)
-        # This is a simplified approach: delete all keys matching the pattern
-        cache.delete_many([get_daily_stats_cache_key("*")])
+        # Global deletion of all daily stats keys is not implemented here because
+        # the Django cache API does not support wildcard deletion in a backend-
+        # agnostic way. Callers should explicitly clear known date keys instead.
+        pass
 
 
 def get_cache_stats() -> dict:
     """
-    Get cache hit/miss statistics and metrics.
+    Get cache hit/miss statistics and metrics (Redis only).
 
     Returns:
-        Dictionary with cache statistics (backend-dependent).
+        Dictionary with cache statistics, or empty dict if Redis is not available.
     """
-    # This would need Redis-specific implementation to track hits/misses
-    # For now, return placeholder structure
+    # Relies on django-redis library's client interface for stable API access
     try:
-        info = cache._cache.conn.info()  # Requires redis backend
-        return {
-            "connected": True,
-            "memory_used_mb": info.get("used_memory", 0) / (1024 * 1024),
-            "connected_clients": info.get("connected_clients", 0),
-            "total_commands_processed": info.get("total_commands_processed", 0),
-        }
-    except (AttributeError, Exception):
-        # Not a Redis cache or Redis unavailable
-        return {
-            "connected": False,
-            "message": "Cache stats not available for current backend",
-        }
+        # django-redis backend exposes cache.client which has get_client() method
+        client = cache.client  # type: ignore
+        if hasattr(client, "get_client"):
+            redis_client = client.get_client()
+            info = redis_client.info()
+            return {
+                "connected": True,
+                "memory_used_mb": info.get("used_memory", 0) / (1024 * 1024),
+                "connected_clients": info.get("connected_clients", 0),
+                "total_commands_processed": info.get("total_commands_processed", 0),
+            }
+    except (AttributeError, Exception):  # noqa: BLE001
+        pass
+    # Not a Redis cache or Redis unavailable
+    return {}

--- a/backend/api/cache_service.py
+++ b/backend/api/cache_service.py
@@ -1,0 +1,137 @@
+"""
+Cache service for managing application-level caching.
+
+Provides centralized cache key management and TTL configuration
+for frequently accessed data: GlobalSettings, ClientSettings, Diet, and daily stats.
+"""
+
+from typing import Any, Optional
+
+from django.core.cache import cache
+
+# Cache key constants
+GLOBAL_SETTINGS_CACHE_KEY = "global_settings"
+CLIENT_SETTINGS_CACHE_KEY_PREFIX = "client_settings"
+DIET_LIST_CACHE_KEY = "diet_list"
+DAILY_STATS_CACHE_KEY_PREFIX = "daily_stats"
+
+# Cache timeout (TTL) constants in seconds
+GLOBAL_SETTINGS_TIMEOUT = 3600  # 1 hour
+CLIENT_SETTINGS_TIMEOUT = 3600  # 1 hour
+DIET_LIST_TIMEOUT = 86400  # 24 hours (static data)
+DAILY_STATS_TIMEOUT = 300  # 5 minutes
+
+
+def get_global_settings_cache_key() -> str:
+    """Return the cache key for GlobalSettings."""
+    return GLOBAL_SETTINGS_CACHE_KEY
+
+
+def get_client_settings_cache_key(user_id: int) -> str:
+    """Return the cache key for ClientSettings by user ID."""
+    return f"{CLIENT_SETTINGS_CACHE_KEY_PREFIX}:{user_id}"
+
+
+def get_diet_list_cache_key() -> str:
+    """Return the cache key for Diet list."""
+    return DIET_LIST_CACHE_KEY
+
+
+def get_daily_stats_cache_key(date_str: str) -> str:
+    """Return the cache key for daily stats by date (YYYY-MM-DD format)."""
+    return f"{DAILY_STATS_CACHE_KEY_PREFIX}:{date_str}"
+
+
+def get_cached(key: str) -> Optional[Any]:
+    """
+    Retrieve a value from cache.
+
+    Args:
+        key: The cache key.
+
+    Returns:
+        The cached value or None if not found.
+    """
+    return cache.get(key)
+
+
+def set_cached(key: str, value: Any, timeout: Optional[int] = None) -> None:
+    """
+    Set a value in cache.
+
+    Args:
+        key: The cache key.
+        value: The value to cache.
+        timeout: TTL in seconds. If None, uses default timeout.
+    """
+    cache.set(key, value, timeout=timeout or 300)
+
+
+def delete_cached(key: str) -> None:
+    """
+    Delete a value from cache.
+
+    Args:
+        key: The cache key.
+    """
+    cache.delete(key)
+
+
+def clear_global_settings_cache() -> None:
+    """Clear the GlobalSettings cache."""
+    delete_cached(get_global_settings_cache_key())
+
+
+def clear_client_settings_cache(user_id: int) -> None:
+    """
+    Clear the ClientSettings cache for a specific user.
+
+    Args:
+        user_id: The user ID.
+    """
+    delete_cached(get_client_settings_cache_key(user_id))
+
+
+def clear_diet_list_cache() -> None:
+    """Clear the Diet list cache."""
+    delete_cached(get_diet_list_cache_key())
+
+
+def clear_daily_stats_cache(date_str: Optional[str] = None) -> None:
+    """
+    Clear the daily stats cache.
+
+    Args:
+        date_str: Optional specific date (YYYY-MM-DD). If None, clears all stats.
+    """
+    if date_str:
+        delete_cached(get_daily_stats_cache_key(date_str))
+    else:
+        # Clear all daily stats cache keys (pattern matching via cache backend)
+        # This is a simplified approach: delete all keys matching the pattern
+        cache.delete_many([get_daily_stats_cache_key("*")])
+
+
+def get_cache_stats() -> dict:
+    """
+    Get cache hit/miss statistics and metrics.
+
+    Returns:
+        Dictionary with cache statistics (backend-dependent).
+    """
+    # This would need Redis-specific implementation to track hits/misses
+    # For now, return placeholder structure
+    try:
+        info = cache._cache.conn.info()  # Requires redis backend
+        return {
+            "connected": True,
+            "memory_used_mb": info.get("used_memory", 0) / (1024 * 1024),
+            "connected_clients": info.get("connected_clients", 0),
+            "total_commands_processed": info.get("total_commands_processed", 0),
+        }
+    except (AttributeError, Exception):
+        # Not a Redis cache or Redis unavailable
+        return {
+            "connected": False,
+            "message": "Cache stats not available for current backend",
+        }

--- a/backend/api/cached_settings_service.py
+++ b/backend/api/cached_settings_service.py
@@ -40,8 +40,8 @@ def get_global_settings():
     if cached_settings is not None:
         return cached_settings
 
-    # Fetch from database
-    settings = GlobalSettings.objects.get(pk=1)
+    # Fetch from database (or create if fresh DB)
+    settings, _ = GlobalSettings.objects.get_or_create(pk=1)
 
     # Cache for future requests
     set_cached(cache_key, settings, timeout=GLOBAL_SETTINGS_TIMEOUT)

--- a/backend/api/cached_settings_service.py
+++ b/backend/api/cached_settings_service.py
@@ -1,0 +1,92 @@
+"""
+Cached settings retrieval service.
+
+Provides functions to retrieve GlobalSettings and ClientSettings with caching.
+Cache is automatically invalidated via signals when settings are updated.
+"""
+
+from typing import Optional
+
+from django.contrib.auth.models import User
+
+from api.cache_service import (
+    CLIENT_SETTINGS_TIMEOUT,
+    GLOBAL_SETTINGS_TIMEOUT,
+    get_cached,
+    get_client_settings_cache_key,
+    get_global_settings_cache_key,
+    set_cached,
+)
+from api.models import ClientSettings, GlobalSettings
+
+
+def get_global_settings():
+    """
+    Retrieve GlobalSettings with caching.
+
+    Returns the cached instance if available, otherwise fetches from DB
+    and caches for future requests.
+
+    Returns:
+        GlobalSettings: The global settings instance (singleton).
+
+    Raises:
+        GlobalSettings.DoesNotExist: If GlobalSettings doesn't exist.
+    """
+    cache_key = get_global_settings_cache_key()
+
+    # Try to get from cache
+    cached_settings = get_cached(cache_key)
+    if cached_settings is not None:
+        return cached_settings
+
+    # Fetch from database
+    settings = GlobalSettings.objects.get(pk=1)
+
+    # Cache for future requests
+    set_cached(cache_key, settings, timeout=GLOBAL_SETTINGS_TIMEOUT)
+
+    return settings
+
+
+def get_client_settings(user_id: int) -> Optional[ClientSettings]:
+    """
+    Retrieve ClientSettings for a user with caching.
+
+    Returns the cached instance if available, otherwise fetches from DB
+    and caches for future requests.
+
+    Args:
+        user_id: The user ID.
+
+    Returns:
+        ClientSettings: The client settings instance, or None if not found.
+    """
+    cache_key = get_client_settings_cache_key(user_id)
+
+    # Try to get from cache
+    cached_settings = get_cached(cache_key)
+    if cached_settings is not None:
+        return cached_settings
+
+    # Fetch from database
+    try:
+        settings = ClientSettings.objects.get(user_id=user_id)
+        # Cache for future requests
+        set_cached(cache_key, settings, timeout=CLIENT_SETTINGS_TIMEOUT)
+        return settings
+    except ClientSettings.DoesNotExist:
+        return None
+
+
+def get_client_settings_by_user(user: User) -> Optional[ClientSettings]:
+    """
+    Retrieve ClientSettings for a user object with caching.
+
+    Args:
+        user: The User instance.
+
+    Returns:
+        ClientSettings: The client settings instance, or None if not found.
+    """
+    return get_client_settings(user.id)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,8 +1,13 @@
+import logging
+import time
 from typing import Any, Dict, Optional
 
+from django.db import IntegrityError, transaction
 from rest_framework import serializers
 
 from .models import DailyOrder
+
+logger = logging.getLogger(__name__)
 
 
 class DailyOrderSerializer(serializers.ModelSerializer):
@@ -25,16 +30,51 @@ class DailyOrderSerializer(serializers.ModelSerializer):
                 user=user, date=validated_data["date"], status="draft", data={}
             )
 
-        status_val = "submitted"  # Always confirmed
+        new_data = validated_data.get("data", {})
 
-        order, created = DailyOrder.objects.update_or_create(
-            user=user,
-            date=validated_data["date"],
-            defaults={
-                "data": validated_data.get("data", {}),
-                "status": status_val,
-            },
-        )
+        # Use select_for_update inside an atomic block to prevent race conditions
+        # when multiple concurrent requests submit an order for the same (user, date).
+        # The SELECT ... FOR UPDATE acquires a row lock so only one writer proceeds
+        # at a time; the outer transaction.atomic() ensures the lock is held for the
+        # full read-modify-write cycle.
+        with transaction.atomic():
+            try:
+                t0 = time.monotonic()
+                order = DailyOrder.objects.select_for_update(nowait=False).get(
+                    user=user, date=validated_data["date"]
+                )
+                wait_ms = (time.monotonic() - t0) * 1000
+                if wait_ms > 100:
+                    logger.warning(
+                        "select_for_update lock wait %.1f ms for user=%s date=%s",
+                        wait_ms,
+                        user.pk,
+                        validated_data["date"],
+                    )
+                order.data = new_data
+                order.status = "submitted"
+                order.save(update_fields=["data", "status", "updated_at"])
+            except DailyOrder.DoesNotExist:
+                # Wrap create() in its own savepoint so that if IntegrityError is
+                # raised (another request raced us to INSERT), only this savepoint
+                # is rolled back and the outer atomic block remains usable.
+                try:
+                    with transaction.atomic():
+                        order = DailyOrder.objects.create(
+                            user=user,
+                            date=validated_data["date"],
+                            data=new_data,
+                            status="submitted",
+                        )
+                except IntegrityError:
+                    # Another request won the INSERT race; retry with a lock.
+                    order = DailyOrder.objects.select_for_update(nowait=False).get(
+                        user=user, date=validated_data["date"]
+                    )
+                    order.data = new_data
+                    order.status = "submitted"
+                    order.save(update_fields=["data", "status", "updated_at"])
+
         return order
 
 

--- a/backend/api/services/auto_order_service.py
+++ b/backend/api/services/auto_order_service.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, Dict, List
 
 from django.contrib.auth.models import User
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from ..models import DailyOrder
@@ -149,13 +150,31 @@ def apply_auto_orders(target_date: datetime.date | None = None) -> Dict[str, Any
             skipped += 1
             continue
 
-        DailyOrder.objects.create(
-            user=client,
-            date=target_date,
-            status="submitted",
-            is_auto=True,
-            data=auto_data,
-        )
+        # Use get_or_create inside an atomic block to be idempotent when the
+        # auto-order task is triggered concurrently (e.g. duplicate Celery tasks).
+        # select_for_update on the lookup prevents two concurrent tasks from
+        # both seeing DoesNotExist and racing to INSERT.
+        try:
+            with transaction.atomic():
+                _, auto_created = DailyOrder.objects.get_or_create(
+                    user=client,
+                    date=target_date,
+                    defaults={
+                        "status": "submitted",
+                        "is_auto": True,
+                        "data": auto_data,
+                    },
+                )
+        except IntegrityError:
+            # Concurrent task already created the row; treat as skipped.
+            skipped += 1
+            continue
+
+        if not auto_created:
+            # A manual order appeared between the preload query and now.
+            skipped += 1
+            continue
+
         created.append(client.email)
         logger.info(
             "Auto-order created for user=%s date=%s (template from %s)",

--- a/backend/api/services/auto_order_service.py
+++ b/backend/api/services/auto_order_service.py
@@ -152,8 +152,8 @@ def apply_auto_orders(target_date: datetime.date | None = None) -> Dict[str, Any
 
         # Use get_or_create inside an atomic block to be idempotent when the
         # auto-order task is triggered concurrently (e.g. duplicate Celery tasks).
-        # select_for_update on the lookup prevents two concurrent tasks from
-        # both seeing DoesNotExist and racing to INSERT.
+        # Rely on a unique constraint for (user, date) plus IntegrityError handling
+        # to ensure that at most one auto-order row is ultimately created.
         try:
             with transaction.atomic():
                 _, auto_created = DailyOrder.objects.get_or_create(

--- a/backend/api/signals.py
+++ b/backend/api/signals.py
@@ -2,14 +2,16 @@
 Django signals for the api app.
 
 GlobalSettings post_save → keeps the Celery Beat PeriodicTasks for:
-- auto-orders: fires at max(deadline_breakfast, deadline_lunch, deadline_olovrant)
-- daily reports: fires at breakfast deadline (breakfast only) and olovrant deadline (all meals)
+- auto-orders: fires at max(deadline_breakfast, deadline_lunch,
+  deadline_olovrant)
+- daily reports: fires at breakfast deadline (breakfast only) and
+  olovrant deadline (all meals)
 """
 
 import json
 import logging
 
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 logger = logging.getLogger(__name__)
@@ -32,7 +34,7 @@ def _sync_auto_order_schedule(settings_instance) -> None:
         from django_celery_beat.models import CrontabSchedule, PeriodicTask
     except ImportError:
         logger.warning(
-            "django_celery_beat not installed – skipping auto-order schedule sync."
+            "django_celery_beat not installed – " "skipping auto-order schedule sync."
         )
         return
 
@@ -80,17 +82,19 @@ def _sync_auto_order_schedule(settings_instance) -> None:
 def _sync_daily_report_schedule(settings_instance) -> None:
     """
     Create or update two Celery Beat PeriodicTasks for daily reports:
+
     1. Breakfast-only report at breakfast deadline (Monday–Friday)
     2. Full report (all meals) at olovrant deadline (Monday–Friday)
 
-    Tasks are only created if report_email_recipients is configured (non-empty).
+    Tasks are only created if report_email_recipients is configured
+    (non-empty).
     """
     try:
         from django.conf import settings
         from django_celery_beat.models import CrontabSchedule, PeriodicTask
     except ImportError:
         logger.warning(
-            "django_celery_beat not installed – skipping daily report schedule sync."
+            "django_celery_beat not installed – " "skipping daily report schedule sync."
         )
         return
 
@@ -98,7 +102,8 @@ def _sync_daily_report_schedule(settings_instance) -> None:
     if not settings_instance.report_email_recipients:
         logger.debug(
             "Skipping daily report task creation: no recipients configured. "
-            "Add recipients to GlobalSettings.report_email_recipients to enable automatic email sending."
+            "Add recipients to GlobalSettings.report_email_recipients to "
+            "enable automatic email sending."
         )
         return
 
@@ -122,7 +127,9 @@ def _sync_daily_report_schedule(settings_instance) -> None:
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"meals": ["breakfast"]}),
                 "enabled": True,
-                "description": "Daily report: breakfast only, sent at breakfast deadline.",
+                "description": (
+                    "Daily report: breakfast only, sent at breakfast deadline."
+                ),
             },
         )
 
@@ -152,7 +159,10 @@ def _sync_daily_report_schedule(settings_instance) -> None:
                 "args": json.dumps([]),
                 "kwargs": json.dumps({"meals": ["breakfast", "lunch", "olovrant"]}),
                 "enabled": True,
-                "description": "Daily report: all meals (breakfast, lunch, olovrant), sent at olovrant deadline.",
+                "description": (
+                    "Daily report: all meals (breakfast, lunch, olovrant), "
+                    "sent at olovrant deadline."
+                ),
             },
         )
 
@@ -172,11 +182,46 @@ def on_global_settings_saved(sender, instance, created=False, **kwargs):
 
     This signal handler ensures PeriodicTasks are created or updated whenever
     the GlobalSettings (deadlines, recipients, etc.) change.
+
+    Also invalidates the GlobalSettings cache to ensure fresh data.
     """
     try:
         _sync_auto_order_schedule(instance)
         _sync_daily_report_schedule(instance)
+
+        # Invalidate GlobalSettings cache
+        from api.cache_service import clear_global_settings_cache
+
+        clear_global_settings_cache()
+
         action = "created" if created else "updated"
-        logger.debug("GlobalSettings %s – periodic tasks synced", action)
+        logger.debug(
+            "GlobalSettings %s – periodic tasks synced and cache cleared", action
+        )
     except Exception as exc:
         logger.exception("Error syncing periodic tasks for GlobalSettings: %s", exc)
+
+
+@receiver(post_save, sender="api.ClientSettings")
+def on_client_settings_saved(sender, instance, created=False, **kwargs):
+    """Invalidate ClientSettings cache when saved."""
+    try:
+        from api.cache_service import clear_client_settings_cache
+
+        clear_client_settings_cache(instance.user_id)
+        logger.debug("ClientSettings cache cleared for user_id=%s", instance.user_id)
+    except Exception as exc:
+        logger.exception("Error clearing ClientSettings cache: %s", exc)
+
+
+@receiver(post_save, sender="api.Diet")
+@receiver(post_delete, sender="api.Diet")
+def on_diet_changed(sender, instance, **kwargs):
+    """Invalidate Diet list cache when Diet is saved or deleted."""
+    try:
+        from api.cache_service import clear_diet_list_cache
+
+        clear_diet_list_cache()
+        logger.debug("Diet list cache cleared")
+    except Exception as exc:
+        logger.exception("Error clearing Diet list cache: %s", exc)

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -8,6 +8,76 @@ from celery import shared_task
 
 logger = logging.getLogger(__name__)
 
+REPORT_CACHE_TIMEOUT = 3600  # 1 hour
+
+
+@shared_task(
+    bind=True,
+    max_retries=0,
+    time_limit=600,
+    soft_time_limit=590,
+    name="api.tasks.generate_report_pdf",
+)
+def generate_report_pdf_task(self, date_str: str):
+    """Generate a PDF report in the background and store it in cache.
+
+    Args:
+        date_str: Target date in YYYY-MM-DD format.
+
+    Returns:
+        dict with status, format, and date on success.
+    """
+    import datetime
+
+    from django.core.cache import cache
+
+    from api.exporters import PDFReportExporter
+    from api.models import DailyOrder
+
+    target_date = datetime.date.fromisoformat(date_str)
+    orders = (
+        DailyOrder.objects.filter(date=target_date)
+        .select_related("user", "user__settings")
+        .order_by("user__email")
+    )
+    pdf_bytes = PDFReportExporter(orders, date_str).generate()
+    cache_key = f"report_task:pdf:{date_str}"
+    cache.set(cache_key, pdf_bytes, timeout=REPORT_CACHE_TIMEOUT)
+    logger.info("generate_report_pdf_task complete for %s", date_str)
+    return {"status": "complete", "format": "pdf", "date": date_str}
+
+
+@shared_task(
+    bind=True,
+    max_retries=0,
+    time_limit=600,
+    soft_time_limit=590,
+    name="api.tasks.generate_report_xlsx",
+)
+def generate_report_xlsx_task(self, date_str: str):
+    """Generate an XLSX report in the background and store it in cache.
+
+    Args:
+        date_str: Target date in YYYY-MM-DD format.
+
+    Returns:
+        dict with status, format, and date on success.
+    """
+    import datetime
+
+    from django.core.cache import cache
+
+    from api.exporters import XLSXReportExporter
+    from api.services import ReportService
+
+    target_date = datetime.date.fromisoformat(date_str)
+    rows_data = ReportService.get_orders_for_export(target_date)
+    xlsx_bytes = XLSXReportExporter(rows_data, date_str).generate()
+    cache_key = f"report_task:xlsx:{date_str}"
+    cache.set(cache_key, xlsx_bytes, timeout=REPORT_CACHE_TIMEOUT)
+    logger.info("generate_report_xlsx_task complete for %s", date_str)
+    return {"status": "complete", "format": "xlsx", "date": date_str}
+
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
 def apply_auto_orders_task(self, date_str: str | None = None):

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -41,10 +41,17 @@ def generate_report_pdf_task(self, date_str: str):
         .order_by("user__email")
     )
     pdf_bytes = PDFReportExporter(orders, date_str).generate()
-    cache_key = f"report_task:pdf:{date_str}"
+    # Use task id in cache key to ensure concurrent requests for the same date/format
+    # don't overwrite each other. The download endpoint uses this key from the task result.
+    cache_key = f"report_task:{self.request.id}"
     cache.set(cache_key, pdf_bytes, timeout=REPORT_CACHE_TIMEOUT)
     logger.info("generate_report_pdf_task complete for %s", date_str)
-    return {"status": "complete", "format": "pdf", "date": date_str}
+    return {
+        "status": "complete",
+        "format": "pdf",
+        "date": date_str,
+        "cache_key": cache_key,
+    }
 
 
 @shared_task(
@@ -73,10 +80,17 @@ def generate_report_xlsx_task(self, date_str: str):
     target_date = datetime.date.fromisoformat(date_str)
     rows_data = ReportService.get_orders_for_export(target_date)
     xlsx_bytes = XLSXReportExporter(rows_data, date_str).generate()
-    cache_key = f"report_task:xlsx:{date_str}"
+    # Use task id in cache key to ensure concurrent requests for the same date/format
+    # don't overwrite each other. The download endpoint uses this key from the task result.
+    cache_key = f"report_task:{self.request.id}"
     cache.set(cache_key, xlsx_bytes, timeout=REPORT_CACHE_TIMEOUT)
     logger.info("generate_report_xlsx_task complete for %s", date_str)
-    return {"status": "complete", "format": "xlsx", "date": date_str}
+    return {
+        "status": "complete",
+        "format": "xlsx",
+        "date": date_str,
+        "cache_key": cache_key,
+    }
 
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)

--- a/backend/api/tests/integration/test_order_concurrency.py
+++ b/backend/api/tests/integration/test_order_concurrency.py
@@ -1,0 +1,302 @@
+"""
+Concurrency tests for DailyOrder submission.
+
+These tests simulate race conditions that occur when multiple requests submit
+an order for the same (user, date) simultaneously.  Because true OS-level
+parallelism is hard to guarantee inside a single pytest process, we exercise
+the logical paths by:
+
+  1. Direct serializer / service calls that replicate the interleaved-execution
+     scenario (IntegrityError on INSERT → retry with select_for_update).
+  2. A threading-based smoke test that fires N concurrent API requests and
+     asserts exactly one row is created and no uncaught exceptions are raised.
+"""
+
+import datetime
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from django.contrib.auth.models import User
+from django.db import IntegrityError
+from django.test import RequestFactory
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from api.models import DailyOrder
+from api.serializers import DailyOrderSerializer
+
+pytestmark = pytest.mark.integration
+
+TARGET_DATE = datetime.date(2025, 3, 10)
+
+ORDER_DATA = {
+    "breakfast": {"Dospelý": {"menuCounts": {"A": 2}, "diets": {}}},
+    "lunch": {"Dospelý": {"menuCounts": {"B": 1}, "diets": {}}},
+    "olovrant": {},
+}
+
+
+# ---------------------------------------------------------------------------
+# Serializer-level unit tests (no HTTP layer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSerializerConcurrency:
+    """Validate the select_for_update / IntegrityError retry path."""
+
+    def test_create_new_order_no_conflict(self, user):
+        """Happy path: create succeeds without any lock contention."""
+        serializer = DailyOrderSerializer(
+            data={"date": str(TARGET_DATE), "data": ORDER_DATA}
+        )
+        assert serializer.is_valid(), serializer.errors
+        order = serializer.save(user=user)
+
+        assert order.pk is not None
+        assert order.date == TARGET_DATE
+        assert order.status == "submitted"
+        db_order = DailyOrder.objects.get(user=user, date=TARGET_DATE)
+        assert db_order.data == ORDER_DATA
+
+    def test_update_existing_order_no_conflict(self, user):
+        """Happy path: update path via select_for_update.get() succeeds."""
+        DailyOrder.objects.create(user=user, date=TARGET_DATE, data={})
+
+        new_data = {"breakfast": {"Dospelý": {"menuCounts": {"A": 3}, "diets": {}}}}
+        serializer = DailyOrderSerializer(
+            data={"date": str(TARGET_DATE), "data": new_data}
+        )
+        assert serializer.is_valid(), serializer.errors
+        order = serializer.save(user=user)
+
+        assert DailyOrder.objects.filter(user=user, date=TARGET_DATE).count() == 1
+        assert order.data == new_data
+
+    def test_integrity_error_retry_path(self, user):
+        """
+        Simulate the race: DoesNotExist → create() raises IntegrityError
+        (another thread won the race) → retry with select_for_update.get().
+
+        We verify that even when create() raises IntegrityError, the
+        serializer still returns the existing row after the retry.
+        """
+        existing_order = DailyOrder.objects.create(
+            user=user,
+            date=TARGET_DATE,
+            data={"lunch": {"Dospelý": {"menuCounts": {"A": 1}, "diets": {}}}},
+        )
+
+        # Patch DailyOrder.objects so:
+        #   select_for_update().get() → DoesNotExist on first call (simulates the
+        #     "gap" between read and write in a concurrent scenario)
+        #   create() → raises IntegrityError
+        #   The second select_for_update().get() returns the existing row
+        original_manager = DailyOrder.objects
+
+        get_call_count = {"n": 0}
+
+        class FakeQS:
+            def select_for_update(self, **kwargs):
+                return self
+
+            def get(self, **kwargs):
+                get_call_count["n"] += 1
+                if get_call_count["n"] == 1:
+                    raise DailyOrder.DoesNotExist
+                # Second call returns the existing row
+                return existing_order
+
+        class FakeManager:
+            def select_for_update(self, **kwargs):
+                return FakeQS()
+
+            def create(self, **kwargs):
+                raise IntegrityError("duplicate key")
+
+            def filter(self, **kwargs):
+                return original_manager.filter(**kwargs)
+
+            def get(self, **kwargs):
+                return original_manager.get(**kwargs)
+
+        with patch.object(DailyOrder, "objects", FakeManager()):
+            serializer = DailyOrderSerializer(
+                data={"date": str(TARGET_DATE), "data": ORDER_DATA}
+            )
+            assert serializer.is_valid(), serializer.errors
+            order = serializer.save(user=user)
+
+        assert order.pk == existing_order.pk
+        assert (
+            get_call_count["n"] == 2
+        ), "Expected exactly 2 get() calls (first miss, retry)"
+
+    def test_draft_status_deletes_existing_order(self, user):
+        """Draft submission deletes the stored order (unchanged behaviour)."""
+        DailyOrder.objects.create(user=user, date=TARGET_DATE, data=ORDER_DATA)
+
+        serializer = DailyOrderSerializer(
+            data={"date": str(TARGET_DATE), "data": {}, "status": "draft"}
+        )
+        assert serializer.is_valid(), serializer.errors
+        order = serializer.save(user=user)
+
+        assert order.pk is None  # unsaved sentinel
+        assert DailyOrder.objects.filter(user=user, date=TARGET_DATE).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Threading smoke-test (real DB, real HTTP)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+class TestConcurrentHTTPSubmissions:
+    """
+    Spawn N threads each sending a POST /api/orders/ for the same (user, date).
+    Only one row must exist in the DB at the end; all responses must be 2xx.
+    """
+
+    CONCURRENCY = 8
+
+    def _make_client(self, user: User) -> APIClient:
+        client = APIClient()
+        client.force_authenticate(user=user)
+        return client
+
+    def _submit(self, user: User, data: dict) -> int:
+        client = self._make_client(user)
+        url = reverse("dailyorder-list")
+        resp = client.post(url, data, format="json")
+        return resp.status_code
+
+    def test_concurrent_submissions_single_row(self, user):
+        """N concurrent POSTs for the same date create exactly one DB row."""
+        payload = {"date": str(TARGET_DATE), "data": ORDER_DATA}
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                code = self._submit(user, payload)
+                results.append(code)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(self.CONCURRENCY)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Unhandled exceptions in threads: {errors}"
+        assert all(
+            200 <= code < 300 for code in results
+        ), f"Non-2xx responses: {results}"
+        assert (
+            DailyOrder.objects.filter(user=user, date=TARGET_DATE).count() == 1
+        ), "Expected exactly one order row after concurrent submissions"
+
+    def test_concurrent_updates_last_write_wins(self, user):
+        """
+        After N concurrent updates the DB ends up with exactly 1 row.
+        We do not assert which data value "wins" — only that there is no
+        duplicate row and no server error.
+        """
+        # Seed an existing order
+        DailyOrder.objects.create(user=user, date=TARGET_DATE, data={})
+
+        payloads = [
+            {
+                "date": str(TARGET_DATE),
+                "data": {
+                    "breakfast": {"Dospelý": {"menuCounts": {"A": i}, "diets": {}}},
+                    "lunch": {},
+                    "olovrant": {},
+                },
+            }
+            for i in range(self.CONCURRENCY)
+        ]
+
+        status_codes = []
+        errors = []
+
+        def worker(payload):
+            try:
+                code = self._submit(user, payload)
+                status_codes.append(code)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(p,)) for p in payloads]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Unhandled exceptions: {errors}"
+        assert all(
+            200 <= code < 300 for code in status_codes
+        ), f"Non-2xx responses: {status_codes}"
+        assert (
+            DailyOrder.objects.filter(user=user, date=TARGET_DATE).count() == 1
+        ), "Concurrent updates produced duplicate rows"
+
+
+# ---------------------------------------------------------------------------
+# auto_order_service idempotency under concurrent Celery task execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+class TestAutoOrderServiceConcurrency:
+    """
+    Verify that apply_auto_orders() is idempotent when called concurrently.
+    Two threads calling apply_auto_orders() for the same date must not
+    duplicate rows for any client.
+    """
+
+    def test_concurrent_apply_auto_orders_no_duplicates(self, db):
+        from api.services.auto_order_service import apply_auto_orders
+
+        # Create clients with a historical order so auto-order logic triggers
+        clients = []
+        for i in range(3):
+            u = User.objects.create_user(
+                username=f"auto_user_{i}@example.com",
+                email=f"auto_user_{i}@example.com",
+                password="pass",
+            )
+            DailyOrder.objects.create(
+                user=u,
+                date=datetime.date(2025, 3, 7),  # a Friday before TARGET_DATE
+                data=ORDER_DATA,
+                status="submitted",
+            )
+            clients.append(u)
+
+        target = datetime.date(2025, 3, 10)  # Monday
+        results = []
+        errors = []
+
+        def run():
+            try:
+                results.append(apply_auto_orders(target))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        t1, t2 = threading.Thread(target=run), threading.Thread(target=run)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Exceptions in auto_order threads: {errors}"
+
+        for client in clients:
+            count = DailyOrder.objects.filter(user=client, date=target).count()
+            assert count == 1, f"Expected 1 auto-order for {client.email}, got {count}"

--- a/backend/api/tests/integration/test_order_concurrency.py
+++ b/backend/api/tests/integration/test_order_concurrency.py
@@ -14,13 +14,11 @@ the logical paths by:
 
 import datetime
 import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth.models import User
 from django.db import IntegrityError
-from django.test import RequestFactory
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient

--- a/backend/api/tests/integration/test_report_async.py
+++ b/backend/api/tests/integration/test_report_async.py
@@ -269,9 +269,11 @@ class TestGenerateReportTasks:
         assert result["status"] == "complete"
         assert result["format"] == "pdf"
         assert result["date"] == today_str
+        assert "cache_key" in result
         mock_cache.set.assert_called_once()
         cache_key = mock_cache.set.call_args[0][0]
-        assert f"pdf:{today_str}" in cache_key
+        # Cache key now uses task_id instead of date/format
+        assert cache_key.startswith("report_task:")
 
     @pytest.mark.django_db
     def test_generate_xlsx_task_stores_in_cache(self, daily_order, today_str):
@@ -289,9 +291,11 @@ class TestGenerateReportTasks:
 
         assert result["status"] == "complete"
         assert result["format"] == "xlsx"
+        assert "cache_key" in result
         mock_cache.set.assert_called_once()
         cache_key = mock_cache.set.call_args[0][0]
-        assert f"xlsx:{today_str}" in cache_key
+        # Cache key now uses task_id instead of date/format
+        assert cache_key.startswith("report_task:")
 
     @pytest.mark.django_db
     def test_pdf_task_uses_correct_cache_timeout(self, daily_order, today_str):

--- a/backend/api/tests/integration/test_report_async.py
+++ b/backend/api/tests/integration/test_report_async.py
@@ -1,0 +1,308 @@
+"""Integration tests for async report generation via Celery tasks."""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from api.models import DailyOrder
+
+
+@pytest.fixture
+def today_str():
+    return date.today().isoformat()
+
+
+@pytest.fixture
+def daily_order(db, user, today_str):
+    return DailyOrder.objects.create(
+        user=user,
+        date=today_str,
+        status="submitted",
+        data={
+            "breakfast": {"Dospelý": {"menuCounts": {"A": 2}, "diets": {}}},
+            "lunch": {"ZŠ": {"menuCounts": {"B": 3}, "diets": {}}},
+            "olovrant": {},
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task submission (POST /api/admin/report-tasks/)
+# ---------------------------------------------------------------------------
+
+
+class TestReportTaskCreate:
+    URL = "/api/admin/report-tasks/"
+
+    def test_submit_pdf_task_returns_202(self, admin_client, today_str):
+        with patch("api.views.report_task_views.generate_report_pdf_task") as mock_task:
+            mock_task.delay.return_value = MagicMock(id="task-pdf-001")
+            res = admin_client.post(
+                self.URL, {"date": today_str, "format": "pdf"}, format="json"
+            )
+
+        assert res.status_code == status.HTTP_202_ACCEPTED
+        data = res.json()
+        assert data["task_id"] == "task-pdf-001"
+        assert data["status"] == "pending"
+        assert data["format"] == "pdf"
+        assert data["date"] == today_str
+        assert "status_url" in data
+        assert "download_url" in data
+
+    def test_submit_xlsx_task_returns_202(self, admin_client, today_str):
+        with patch(
+            "api.views.report_task_views.generate_report_xlsx_task"
+        ) as mock_task:
+            mock_task.delay.return_value = MagicMock(id="task-xlsx-001")
+            res = admin_client.post(
+                self.URL, {"date": today_str, "format": "xlsx"}, format="json"
+            )
+
+        assert res.status_code == status.HTTP_202_ACCEPTED
+        assert res.json()["format"] == "xlsx"
+        assert res.json()["task_id"] == "task-xlsx-001"
+
+    def test_default_format_is_pdf(self, admin_client, today_str):
+        with patch("api.views.report_task_views.generate_report_pdf_task") as mock_task:
+            mock_task.delay.return_value = MagicMock(id="task-default-001")
+            res = admin_client.post(self.URL, {"date": today_str}, format="json")
+
+        assert res.status_code == status.HTTP_202_ACCEPTED
+        assert res.json()["format"] == "pdf"
+
+    def test_missing_date_returns_400(self, admin_client):
+        res = admin_client.post(self.URL, {}, format="json")
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+        assert "date" in res.json()["error"]
+
+    def test_invalid_date_returns_400(self, admin_client):
+        res = admin_client.post(self.URL, {"date": "not-a-date"}, format="json")
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_invalid_format_returns_400(self, admin_client, today_str):
+        res = admin_client.post(
+            self.URL, {"date": today_str, "format": "docx"}, format="json"
+        )
+        assert res.status_code == status.HTTP_400_BAD_REQUEST
+        assert "format" in res.json()["error"]
+
+    def test_non_admin_is_forbidden(self, authenticated_client, today_str):
+        res = authenticated_client.post(self.URL, {"date": today_str}, format="json")
+        assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_unauthenticated_is_rejected(self, today_str):
+        res = APIClient().post(self.URL, {"date": today_str}, format="json")
+        assert res.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task status polling (GET /api/admin/report-tasks/{id}/)
+# ---------------------------------------------------------------------------
+
+
+class TestReportTaskRetrieve:
+    def _url(self, task_id):
+        return f"/api/admin/report-tasks/{task_id}/"
+
+    def test_pending_task_status(self, admin_client):
+        with patch("api.views.report_task_views.AsyncResult") as MockResult:
+            MockResult.return_value = MagicMock(
+                status="PENDING", successful=lambda: False, failed=lambda: False
+            )
+            res = admin_client.get(self._url("abc-pending"))
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.json()["status"] == "pending"
+        assert res.json()["task_id"] == "abc-pending"
+
+    def test_processing_task_status(self, admin_client):
+        with patch("api.views.report_task_views.AsyncResult") as MockResult:
+            MockResult.return_value = MagicMock(
+                status="STARTED", successful=lambda: False, failed=lambda: False
+            )
+            res = admin_client.get(self._url("abc-started"))
+
+        assert res.json()["status"] == "processing"
+
+    def test_complete_task_status(self, admin_client):
+        task_result = {"status": "complete", "format": "pdf", "date": "2026-01-15"}
+        with patch("api.views.report_task_views.AsyncResult") as MockResult:
+            MockResult.return_value = MagicMock(
+                status="SUCCESS",
+                successful=lambda: True,
+                failed=lambda: False,
+                result=task_result,
+            )
+            res = admin_client.get(self._url("abc-success"))
+
+        data = res.json()
+        assert data["status"] == "complete"
+        assert data["result"] == task_result
+
+    def test_failed_task_status(self, admin_client):
+        with patch("api.views.report_task_views.AsyncResult") as MockResult:
+            mock_result = MagicMock(
+                status="FAILURE",
+                successful=lambda: False,
+                failed=lambda: True,
+            )
+            mock_result.result = Exception("worker crashed")
+            MockResult.return_value = mock_result
+            res = admin_client.get(self._url("abc-failed"))
+
+        data = res.json()
+        assert data["status"] == "failed"
+        assert "error" in data
+
+    def test_non_admin_is_forbidden(self, authenticated_client):
+        res = authenticated_client.get(self._url("any-id"))
+        assert res.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------------------------------------------------------------------
+# File download (GET /api/admin/report-tasks/{id}/download/)
+# ---------------------------------------------------------------------------
+
+
+class TestReportTaskDownload:
+    def _url(self, task_id):
+        return f"/api/admin/report-tasks/{task_id}/download/"
+
+    def test_download_pdf_when_complete(self, admin_client):
+        fake_pdf = b"%PDF-1.4 fake content"
+        task_result = {"format": "pdf", "date": "2026-01-15"}
+        with (
+            patch("api.views.report_task_views.AsyncResult") as MockResult,
+            patch("api.views.report_task_views.cache") as mock_cache,
+        ):
+            MockResult.return_value = MagicMock(
+                successful=lambda: True,
+                result=task_result,
+            )
+            mock_cache.get.return_value = fake_pdf
+            res = admin_client.get(self._url("pdf-task-ok"))
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res["Content-Type"] == "application/pdf"
+        assert 'filename="prehlad_2026-01-15.pdf"' in res["Content-Disposition"]
+        # FileResponse uses streaming_content, collect it into bytes
+        content = b"".join(res.streaming_content)
+        assert content == fake_pdf
+
+    def test_download_xlsx_when_complete(self, admin_client):
+        fake_xlsx = b"PK\x03\x04fake-xlsx-content"
+        task_result = {"format": "xlsx", "date": "2026-01-15"}
+        with (
+            patch("api.views.report_task_views.AsyncResult") as MockResult,
+            patch("api.views.report_task_views.cache") as mock_cache,
+        ):
+            MockResult.return_value = MagicMock(
+                successful=lambda: True,
+                result=task_result,
+            )
+            mock_cache.get.return_value = fake_xlsx
+            res = admin_client.get(self._url("xlsx-task-ok"))
+
+        assert res.status_code == status.HTTP_200_OK
+        assert "spreadsheetml" in res["Content-Type"]
+        assert 'filename="prehlad_2026-01-15.xlsx"' in res["Content-Disposition"]
+
+    def test_download_returns_404_when_task_not_complete(self, admin_client):
+        with patch("api.views.report_task_views.AsyncResult") as MockResult:
+            MockResult.return_value = MagicMock(
+                successful=lambda: False,
+                status="PENDING",
+            )
+            res = admin_client.get(self._url("not-done"))
+
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+        assert "status" in res.json()
+
+    def test_download_returns_404_when_cache_expired(self, admin_client):
+        task_result = {"format": "pdf", "date": "2026-01-01"}
+        with (
+            patch("api.views.report_task_views.AsyncResult") as MockResult,
+            patch("api.views.report_task_views.cache") as mock_cache,
+        ):
+            MockResult.return_value = MagicMock(
+                successful=lambda: True,
+                result=task_result,
+            )
+            mock_cache.get.return_value = None  # expired
+            res = admin_client.get(self._url("expired-task"))
+
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+        assert "expired" in res.json()["error"].lower()
+
+    def test_non_admin_is_forbidden(self, authenticated_client):
+        res = authenticated_client.get(self._url("any-id"))
+        assert res.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------------------------------------------------------------------
+# Celery tasks (unit level – no real Celery worker)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReportTasks:
+    @pytest.mark.django_db
+    def test_generate_pdf_task_stores_in_cache(self, daily_order, today_str):
+        from unittest.mock import patch
+
+        with (
+            patch("api.exporters.PDFReportExporter") as MockPDF,
+            patch("django.core.cache.cache") as mock_cache,
+        ):
+            MockPDF.return_value.generate.return_value = b"%PDF fake"
+
+            from api.tasks import generate_report_pdf_task
+
+            result = generate_report_pdf_task(today_str)
+
+        assert result["status"] == "complete"
+        assert result["format"] == "pdf"
+        assert result["date"] == today_str
+        mock_cache.set.assert_called_once()
+        cache_key = mock_cache.set.call_args[0][0]
+        assert f"pdf:{today_str}" in cache_key
+
+    @pytest.mark.django_db
+    def test_generate_xlsx_task_stores_in_cache(self, daily_order, today_str):
+        with (
+            patch("api.exporters.XLSXReportExporter") as MockXLSX,
+            patch("api.services.report_service.ReportService") as MockService,
+            patch("django.core.cache.cache") as mock_cache,
+        ):
+            MockService.get_orders_for_export.return_value = []
+            MockXLSX.return_value.generate.return_value = b"PK xlsx"
+
+            from api.tasks import generate_report_xlsx_task
+
+            result = generate_report_xlsx_task(today_str)
+
+        assert result["status"] == "complete"
+        assert result["format"] == "xlsx"
+        mock_cache.set.assert_called_once()
+        cache_key = mock_cache.set.call_args[0][0]
+        assert f"xlsx:{today_str}" in cache_key
+
+    @pytest.mark.django_db
+    def test_pdf_task_uses_correct_cache_timeout(self, daily_order, today_str):
+        with (
+            patch("api.exporters.PDFReportExporter") as MockPDF,
+            patch("django.core.cache.cache") as mock_cache,
+        ):
+            MockPDF.return_value.generate.return_value = b"%PDF"
+
+            from api.tasks import REPORT_CACHE_TIMEOUT, generate_report_pdf_task
+
+            generate_report_pdf_task(today_str)
+
+        assert mock_cache.set.call_args[1].get("timeout") == REPORT_CACHE_TIMEOUT

--- a/backend/api/tests/integration/test_report_async.py
+++ b/backend/api/tests/integration/test_report_async.py
@@ -19,7 +19,7 @@ def today_str():
 def daily_order(db, user, today_str):
     return DailyOrder.objects.create(
         user=user,
-        date=today_str,
+        date=date.fromisoformat(today_str),
         status="submitted",
         data={
             "breakfast": {"Dospelý": {"menuCounts": {"A": 2}, "diets": {}}},

--- a/backend/api/tests/test_caching.py
+++ b/backend/api/tests/test_caching.py
@@ -225,7 +225,7 @@ class TestClientSettingsCaching:
 
 
 class TestDietListCaching:
-    """Test Diet list caching via @cache_page decorator."""
+    """Test Diet list caching via custom cache_service helpers."""
 
     def setup_method(self):
         """Clear cache before each test."""

--- a/backend/api/tests/test_caching.py
+++ b/backend/api/tests/test_caching.py
@@ -1,0 +1,492 @@
+"""
+Tests for Redis caching implementation.
+
+Tests cover:
+- GlobalSettings caching with signal-based invalidation
+- ClientSettings caching with signal-based invalidation
+- Diet list caching with signal-based invalidation
+- Daily stats caching with 5-minute TTL
+- Cache hit/miss tracking
+"""
+
+import json
+from datetime import date, datetime, time
+
+import pytest
+from django.core.cache import cache
+from django.test import Client
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from api.cache_service import (
+    clear_client_settings_cache,
+    clear_diet_list_cache,
+    clear_global_settings_cache,
+    delete_cached,
+    get_cached,
+    get_client_settings_cache_key,
+    get_daily_stats_cache_key,
+    get_diet_list_cache_key,
+    get_global_settings_cache_key,
+    set_cached,
+)
+from api.cached_settings_service import get_client_settings, get_global_settings
+from api.models import ClientSettings, DailyOrder, Diet, GlobalSettings, User
+
+pytestmark = pytest.mark.django_db
+
+
+class TestCacheService:
+    """Test basic cache service functions."""
+
+    def test_set_and_get_cached_value(self):
+        """Test setting and retrieving a value from cache."""
+        key = "test_key"
+        value = {"data": "test"}
+
+        set_cached(key, value, timeout=100)
+        cached_value = get_cached(key)
+
+        assert cached_value == value
+
+    def test_delete_cached_value(self):
+        """Test deleting a value from cache."""
+        key = "test_key"
+        value = {"data": "test"}
+
+        set_cached(key, value)
+        assert get_cached(key) == value
+
+        delete_cached(key)
+        assert get_cached(key) is None
+
+    def test_cache_key_generation(self):
+        """Test cache key generation functions."""
+        assert get_global_settings_cache_key() == "global_settings"
+        assert get_client_settings_cache_key(1) == "client_settings:1"
+        assert get_client_settings_cache_key(123) == "client_settings:123"
+        assert get_diet_list_cache_key() == "diet_list"
+        assert get_daily_stats_cache_key("2026-03-06") == "daily_stats:2026-03-06"
+
+
+class TestGlobalSettingsCaching:
+    """Test GlobalSettings caching with signal-based invalidation."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        cache.clear()
+
+    def test_global_settings_cached_on_first_access(self):
+        """Test that GlobalSettings is cached on first retrieval."""
+        settings = GlobalSettings.objects.create(
+            pk=1,
+            deadline_breakfast=time(8, 0),
+            deadline_lunch=time(11, 0),
+            deadline_olovrant=time(16, 0),
+        )
+
+        # First call should hit database
+        result = get_global_settings()
+        assert result.pk == settings.pk
+
+        # Check it's in cache
+        cache_key = get_global_settings_cache_key()
+        cached = get_cached(cache_key)
+        assert cached is not None
+        assert cached.pk == settings.pk
+
+    def test_global_settings_cache_hit(self):
+        """Test that subsequent calls use cached value."""
+        settings = GlobalSettings.objects.create(
+            pk=1,
+            deadline_breakfast=time(8, 0),
+            deadline_lunch=time(11, 0),
+            deadline_olovrant=time(16, 0),
+        )
+
+        # First call
+        result1 = get_global_settings()
+
+        # Manually update database and Save (but don't call service again yet)
+        # to test that the cached instance reflects the change
+        from django.core.cache import cache as django_cache
+
+        django_cache.clear()  # Clear cache to test fresh fetch
+
+        settings.deadline_breakfast = time(9, 0)
+        settings.save()
+
+        # Clear cache to force fresh database read
+        from api.cache_service import clear_global_settings_cache
+
+        clear_global_settings_cache()
+
+        # Next call should return the updated value
+        result2 = get_global_settings()
+        assert result2.deadline_breakfast == time(9, 0)  # Updated from DB
+
+    def test_global_settings_cache_invalidation_on_save(self):
+        """Test that cache is invalidated when GlobalSettings is saved."""
+        settings = GlobalSettings.objects.create(
+            pk=1,
+            deadline_breakfast=time(8, 0),
+            deadline_lunch=time(11, 0),
+            deadline_olovrant=time(16, 0),
+        )
+
+        # Load into cache
+        result1 = get_global_settings()
+
+        # Update and save
+        settings.deadline_breakfast = time(9, 0)
+        settings.save()
+
+        # Cache should be invalidated; fetch fresh from DB
+        cache_key = get_global_settings_cache_key()
+        assert get_cached(cache_key) is None
+
+        # Next retrieval should get updated value from database
+        result2 = get_global_settings()
+        assert result2.deadline_breakfast == time(9, 0)
+
+
+class TestClientSettingsCaching:
+    """Test ClientSettings caching with signal-based invalidation."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        cache.clear()
+
+    def test_client_settings_cached_on_first_access(self):
+        """Test that ClientSettings is cached on first retrieval."""
+        user = User.objects.create(username="testuser", email="test@example.com")
+        settings = ClientSettings.objects.create(
+            user=user, visible_meals=["breakfast", "lunch"]
+        )
+
+        # First call should hit database and cache
+        result = get_client_settings(user.id)
+        assert result.pk == settings.pk
+
+        # Check it's in cache
+        cache_key = get_client_settings_cache_key(user.id)
+        cached = get_cached(cache_key)
+        assert cached is not None
+        assert cached.pk == settings.pk
+
+    def test_client_settings_cache_invalidation_on_save(self):
+        """Test that cache is invalidated when ClientSettings is saved."""
+        user = User.objects.create(username="testuser", email="test@example.com")
+        settings = ClientSettings.objects.create(
+            user=user, visible_meals=["breakfast", "lunch"]
+        )
+
+        # Load into cache
+        result1 = get_client_settings(user.id)
+        assert result1.visible_meals == ["breakfast", "lunch"]
+
+        # Update and save
+        settings.visible_meals = ["lunch"]
+        settings.save()
+
+        # Cache should be invalidated
+        cache_key = get_client_settings_cache_key(user.id)
+        assert get_cached(cache_key) is None
+
+        # Next retrieval should get updated value
+        result2 = get_client_settings(user.id)
+        assert result2.visible_meals == ["lunch"]
+
+    def test_client_settings_different_users_separate_cache(self):
+        """Test that different users have separate cache entries."""
+        user1 = User.objects.create(username="user1", email="user1@example.com")
+        user2 = User.objects.create(username="user2", email="user2@example.com")
+
+        settings1 = ClientSettings.objects.create(
+            user=user1, visible_meals=["breakfast"]
+        )
+        settings2 = ClientSettings.objects.create(
+            user=user2, visible_meals=["lunch", "olovrant"]
+        )
+
+        # Cache both
+        get_client_settings(user1.id)
+        get_client_settings(user2.id)
+
+        # Check separate cache keys
+        cache_key1 = get_client_settings_cache_key(user1.id)
+        cache_key2 = get_client_settings_cache_key(user2.id)
+        assert cache_key1 != cache_key2
+
+        cached1 = get_cached(cache_key1)
+        cached2 = get_cached(cache_key2)
+        assert cached1.visible_meals == ["breakfast"]
+        assert cached2.visible_meals == ["lunch", "olovrant"]
+
+
+class TestDietListCaching:
+    """Test Diet list caching via @cache_page decorator."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        cache.clear()
+        self.client = APIClient()
+        self.admin_user = User.objects.create_user(
+            username="admin", password="test", is_staff=True, is_superuser=True
+        )
+        self.client.force_authenticate(user=self.admin_user)
+
+    def test_diet_list_cache_hit(self):
+        """Test that Diet list is cached."""
+        diet1 = Diet.objects.create(name="Vegetarian", is_active=True)
+        diet2 = Diet.objects.create(name="GlutenFree", is_active=True)
+
+        # First request should hit database
+        response1 = self.client.get("/api/diets/")
+        assert response1.status_code == status.HTTP_200_OK
+        data1 = response1.json()
+
+        # Count iterations/DB queries for cache behavior
+        # (Actual query count testing would require using assertNumQueries)
+
+        # Second request should use cached response
+        response2 = self.client.get("/api/diets/")
+        assert response2.status_code == status.HTTP_200_OK
+        data2 = response2.json()
+
+        # Same data should be returned
+        assert data1 == data2
+
+    def test_diet_list_cache_invalidation_on_create(self):
+        """Test that cache is invalidated when Diet is created."""
+        diet1 = Diet.objects.create(name="Vegetarian", is_active=True)
+
+        # First request
+        response1 = self.client.get("/api/diets/")
+        assert response1.status_code == status.HTTP_200_OK
+        data1 = response1.json()
+        count1 = (
+            len(data1) if isinstance(data1, list) else len(data1.get("results", []))
+        )
+
+        # Create new diet - should invalidate cache
+        diet2 = Diet.objects.create(name="GlutenFree", is_active=True)
+
+        # Second request should reflect the new diet
+        response2 = self.client.get("/api/diets/")
+        data2 = response2.json()
+        count2 = (
+            len(data2) if isinstance(data2, list) else len(data2.get("results", []))
+        )
+
+        assert count2 >= count1  # At least as many as before
+
+    def test_diet_list_cache_invalidation_on_update(self):
+        """Test that cache is invalidated when Diet is updated."""
+        diet = Diet.objects.create(name="Vegetarian", is_active=True)
+
+        # First request
+        response1 = self.client.get("/api/diets/")
+        data1 = response1.json()
+
+        # Update diet
+        diet.is_active = False
+        diet.save()
+
+        # Cache should be invalidated, next request should reflect change
+        response2 = self.client.get("/api/diets/")
+        data2 = response2.json()
+
+        # The response data should reflect the update
+        # (Exact assertion depends on how is_active is serialized)
+
+    def test_diet_list_cache_invalidation_on_delete(self):
+        """Test that cache is invalidated when Diet is deleted."""
+        diet1 = Diet.objects.create(name="Vegetarian", is_active=True)
+        diet2 = Diet.objects.create(name="GlutenFree", is_active=True)
+
+        # First request
+        response1 = self.client.get("/api/diets/")
+        data1 = response1.json()
+        count1 = (
+            len(data1) if isinstance(data1, list) else len(data1.get("results", []))
+        )
+
+        # Delete diet
+        diet1.delete()
+
+        # Cache should be invalidated
+        response2 = self.client.get("/api/diets/")
+        data2 = response2.json()
+        count2 = (
+            len(data2) if isinstance(data2, list) else len(data2.get("results", []))
+        )
+
+        assert count2 <= count1  # Fewer or equal after deletion
+
+
+class TestDailyStatsCaching:
+    """Test daily stats caching with 5-minute TTL."""
+
+    def setup_method(self):
+        """Clear cache and set up test data."""
+        cache.clear()
+        self.client = APIClient()
+        self.admin_user = User.objects.create_user(
+            username="admin", password="test", is_staff=True, is_superuser=True
+        )
+        self.client.force_authenticate(user=self.admin_user)
+
+    def test_daily_stats_cache_hit(self):
+        """Test that daily stats are cached."""
+        test_date = date(2026, 3, 6)
+
+        user = User.objects.create(username="user", email="user@example.com")
+        order = DailyOrder.objects.create(
+            user=user,
+            date=test_date,
+            data={
+                "breakfast": {"menuCounts": {"A": 1}, "diets": {}},
+                "lunch": {"menuCounts": {"B": 1}, "diets": {}},
+                "olovrant": {"menuCounts": {}, "diets": {}},
+            },
+        )
+
+        # First request
+        response1 = self.client.get(
+            f"/api/admin/summary/daily-stats/?date={test_date.isoformat()}"
+        )
+        assert response1.status_code == status.HTTP_200_OK
+        data1 = response1.json()
+
+        # Check cache
+        cache_key = get_daily_stats_cache_key(test_date.isoformat())
+        cached = get_cached(cache_key)
+        assert cached is not None
+        assert cached == data1
+
+    def test_daily_stats_cache_different_dates_separate_cache(self):
+        """Test that different dates have separate cache entries."""
+        user = User.objects.create(username="user", email="user@example.com")
+
+        date1 = date(2026, 3, 6)
+        date2 = date(2026, 3, 7)
+
+        DailyOrder.objects.create(
+            user=user,
+            date=date1,
+            data={"breakfast": {"menuCounts": {"A": 1}, "diets": {}}},
+        )
+        DailyOrder.objects.create(
+            user=user,
+            date=date2,
+            data={"breakfast": {"menuCounts": {"B": 1}, "diets": {}}},
+        )
+
+        # Request both dates
+        response1 = self.client.get(
+            f"/api/admin/summary/daily-stats/?date={date1.isoformat()}"
+        )
+        response2 = self.client.get(
+            f"/api/admin/summary/daily-stats/?date={date2.isoformat()}"
+        )
+
+        data1 = response1.json()
+        data2 = response2.json()
+
+        # Check separate cache keys
+        cache_key1 = get_daily_stats_cache_key(date1.isoformat())
+        cache_key2 = get_daily_stats_cache_key(date2.isoformat())
+        assert cache_key1 != cache_key2
+
+        # Should have different cached data
+        assert get_cached(cache_key1) is not None
+        assert get_cached(cache_key2) is not None
+
+    def test_daily_stats_invalid_date_not_cached(self):
+        """Test that invalid dates return error and don't cache."""
+        response = self.client.get("/api/admin/summary/daily-stats/?date=invalid-date")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_daily_stats_missing_date_parameter(self):
+        """Test that missing date parameter returns error."""
+        response = self.client.get("/api/admin/summary/daily-stats/")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class TestCacheHitRateTracking:
+    """Test cache hit/miss tracking."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        cache.clear()
+
+    def test_cache_hit_miss_sequence(self):
+        """Test tracking cache hits and misses."""
+        key = "test_key"
+        value = {"data": "test"}
+
+        # First access - miss
+        assert get_cached(key) is None
+
+        # Set value
+        set_cached(key, value)
+
+        # Second access - hit
+        assert get_cached(key) == value
+
+        # Delete and access - miss
+        delete_cached(key)
+        assert get_cached(key) is None
+
+
+class TestCachePerformance:
+    """Test that caching actually reduces database queries."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        cache.clear()
+
+    def test_global_settings_multiple_accesses(self, django_assert_num_queries):
+        """Test that multiple GlobalSettings accesses only hit DB once."""
+        settings = GlobalSettings.objects.create(
+            pk=1,
+            deadline_breakfast=time(8, 0),
+            deadline_lunch=time(11, 0),
+            deadline_olovrant=time(16, 0),
+        )
+
+        # First access should hit DB
+        with django_assert_num_queries(1):
+            result1 = get_global_settings()
+
+        # Subsequent accesses should use cache (0 queries)
+        with django_assert_num_queries(0):
+            result2 = get_global_settings()
+            result3 = get_global_settings()
+
+        assert result1.pk == result2.pk == result3.pk
+
+    def test_client_settings_multiple_users(self, django_assert_num_queries):
+        """Test that each user's settings are cached independently."""
+        user1 = User.objects.create(username="user1", email="user1@example.com")
+        user2 = User.objects.create(username="user2", email="user2@example.com")
+
+        ClientSettings.objects.create(user=user1, visible_meals=["breakfast"])
+        ClientSettings.objects.create(user=user2, visible_meals=["lunch"])
+
+        # First access for user1 - 1 query
+        with django_assert_num_queries(1):
+            get_client_settings(user1.id)
+
+        # Subsequent access for user1 - 0 queries (cached)
+        with django_assert_num_queries(0):
+            get_client_settings(user1.id)
+
+        # First access for user2 - 1 query
+        with django_assert_num_queries(1):
+            get_client_settings(user2.id)
+
+        # Subsequent access for user2 - 0 queries (cached)
+        with django_assert_num_queries(0):
+            get_client_settings(user2.id)

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -17,6 +17,7 @@ from .views import (
     PendingRegistrationsViewSet,
     PlannedOrdersViewSet,
     RegistrationView,
+    ReportTaskViewSet,
     ResendVerificationEmailView,
     UserProfileViewSet,
 )
@@ -44,6 +45,11 @@ router.register(
     r"admin/pending-registrations",
     PendingRegistrationsViewSet,
     basename="pending-registrations",
+)
+router.register(
+    r"admin/report-tasks",
+    ReportTaskViewSet,
+    basename="report-task",
 )
 
 urlpatterns = [

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -32,6 +32,7 @@ from .pending_registrations_views import PendingRegistrationsViewSet
 from .registration_views import RegistrationView
 
 # Report views
+from .report_task_views import ReportTaskViewSet
 from .report_views import AdminSummaryViewSet
 
 # Settings views
@@ -55,6 +56,7 @@ __all__ = [
     "AdminUserViewSet",
     # Reports
     "AdminSummaryViewSet",
+    "ReportTaskViewSet",
     # Settings
     "UserProfileViewSet",
     "GlobalSettingsViewSet",

--- a/backend/api/views/diet_views.py
+++ b/backend/api/views/diet_views.py
@@ -2,8 +2,14 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from rest_framework import permissions, viewsets
 
-from ..models import Diet
-from ..serializers_user import DietSerializer
+from api.cache_service import (
+    DIET_LIST_TIMEOUT,
+    get_cached,
+    get_diet_list_cache_key,
+    set_cached,
+)
+from api.models import Diet
+from api.serializers_user import DietSerializer
 
 
 class DietViewSet(viewsets.ModelViewSet):
@@ -24,7 +30,27 @@ class DietViewSet(viewsets.ModelViewSet):
             return [permissions.IsAdminUser()]
         return super().get_permissions()
 
-    @method_decorator(cache_page(60 * 60 * 24))  # Cache for 24 hours
     def list(self, request, *args, **kwargs):
-        """Cache the Diet list since it's rarely modified."""
-        return super().list(request, *args, **kwargs)
+        """
+        Return cached Diet list (24h TTL).
+
+        Cache is automatically invalidated when Diet instances are
+        created/updated/deleted via signal handlers (clear_diet_list_cache).
+        """
+        cache_key = get_diet_list_cache_key()
+
+        # Try to get cached serialized data
+        cached_data = get_cached(cache_key)
+        if cached_data is not None:
+            from rest_framework.response import Response
+
+            return Response(cached_data)
+
+        # Generate response via parent list() method
+        response = super().list(request, *args, **kwargs)
+
+        # Cache the serialized data (response.data is already paginated dict)
+        if response.status_code == 200:
+            set_cached(cache_key, response.data, timeout=DIET_LIST_TIMEOUT)
+
+        return response

--- a/backend/api/views/diet_views.py
+++ b/backend/api/views/diet_views.py
@@ -1,5 +1,3 @@
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from rest_framework import permissions, viewsets
 
 from api.cache_service import (
@@ -36,8 +34,13 @@ class DietViewSet(viewsets.ModelViewSet):
 
         Cache is automatically invalidated when Diet instances are
         created/updated/deleted via signal handlers (clear_diet_list_cache).
+
+        Note: Caching is per-page via pagination aware keys. This avoids returning
+        stale pages when filtering/sorting query params change.
         """
-        cache_key = get_diet_list_cache_key()
+        # Build cache key including pagination params to handle different pages
+        page_num = request.query_params.get("page", "1")
+        cache_key = f"{get_diet_list_cache_key()}:page={page_num}"
 
         # Try to get cached serialized data
         cached_data = get_cached(cache_key)

--- a/backend/api/views/diet_views.py
+++ b/backend/api/views/diet_views.py
@@ -1,13 +1,13 @@
 from rest_framework import permissions, viewsets
 
-from api.cache_service import (
+from ..cache_service import (
     DIET_LIST_TIMEOUT,
     get_cached,
     get_diet_list_cache_key,
     set_cached,
 )
-from api.models import Diet
-from api.serializers_user import DietSerializer
+from ..models import Diet
+from ..serializers_user import DietSerializer
 
 
 class DietViewSet(viewsets.ModelViewSet):

--- a/backend/api/views/diet_views.py
+++ b/backend/api/views/diet_views.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from rest_framework import permissions, viewsets
 
 from ..models import Diet
@@ -7,6 +9,10 @@ from ..serializers_user import DietSerializer
 class DietViewSet(viewsets.ModelViewSet):
     """
     ViewSet for the Diet model (CRUD).
+
+    List action is cached for 24 hours since diet data is static.
+    Cache is automatically invalidated when Diet instances are created/updated/deleted
+    via signal handlers.
     """
 
     queryset = Diet.objects.all()
@@ -17,3 +23,8 @@ class DietViewSet(viewsets.ModelViewSet):
         if self.action in ["create", "update", "partial_update", "destroy"]:
             return [permissions.IsAdminUser()]
         return super().get_permissions()
+
+    @method_decorator(cache_page(60 * 60 * 24))  # Cache for 24 hours
+    def list(self, request, *args, **kwargs):
+        """Cache the Diet list since it's rarely modified."""
+        return super().list(request, *args, **kwargs)

--- a/backend/api/views/report_task_views.py
+++ b/backend/api/views/report_task_views.py
@@ -1,0 +1,157 @@
+"""Async report task views – initiate, poll, and download generated reports."""
+
+import datetime
+import io
+import logging
+
+from celery.result import AsyncResult
+from django.core.cache import cache
+from django.http import FileResponse, HttpResponse
+from rest_framework import permissions, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from api.tasks import generate_report_pdf_task, generate_report_xlsx_task
+
+logger = logging.getLogger(__name__)
+
+_CELERY_STATUS_MAP = {
+    "PENDING": "pending",
+    "STARTED": "processing",
+    "RETRY": "processing",
+    "SUCCESS": "complete",
+    "FAILURE": "failed",
+    "REVOKED": "failed",
+}
+
+_VALID_FORMATS = {"pdf", "xlsx"}
+
+
+class ReportTaskViewSet(viewsets.ViewSet):
+    """
+    ViewSet for async report generation via Celery.
+
+    POST /api/admin/report-tasks/           → submit a report generation task
+    GET  /api/admin/report-tasks/{id}/      → poll task status
+    GET  /api/admin/report-tasks/{id}/download/ → download the completed report
+    """
+
+    permission_classes = [permissions.IsAdminUser]
+
+    def create(self, request):
+        """Submit a background report generation task.
+
+        Query / body params:
+            date   (str, required) – YYYY-MM-DD
+            format (str, optional) – "pdf" (default) or "xlsx"
+
+        Returns 202 with task_id and a status_url for polling.
+        """
+        date_str = request.data.get("date") or request.query_params.get("date")
+        fmt = (
+            request.data.get("format") or request.query_params.get("format", "pdf")
+        ).lower()
+
+        if not date_str:
+            return Response(
+                {"error": "date parameter is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            datetime.date.fromisoformat(date_str)
+        except ValueError:
+            return Response(
+                {"error": "invalid date format, expected YYYY-MM-DD"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if fmt not in _VALID_FORMATS:
+            return Response(
+                {
+                    "error": f"format must be one of: {', '.join(sorted(_VALID_FORMATS))}"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if fmt == "xlsx":
+            task = generate_report_xlsx_task.delay(date_str)
+        else:
+            task = generate_report_pdf_task.delay(date_str)
+
+        logger.info(
+            "Report task %s submitted: format=%s date=%s user=%s",
+            task.id,
+            fmt,
+            date_str,
+            request.user.email,
+        )
+        base_url = f"/api/admin/report-tasks/{task.id}"
+        return Response(
+            {
+                "task_id": task.id,
+                "status": "pending",
+                "format": fmt,
+                "date": date_str,
+                "status_url": f"{base_url}/",
+                "download_url": f"{base_url}/download/",
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+    def retrieve(self, request, pk=None):
+        """Return current status of a report generation task.
+
+        Possible status values: pending, processing, complete, failed.
+        """
+        result = AsyncResult(pk)
+        task_status = _CELERY_STATUS_MAP.get(result.status, "pending")
+
+        payload = {"task_id": pk, "status": task_status}
+
+        if result.successful():
+            payload["result"] = result.result
+        elif result.failed():
+            payload["error"] = str(result.result)
+
+        return Response(payload)
+
+    @action(detail=True, methods=["get"])
+    def download(self, request, pk=None):
+        """Download a completed report file.
+
+        Returns the binary file (PDF or XLSX) stored in cache by the task.
+        Returns 404 if the report has expired or the task hasn't finished.
+        """
+        result = AsyncResult(pk)
+        if not result.successful():
+            task_status = _CELERY_STATUS_MAP.get(result.status, "pending")
+            return Response(
+                {"error": "Report not ready", "status": task_status},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        task_result = result.result or {}
+        fmt = task_result.get("format", "pdf")
+        date_str = task_result.get("date", "")
+
+        cache_key = f"report_task:{fmt}:{date_str}"
+        file_bytes = cache.get(cache_key)
+
+        if not file_bytes:
+            return Response(
+                {"error": "Report expired. Please generate a new one."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        filename = f"prehlad_{date_str}.{fmt}"
+        if fmt == "xlsx":
+            content_type = (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
+            response = HttpResponse(file_bytes, content_type=content_type)
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
+            return response
+
+        # PDF
+        response = FileResponse(io.BytesIO(file_bytes), content_type="application/pdf")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response

--- a/backend/api/views/report_task_views.py
+++ b/backend/api/views/report_task_views.py
@@ -133,7 +133,10 @@ class ReportTaskViewSet(viewsets.ViewSet):
         fmt = task_result.get("format", "pdf")
         date_str = task_result.get("date", "")
 
-        cache_key = f"report_task:{fmt}:{date_str}"
+        # Use a task-identity-based cache key from the Celery task result to ensure
+        # we fetch the bytes produced by this specific task (not overwritten by a
+        # concurrent request for the same date/format). Fall back to task pk if not present.
+        cache_key = task_result.get("cache_key") or f"report_task:{pk}"
         file_bytes = cache.get(cache_key)
 
         if not file_bytes:

--- a/backend/api/views/report_task_views.py
+++ b/backend/api/views/report_task_views.py
@@ -48,9 +48,17 @@ class ReportTaskViewSet(viewsets.ViewSet):
         Returns 202 with task_id and a status_url for polling.
         """
         date_str = request.data.get("date") or request.query_params.get("date")
-        fmt = (
-            request.data.get("format") or request.query_params.get("format", "pdf")
-        ).lower()
+
+        # Validate format parameter (must be a string)
+        fmt_raw = request.data.get("format")
+        if fmt_raw is None:
+            fmt_raw = request.query_params.get("format", "pdf")
+        if not isinstance(fmt_raw, str):
+            return Response(
+                {"error": "format must be a string"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        fmt = fmt_raw.lower()
 
         if not date_str:
             return Response(
@@ -139,7 +147,7 @@ class ReportTaskViewSet(viewsets.ViewSet):
         cache_key = task_result.get("cache_key") or f"report_task:{pk}"
         file_bytes = cache.get(cache_key)
 
-        if not file_bytes:
+        if file_bytes is None:
             return Response(
                 {"error": "Report expired. Please generate a new one."},
                 status=status.HTTP_404_NOT_FOUND,

--- a/backend/api/views/report_task_views.py
+++ b/backend/api/views/report_task_views.py
@@ -65,9 +65,17 @@ class ReportTaskViewSet(viewsets.ViewSet):
                 {"error": "date parameter is required"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        # Validate date_str is a string and valid ISO format
+        if not isinstance(date_str, str):
+            return Response(
+                {"error": "date must be a string in YYYY-MM-DD format"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         try:
             datetime.date.fromisoformat(date_str)
-        except ValueError:
+        except (TypeError, ValueError):
             return Response(
                 {"error": "invalid date format, expected YYYY-MM-DD"},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/backend/api/views/report_views.py
+++ b/backend/api/views/report_views.py
@@ -26,9 +26,15 @@ class AdminSummaryViewSet(viewsets.ViewSet):
         """Get daily order statistics for a given date.
 
         Fetches all orders for the target date and aggregates meal statistics
-        from their data payloads. No additional eager loading is performed
-        since this endpoint only accesses order.data and order.id.
+        from their data payloads. Results are cached for 5 minutes.
         """
+        from ..cache_service import (
+            DAILY_STATS_TIMEOUT,
+            get_cached,
+            get_daily_stats_cache_key,
+            set_cached,
+        )
+
         date_str = request.query_params.get("date")
         if not date_str:
             return Response(
@@ -43,6 +49,12 @@ class AdminSummaryViewSet(viewsets.ViewSet):
                 {"error": "Invalid date format. Use YYYY-MM-DD."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        # Try cache first
+        cache_key = get_daily_stats_cache_key(date_str)
+        cached_stats = get_cached(cache_key)
+        if cached_stats is not None:
+            return Response(cached_stats, status=status.HTTP_200_OK)
 
         orders = DailyOrder.objects.filter(date=target_date)
 
@@ -59,6 +71,9 @@ class AdminSummaryViewSet(viewsets.ViewSet):
             self._aggregate_meal(stats, data, "breakfast")
             self._aggregate_meal(stats, data, "lunch")
             self._aggregate_meal(stats, data, "olovrant")
+
+        # Cache the stats
+        set_cached(cache_key, stats, timeout=DAILY_STATS_TIMEOUT)
 
         return Response(stats)
 
@@ -195,10 +210,10 @@ class AdminSummaryViewSet(viewsets.ViewSet):
         xlsx_bytes = exporter.generate()
 
         filename = f"prehlad_{date_str}.xlsx"
-        response = HttpResponse(
-            xlsx_bytes,
-            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        content_type = (
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         )
+        response = HttpResponse(xlsx_bytes, content_type=content_type)
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
         return response
 

--- a/backend/api/views/settings_views.py
+++ b/backend/api/views/settings_views.py
@@ -47,10 +47,10 @@ class GlobalSettingsViewSet(viewsets.ViewSet):
         return [permissions.IsAdminUser()]
 
     def list(self, request):
-        from ..models import GlobalSettings
+        from ..cached_settings_service import get_global_settings
         from ..serializers import GlobalSettingsSerializer
 
-        settings, _ = GlobalSettings.objects.get_or_create(pk=1)
+        settings = get_global_settings()
         serializer = GlobalSettingsSerializer(settings, context={"request": request})
         return Response(serializer.data)
 
@@ -58,6 +58,7 @@ class GlobalSettingsViewSet(viewsets.ViewSet):
         """
         Using create/post to update settings for simplicity or
         standard REST conventions.
+        Note: Cache is automatically invalidated via signals when settings are saved.
         """
         from ..models import GlobalSettings
         from ..serializers import GlobalSettingsSerializer

--- a/backend/app/settings/base.py
+++ b/backend/app/settings/base.py
@@ -112,6 +112,16 @@ MEDIA_ROOT = BASE_DIR / "media"
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# Cache – Redis for production, LocMem for development
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": os.environ.get("REDIS_URL", "redis://localhost:6379/1"),
+        "KEY_PREFIX": "zdravy_projekt",
+        "TIMEOUT": 300,  # Default 5-minute timeout
+    }
+}
+
 # Celery
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
 CELERY_RESULT_BACKEND = os.environ.get(

--- a/backend/app/settings/base.py
+++ b/backend/app/settings/base.py
@@ -112,15 +112,25 @@ MEDIA_ROOT = BASE_DIR / "media"
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-# Cache – Redis for production, LocMem for development
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": os.environ.get("REDIS_URL", "redis://localhost:6379/1"),
-        "KEY_PREFIX": "zdravy_projekt",
-        "TIMEOUT": 300,  # Default 5-minute timeout
+# Cache – Redis when REDIS_URL is set, LocMem for development
+REDIS_URL = os.environ.get("REDIS_URL")
+if REDIS_URL:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": REDIS_URL,
+            "KEY_PREFIX": "zdravy_projekt",
+            "TIMEOUT": 300,  # Default 5-minute timeout
+        }
     }
-}
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "KEY_PREFIX": "zdravy_projekt",
+            "TIMEOUT": 300,  # Default 5-minute timeout
+        }
+    }
 
 # Celery
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,7 @@ services:
       POSTGRES_PORT: 5432
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
+      REDIS_URL: redis://redis:6379/1
       EMAIL_HOST: mailhog
       EMAIL_PORT: 1025
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
       DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/1}
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -28,6 +28,7 @@ services:
       FRONTEND_URL: ${FRONTEND_URL}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/1}
       EMAIL_HOST: ${EMAIL_HOST}
       EMAIL_PORT: ${EMAIL_PORT:-587}
       EMAIL_HOST_USER: ${EMAIL_HOST_USER}

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -270,7 +270,14 @@ const AdminDashboard: React.FC = () => {
           const statusRes = await apiFetch(
             `${apiBase}/admin/report-tasks/${task_id}/`,
           );
-          if (!statusRes.ok) break;
+          if (!statusRes.ok) {
+            toastError(
+              fmt === "pdf"
+                ? "Chyba pri kontrole stavu generovania PDF súboru."
+                : "Chyba pri kontrole stavu generovania XLSX súboru.",
+            );
+            return;
+          }
           const { status: taskStatus } = (await statusRes.json()) as {
             status: string;
           };

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../../context/auth";
 import { useToast } from "../../context/ToastContext";
 
@@ -229,6 +229,95 @@ const AdminDashboard: React.FC = () => {
   const [pdfLoading, setPdfLoading] = useState(false);
 
   const isAtMax = date >= maxDate;
+  const { error: toastError } = useToast();
+  // Keep a ref so polling loops can be cancelled on unmount
+  const cancelPollRef = useRef(false);
+  useEffect(() => {
+    cancelPollRef.current = false;
+    return () => {
+      cancelPollRef.current = true;
+    };
+  }, []);
+
+  const POLL_INTERVAL_MS = 1500;
+  const POLL_MAX_ATTEMPTS = 200; // ~5 minutes max
+
+  const downloadViaTask = useCallback(
+    async (fmt: "pdf" | "xlsx", setLoading: (v: boolean) => void) => {
+      setLoading(true);
+      const apiBase = import.meta.env.VITE_API_URL || "/api";
+      try {
+        const initRes = await apiFetch(
+          `${apiBase}/admin/report-tasks/?date=${date}&format=${fmt}`,
+          { method: "POST" },
+        );
+        if (!initRes.ok) {
+          toastError(
+            fmt === "pdf"
+              ? "Chyba pri spúšťaní generovania PDF."
+              : "Chyba pri spúšťaní generovania XLSX.",
+          );
+          return;
+        }
+        const { task_id } = (await initRes.json()) as { task_id: string };
+
+        for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, POLL_INTERVAL_MS),
+          );
+          if (cancelPollRef.current) return;
+
+          const statusRes = await apiFetch(
+            `${apiBase}/admin/report-tasks/${task_id}/`,
+          );
+          if (!statusRes.ok) break;
+          const { status: taskStatus } = (await statusRes.json()) as {
+            status: string;
+          };
+
+          if (taskStatus === "complete") {
+            const dlRes = await apiFetch(
+              `${apiBase}/admin/report-tasks/${task_id}/download/`,
+            );
+            if (!dlRes.ok) {
+              toastError("Chyba pri sťahovaní súboru.");
+              return;
+            }
+            const blob = await dlRes.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `prehlad_${date}.${fmt}`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+            return;
+          }
+
+          if (taskStatus === "failed") {
+            toastError(
+              fmt === "pdf"
+                ? "Chyba pri generovaní PDF súboru."
+                : "Chyba pri generovaní XLSX súboru.",
+            );
+            return;
+          }
+        }
+        toastError("Generovanie súboru trvalo príliš dlho.");
+      } catch (e) {
+        console.error(e);
+        toastError(
+          fmt === "pdf"
+            ? "Chyba pri generovaní PDF súboru."
+            : "Chyba pri generovaní XLSX súboru.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [apiFetch, date, toastError],
+  );
 
   const fetchReport = useCallback(async () => {
     setLoading(true);
@@ -261,61 +350,9 @@ const AdminDashboard: React.FC = () => {
     });
   };
 
-  const handleDownloadXlsx = async () => {
-    setXlsxLoading(true);
-    try {
-      const res = await apiFetch(
-        `${import.meta.env.VITE_API_URL || "/api"}/admin/summary/daily-report-xlsx/?date=${date}`,
-      );
-      if (res.ok) {
-        const blob = await res.blob();
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `prehlad_${date}.xlsx`;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(url);
-      } else {
-        toastError("Chyba pri generovaní XLSX súboru.");
-      }
-    } catch (e) {
-      console.error(e);
-      toastError("Chyba pri generovaní XLSX súboru.");
-    } finally {
-      setXlsxLoading(false);
-    }
-  };
+  const handleDownloadXlsx = () => downloadViaTask("xlsx", setXlsxLoading);
 
-  const handleDownloadPdf = async () => {
-    setPdfLoading(true);
-    try {
-      const res = await apiFetch(
-        `${import.meta.env.VITE_API_URL || "/api"}/admin/summary/daily-report-pdf/?date=${date}`,
-      );
-      if (res.ok) {
-        const blob = await res.blob();
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `prehlad_${date}.pdf`;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(url);
-      } else {
-        toastError("Chyba pri generovaní PDF súboru.");
-      }
-    } catch (e) {
-      console.error(e);
-      toastError("Chyba pri generovaní PDF súboru.");
-    } finally {
-      setPdfLoading(false);
-    }
-  };
-
-  const { error: toastError } = useToast();
+  const handleDownloadPdf = () => downloadViaTask("pdf", setPdfLoading);
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500 pb-12">


### PR DESCRIPTION
Add Redis cache configuration plus cache helpers/services and signal-based invalidation for settings and diets; cache daily stats for 5 minutes.
Add async report generation (Celery tasks + DRF ViewSet) and update the admin frontend to submit/poll/download report tasks.
Improve concurrency behavior for order submission and auto-order creation, with new integration/unit tests.
