### PR TITLE
feat: add onboarding tour with context

### DIFF
--- a/backend/api/migrations/0018_userprofile_add_onboarding_completed.py
+++ b/backend/api/migrations/0018_userprofile_add_onboarding_completed.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0017_simplify_userprofile_remove_email_verification"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userprofile",
+            name="onboarding_completed",
+            field=models.BooleanField(
+                default=False,
+                help_text="True once the client has completed or dismissed the onboarding tour.",
+            ),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -145,6 +145,10 @@ class UserProfile(models.Model):
         help_text="API key/identifier used for data pairing (API users only)",
     )
     created_at = models.DateTimeField(auto_now_add=True)
+    onboarding_completed = models.BooleanField(
+        default=False,
+        help_text="True once the client has completed or dismissed the onboarding tour.",
+    )
 
     class Meta:
         ordering = ["-created_at"]

--- a/backend/api/serializers_user.py
+++ b/backend/api/serializers_user.py
@@ -43,6 +43,7 @@ class UserProfileDetailSerializer(serializers.ModelSerializer):
             "client_type",
             "api_identifier",
             "created_at",
+            "onboarding_completed",
         ]
         read_only_fields = ["created_at"]
 
@@ -76,6 +77,9 @@ class UserProfileSerializer(serializers.ModelSerializer):
     dic = serializers.CharField(
         source="profile.dic", required=False, allow_blank=True, allow_null=True
     )
+    onboarding_completed = serializers.BooleanField(
+        source="profile.onboarding_completed", required=False
+    )
 
     class Meta:
         model = User
@@ -87,6 +91,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "company_name",
             "ico",
             "dic",
+            "onboarding_completed",
             "date_joined",
             "groups",
             "settings",
@@ -131,12 +136,14 @@ class UserProfileSerializer(serializers.ModelSerializer):
         if profile_data is not None:
             profile = getattr(user, "profile", None)
             if profile is not None:
-                for field in ("company_name", "ico", "dic"):
+                for field in ("company_name", "ico", "dic", "onboarding_completed"):
                     if field in profile_data:
                         setattr(profile, field, profile_data[field])
                 profile.save(
                     update_fields=[
-                        k for k in ("company_name", "ico", "dic") if k in profile_data
+                        k
+                        for k in ("company_name", "ico", "dic", "onboarding_completed")
+                        if k in profile_data
                     ]
                 )
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import {
 
 import { AppProvider } from "./pages/client/context/AppContext";
 import { AuthProvider, useAuth } from "./context/auth";
+import { OnboardingProvider } from "./context/OnboardingContext";
 import { ToastProvider } from "./context/ToastContext";
 import { PWAProvider } from "./context/PWAContext";
 import { usePWA } from "./hooks/usePWA";
@@ -60,9 +61,11 @@ const ProtectedRoute = () => {
 
   return (
     <AppProvider>
-      <NotificationGuard>
-        <Outlet />
-      </NotificationGuard>
+      <OnboardingProvider>
+        <NotificationGuard>
+          <Outlet />
+        </NotificationGuard>
+      </OnboardingProvider>
     </AppProvider>
   );
 };

--- a/frontend/src/context/OnboardingContext.tsx
+++ b/frontend/src/context/OnboardingContext.tsx
@@ -1,0 +1,180 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "./auth";
+import { TOUR_STEPS } from "../pages/client/components/onboarding/tourSteps";
+
+const API_URL = import.meta.env.VITE_API_URL || "/api";
+
+/** Pages that are part of the tour — navigating to other pages ends it. */
+const TOUR_PAGES = ["/home", "/order"];
+
+interface OnboardingContextType {
+  isTourActive: boolean;
+  currentStep: number;
+  totalSteps: number;
+  startTour: () => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  completeTour: () => Promise<void>;
+  skipTour: () => Promise<void>;
+  resetTour: () => Promise<void>;
+}
+
+const OnboardingContext = createContext<OnboardingContextType | undefined>(
+  undefined,
+);
+
+export const TOTAL_STEPS = TOUR_STEPS.length;
+
+/** Returns the first workday strictly after today (Mon–Fri). */
+function getFirstNextWorkday(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  while (d.getDay() === 0 || d.getDay() === 6) d.setDate(d.getDate() + 1);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { user, isLoading, apiFetch, updateProfile } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [isTourActive, setIsTourActive] = useState(false);
+  const [currentStep, setCurrentStep] = useState(0);
+  const hasAutoStarted = useRef(false);
+
+  const markOnServer = useCallback(
+    async (completed: boolean) => {
+      try {
+        await apiFetch(`${API_URL}/user/profile/`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ onboarding_completed: completed }),
+        });
+      } catch {
+        // Silently ignore — UI already updated optimistically
+      }
+    },
+    [apiFetch],
+  );
+
+  const startTour = useCallback(() => {
+    setCurrentStep(0);
+    setIsTourActive(true);
+  }, []);
+
+  const nextStep = useCallback(() => {
+    setCurrentStep((prev) => {
+      const next = Math.min(prev + 1, TOTAL_STEPS - 1);
+      // Navigate if crossing page boundary
+      const prevPage = TOUR_STEPS[prev].page;
+      const nextPage = TOUR_STEPS[next].page;
+      if (next !== prev && nextPage !== prevPage) {
+        if (nextPage === "/order") {
+          navigate(`/order?date=${getFirstNextWorkday()}`);
+        } else if (nextPage === "/home") {
+          navigate("/home");
+        }
+      }
+      return next;
+    });
+  }, [navigate]);
+
+  const prevStep = useCallback(() => {
+    setCurrentStep((prev) => {
+      const next = Math.max(prev - 1, 0);
+      const prevPage = TOUR_STEPS[prev].page;
+      const nextPage = TOUR_STEPS[next].page;
+      if (next !== prev && nextPage !== prevPage) {
+        if (nextPage === "/order") {
+          navigate(`/order?date=${getFirstNextWorkday()}`);
+        } else if (nextPage === "/home") {
+          navigate("/home");
+        }
+      }
+      return next;
+    });
+  }, [navigate]);
+
+  const completeTour = useCallback(async () => {
+    setIsTourActive(false);
+    updateProfile({ onboarding_completed: true });
+    await markOnServer(true);
+  }, [updateProfile, markOnServer]);
+
+  const skipTour = useCallback(async () => {
+    setIsTourActive(false);
+    updateProfile({ onboarding_completed: true });
+    await markOnServer(true);
+  }, [updateProfile, markOnServer]);
+
+  const resetTour = useCallback(async () => {
+    updateProfile({ onboarding_completed: false });
+    hasAutoStarted.current = false;
+    setCurrentStep(0);
+    setIsTourActive(false);
+    await markOnServer(false);
+  }, [updateProfile, markOnServer]);
+
+  // Auto-start on /home when not yet completed
+  useEffect(() => {
+    if (isLoading || !user) return;
+    if (
+      user.onboarding_completed === false &&
+      location.pathname === "/home" &&
+      !hasAutoStarted.current
+    ) {
+      hasAutoStarted.current = true;
+      startTour();
+    }
+  }, [user, isLoading, location.pathname, startTour]);
+
+  // Complete tour silently when user navigates to a page outside the tour
+  useEffect(() => {
+    if (!isTourActive) return;
+    const isOnTourPage = TOUR_PAGES.some((p) =>
+      location.pathname.startsWith(p),
+    );
+    if (!isOnTourPage) {
+      completeTour();
+    }
+  }, [location.pathname, isTourActive, completeTour]);
+
+  return (
+    <OnboardingContext.Provider
+      value={{
+        isTourActive,
+        currentStep,
+        totalSteps: TOTAL_STEPS,
+        startTour,
+        nextStep,
+        prevStep,
+        completeTour,
+        skipTour,
+        resetTour,
+      }}
+    >
+      {children}
+    </OnboardingContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useOnboarding = () => {
+  const ctx = useContext(OnboardingContext);
+  if (!ctx) {
+    throw new Error("useOnboarding must be used within OnboardingProvider");
+  }
+  return ctx;
+};

--- a/frontend/src/context/OnboardingContext.tsx
+++ b/frontend/src/context/OnboardingContext.tsx
@@ -75,37 +75,32 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const nextStep = useCallback(() => {
-    setCurrentStep((prev) => {
-      const next = Math.min(prev + 1, TOTAL_STEPS - 1);
-      // Navigate if crossing page boundary
-      const prevPage = TOUR_STEPS[prev].page;
-      const nextPage = TOUR_STEPS[next].page;
-      if (next !== prev && nextPage !== prevPage) {
-        if (nextPage === "/order") {
-          navigate(`/order?date=${getFirstNextWorkday()}`);
-        } else if (nextPage === "/home") {
-          navigate("/home");
-        }
+    const next = Math.min(currentStep + 1, TOTAL_STEPS - 1);
+    const prevPage = TOUR_STEPS[currentStep].page;
+    const nextPage = TOUR_STEPS[next].page;
+    setCurrentStep(next);
+    if (next !== currentStep && nextPage !== prevPage) {
+      if (nextPage === "/order") {
+        navigate(`/order?date=${getFirstNextWorkday()}`);
+      } else if (nextPage === "/home") {
+        navigate("/home");
       }
-      return next;
-    });
-  }, [navigate]);
+    }
+  }, [currentStep, navigate]);
 
   const prevStep = useCallback(() => {
-    setCurrentStep((prev) => {
-      const next = Math.max(prev - 1, 0);
-      const prevPage = TOUR_STEPS[prev].page;
-      const nextPage = TOUR_STEPS[next].page;
-      if (next !== prev && nextPage !== prevPage) {
-        if (nextPage === "/order") {
-          navigate(`/order?date=${getFirstNextWorkday()}`);
-        } else if (nextPage === "/home") {
-          navigate("/home");
-        }
+    const next = Math.max(currentStep - 1, 0);
+    const prevPage = TOUR_STEPS[currentStep].page;
+    const nextPage = TOUR_STEPS[next].page;
+    setCurrentStep(next);
+    if (next !== currentStep && nextPage !== prevPage) {
+      if (nextPage === "/order") {
+        navigate(`/order?date=${getFirstNextWorkday()}`);
+      } else if (nextPage === "/home") {
+        navigate("/home");
       }
-      return next;
-    });
-  }, [navigate]);
+    }
+  }, [currentStep, navigate]);
 
   const completeTour = useCallback(async () => {
     setIsTourActive(false);

--- a/frontend/src/context/auth.tsx
+++ b/frontend/src/context/auth.tsx
@@ -24,6 +24,7 @@ interface User {
   first_name?: string;
   last_name?: string;
   company_name?: string;
+  onboarding_completed?: boolean;
   groups?: string[];
   is_staff?: boolean;
   settings?: UserSettings;
@@ -47,6 +48,7 @@ interface AuthContextType {
   refreshToken: () => Promise<boolean>;
   apiFetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   fetchUserProfile: () => Promise<User | null>;
+  updateProfile: (updates: Partial<User>) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -258,6 +260,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     return () => clearInterval(refreshInterval);
   }, [refreshToken, fetchUserProfile]);
 
+  const updateProfile = useCallback((updates: Partial<User>) => {
+    setUser((prev) => {
+      if (!prev) return prev;
+      const updated = { ...prev, ...updates };
+      localStorage.setItem(CACHED_PROFILE_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  }, []);
+
   const login = async (
     accessToken: string,
     refreshTokenStr: string,
@@ -286,6 +297,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         refreshToken,
         apiFetch,
         fetchUserProfile,
+        updateProfile,
       }}
     >
       {children}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,3 +2,12 @@
 
 @source "./index.html";
 @source "./src/**/*.{js,ts,jsx,tsx}";
+
+.tour-highlight {
+  position: relative;
+  z-index: 41;
+  outline: 3px solid #6366f1;
+  outline-offset: 4px;
+  border-radius: 8px;
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
+}

--- a/frontend/src/pages/client/components/onboarding/TourOverlay.tsx
+++ b/frontend/src/pages/client/components/onboarding/TourOverlay.tsx
@@ -103,14 +103,20 @@ const TourOverlay: React.FC = () => {
     }
 
     const el = document.querySelector(`[data-tour-id="${step.targetId}"]`);
-    if (!el) return;
+    if (!el) {
+      setTooltipPos(null);
+      return;
+    }
 
     // Scroll into view first, then measure
     el.scrollIntoView({ behavior: "smooth", block: "center" });
 
     const measure = () => {
       const rect = el.getBoundingClientRect();
-      if (rect.width === 0 && rect.height === 0) return; // element not visible
+      if (rect.width === 0 && rect.height === 0) {
+        setTooltipPos(null);
+        return;
+      }
       const pos = calcPosition(rect, step.placement);
       setTooltipPos(pos);
 

--- a/frontend/src/pages/client/components/onboarding/TourOverlay.tsx
+++ b/frontend/src/pages/client/components/onboarding/TourOverlay.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
+import { useOnboarding } from "../../../../context/OnboardingContext";
+import { TOUR_STEPS, TourStep } from "./tourSteps";
+import TourTooltip from "./TourTooltip";
+
+const TOOLTIP_WIDTH = 288; // w-72
+const TOOLTIP_HEIGHT = 190; // approximate
+const OFFSET = 12; // gap between target and tooltip
+const VIEWPORT_PADDING = 8;
+
+interface TooltipPos {
+  top: number;
+  left: number;
+  arrowPlacement: TourStep["placement"];
+}
+
+function calcPosition(
+  rect: DOMRect,
+  preferredPlacement: TourStep["placement"],
+): TooltipPos {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  const placements: TourStep["placement"][] = [
+    preferredPlacement,
+    "bottom",
+    "top",
+    "right",
+    "left",
+  ];
+
+  for (const p of placements) {
+    let top = 0;
+    let left = 0;
+
+    if (p === "bottom") {
+      top = rect.bottom + OFFSET;
+      left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2;
+    } else if (p === "top") {
+      top = rect.top - TOOLTIP_HEIGHT - OFFSET;
+      left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2;
+    } else if (p === "right") {
+      top = rect.top + rect.height / 2 - TOOLTIP_HEIGHT / 2;
+      left = rect.right + OFFSET;
+    } else {
+      top = rect.top + rect.height / 2 - TOOLTIP_HEIGHT / 2;
+      left = rect.left - TOOLTIP_WIDTH - OFFSET;
+    }
+
+    // Clamp to viewport
+    left = Math.max(
+      VIEWPORT_PADDING,
+      Math.min(left, vw - TOOLTIP_WIDTH - VIEWPORT_PADDING),
+    );
+    top = Math.max(
+      VIEWPORT_PADDING,
+      Math.min(top, vh - TOOLTIP_HEIGHT - VIEWPORT_PADDING),
+    );
+
+    const fitsVertically =
+      top >= VIEWPORT_PADDING && top + TOOLTIP_HEIGHT <= vh - VIEWPORT_PADDING;
+    const fitsHorizontally =
+      left >= VIEWPORT_PADDING &&
+      left + TOOLTIP_WIDTH <= vw - VIEWPORT_PADDING;
+    if (fitsVertically && fitsHorizontally) {
+      return { top, left, arrowPlacement: p };
+    }
+  }
+
+  // Fallback: center below
+  return {
+    top: rect.bottom + OFFSET,
+    left: Math.max(VIEWPORT_PADDING, vw / 2 - TOOLTIP_WIDTH / 2),
+    arrowPlacement: "top",
+  };
+}
+
+const TourOverlay: React.FC = () => {
+  const { isTourActive, currentStep } = useOnboarding();
+  const location = useLocation();
+  const [tooltipPos, setTooltipPos] = useState<TooltipPos | null>(null);
+  const highlightedEl = useRef<Element | null>(null);
+
+  useEffect(() => {
+    if (!isTourActive) {
+      setTooltipPos(null);
+      return;
+    }
+
+    const step = TOUR_STEPS[currentStep];
+
+    // Only render on the page this step belongs to
+    if (!location.pathname.startsWith(step.page)) {
+      setTooltipPos(null);
+      return;
+    }
+
+    // Remove highlight from previous element
+    if (highlightedEl.current) {
+      highlightedEl.current.classList.remove("tour-highlight");
+      highlightedEl.current = null;
+    }
+
+    const el = document.querySelector(`[data-tour-id="${step.targetId}"]`);
+    if (!el) return;
+
+    // Scroll into view first, then measure
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+
+    const measure = () => {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) return; // element not visible
+      const pos = calcPosition(rect, step.placement);
+      setTooltipPos(pos);
+
+      el.classList.add("tour-highlight");
+      highlightedEl.current = el;
+    };
+
+    // Small delay to let scrollIntoView settle
+    const timer = setTimeout(measure, 350);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [isTourActive, currentStep, location.pathname]);
+
+  // Cleanup highlight on unmount
+  useEffect(() => {
+    return () => {
+      if (highlightedEl.current) {
+        highlightedEl.current.classList.remove("tour-highlight");
+      }
+    };
+  }, []);
+
+  // Only render when we have a position (element was found on correct page)
+  if (!isTourActive || !tooltipPos) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div className="fixed inset-0 z-40 bg-black/50 pointer-events-none" />
+
+      {/* Tooltip */}
+      <TourTooltip
+        top={tooltipPos.top}
+        left={tooltipPos.left}
+        arrowPlacement={tooltipPos.arrowPlacement}
+      />
+    </>
+  );
+};
+
+export default TourOverlay;

--- a/frontend/src/pages/client/components/onboarding/TourTooltip.tsx
+++ b/frontend/src/pages/client/components/onboarding/TourTooltip.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { useOnboarding } from "../../../../context/OnboardingContext";
+import { TOUR_STEPS } from "./tourSteps";
+
+interface Props {
+  top: number;
+  left: number;
+  arrowPlacement: "top" | "bottom" | "left" | "right";
+}
+
+const TourTooltip: React.FC<Props> = ({ top, left, arrowPlacement }) => {
+  const { currentStep, totalSteps, nextStep, prevStep, completeTour, skipTour } =
+    useOnboarding();
+  const step = TOUR_STEPS[currentStep];
+  const isLast = currentStep === totalSteps - 1;
+  const isFirst = currentStep === 0;
+
+  const arrowClass: Record<string, string> = {
+    top: "top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 border-t-0 border-l-0",
+    bottom:
+      "bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 border-b-0 border-r-0",
+    left: "left-0 top-1/2 -translate-y-1/2 -translate-x-1/2 border-l-0 border-b-0",
+    right:
+      "right-0 top-1/2 -translate-y-1/2 translate-x-1/2 border-r-0 border-t-0",
+  };
+
+  return (
+    <div
+      className="fixed z-50 w-72 bg-white rounded-2xl shadow-2xl border border-indigo-100 p-4"
+      style={{ top, left }}
+    >
+      {/* Arrow */}
+      <div
+        className={`absolute w-3 h-3 bg-white border border-indigo-100 rotate-45 ${arrowClass[arrowPlacement]}`}
+      />
+
+      {/* Step counter */}
+      <p className="text-xs text-slate-400 text-right mb-1">
+        Krok {currentStep + 1} z {totalSteps}
+      </p>
+
+      {/* Content */}
+      <p className="text-base font-bold text-slate-900 mb-1">{step.title}</p>
+      <p className="text-sm text-slate-600 mb-4">{step.body}</p>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between gap-2">
+        <button
+          onClick={() => skipTour()}
+          className="text-sm text-slate-400 hover:text-slate-600 transition-colors"
+        >
+          Preskočiť
+        </button>
+        <div className="flex gap-2">
+          {!isFirst && (
+            <button
+              onClick={prevStep}
+              className="px-3 py-1.5 text-sm text-indigo-600 border border-indigo-200 rounded-lg hover:bg-indigo-50 transition-colors"
+            >
+              Späť
+            </button>
+          )}
+          <button
+            onClick={isLast ? () => completeTour() : nextStep}
+            className="px-4 py-1.5 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg transition-colors"
+          >
+            {isLast ? "Dokončiť" : "Ďalej"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TourTooltip;

--- a/frontend/src/pages/client/components/onboarding/tourSteps.ts
+++ b/frontend/src/pages/client/components/onboarding/tourSteps.ts
@@ -1,0 +1,76 @@
+export interface TourStep {
+  targetId: string;
+  title: string;
+  body: string;
+  placement: "top" | "bottom" | "left" | "right";
+  page: "/home" | "/order";
+}
+
+export const TOUR_STEPS: TourStep[] = [
+  // ── Home page (steps 0–4) ────────────────────────────────────────────────
+  {
+    targetId: "tour-new-order-btn",
+    title: "Nová objednávka",
+    body: "Kliknutím sem vytvoríte objednávku na nasledujúci pracovný deň. Môžete si vybrať raňajky, obed a olovrant.",
+    placement: "bottom",
+    page: "/home",
+  },
+  {
+    targetId: "tour-today-section",
+    title: "Dnešná objednávka",
+    body: "Prehľad vašej dnešnej objednávky. Ak je termín stále aktívny, môžete ju ešte upraviť kliknutím na kartu.",
+    placement: "bottom",
+    page: "/home",
+  },
+  {
+    targetId: "tour-planned-section",
+    title: "Plánované objednávky",
+    body: "Objednávky na najbližšie pracovné dni. Kliknutím na kartu zobrazíte detail alebo ju upravíte.",
+    placement: "top",
+    page: "/home",
+  },
+  {
+    targetId: "tour-history-section",
+    title: "História",
+    body: "Posledných 5 odovzdaných objednávok. Kliknutím na deň zobrazíte detail s rozpisom porcií.",
+    placement: "top",
+    page: "/home",
+  },
+  {
+    targetId: "tour-profile-btn",
+    title: "Profil a nastavenia",
+    body: "Tu nájdete váš profil, nastavenia aplikácie, inštaláciu PWA a push notifikácie.",
+    placement: "bottom",
+    page: "/home",
+  },
+
+  // ── Order page (steps 5–9) ───────────────────────────────────────────────
+  {
+    targetId: "tour-day-selector",
+    title: "Výber dátumu",
+    body: "Pomocou šípok prechádzajte medzi pracovnými dňami. Objednávku môžete vytvoriť vopred na viaceré dni.",
+    placement: "bottom",
+    page: "/order",
+  },
+  {
+    targetId: "tour-meal-card",
+    title: "Prepínač jedla",
+    body: "Každé jedlo (raňajky, obed, olovrant) môžete zapnúť alebo vypnúť prepínačom. Ak je zapnuté, zobrazí sa zadávanie porcií.",
+    placement: "bottom",
+    page: "/order",
+  },
+  {
+    targetId: "tour-category-row",
+    title: "Počet porcií",
+    body: "Pre každú vekovú skupinu (napr. Škôlka, ZŠ 1. stupeň) nastavte počet porcií pomocou tlačidiel + a –. Menu A/B sú varianty obeda.",
+    placement: "right",
+    page: "/order",
+  },
+  {
+    targetId: "tour-order-summary",
+    title: "Odoslanie objednávky",
+    body: "Tu vidíte celkový súhrn porcií. Po kontrole kliknite na Odoslať objednávku – objednávka bude zaznamenaná.",
+    placement: "top",
+    page: "/order",
+  },
+];

--- a/frontend/src/pages/client/components/order/CategoryRow.tsx
+++ b/frontend/src/pages/client/components/order/CategoryRow.tsx
@@ -70,6 +70,7 @@ interface CategoryRowProps {
     hasDietsEnabled: boolean;
     disabled?: boolean;
     visibleMenus?: string[];
+    tourId?: string;
 }
 
 const CategoryRow = ({
@@ -80,7 +81,8 @@ const CategoryRow = ({
     onOpenDiets,
     hasDietsEnabled,
     disabled,
-    visibleMenus
+    visibleMenus,
+    tourId,
 }: CategoryRowProps) => {
     // Determine which menus to show based on the keys in menuCounts
     let menus = Object.keys(menuCounts || {});
@@ -96,7 +98,7 @@ const CategoryRow = ({
     });
 
     return (
-        <div className="bg-slate-50 rounded-xl border border-slate-100 hover:border-indigo-100 transition-colors overflow-hidden">
+        <div data-tour-id={tourId} className="bg-slate-50 rounded-xl border border-slate-100 hover:border-indigo-100 transition-colors overflow-hidden">
             <div className="bg-slate-100/50 px-4 py-2 border-b border-slate-100">
                 <span className="font-semibold text-slate-700 text-sm">{label}</span>
             </div>

--- a/frontend/src/pages/client/components/order/MealCard.tsx
+++ b/frontend/src/pages/client/components/order/MealCard.tsx
@@ -11,6 +11,7 @@ interface MealCardProps {
     statusMessage?: ReactNode | null;
     children: ReactNode;
     icon: ComponentType<{ className?: string }>;
+    tourId?: string;
 }
 
 const MealCard = ({
@@ -21,10 +22,11 @@ const MealCard = ({
     statusMessage,
     children,
     icon: Icon,
-    className
+    className,
+    tourId,
 }: MealCardProps & { className?: string }) => {
     return (
-        <Card className={cn("transition-all duration-300", isActive ? "ring-2 ring-indigo-500/10 shadow-md" : "opacity-90", className)}>
+        <Card data-tour-id={tourId} className={cn("transition-all duration-300", isActive ? "ring-2 ring-indigo-500/10 shadow-md" : "opacity-90", className)}>
             <CardHeader className="flex flex-row items-center justify-between py-3">
                 <div className="flex items-center gap-3">
                     <div className={cn("p-2 rounded-lg transition-colors", isActive ? "bg-indigo-100 text-indigo-700" : "bg-slate-100 text-slate-500")}>

--- a/frontend/src/pages/client/pages/HomePage.tsx
+++ b/frontend/src/pages/client/pages/HomePage.tsx
@@ -20,6 +20,7 @@ import { useToast } from "../../../context/ToastContext";
 import OrderSummaryModal from "../components/order/OrderSummaryModal";
 import OrderService, { DailyOrder } from "../services/OrderService";
 import { OrderRequestError } from "../hooks/useOrder";
+import TourOverlay from "../components/onboarding/TourOverlay";
 
 const API_URL = import.meta.env.VITE_API_URL || "/api";
 
@@ -399,7 +400,7 @@ const HomePage = () => {
           </div>
           <div className="flex gap-2 md:gap-3">
             <Link to="/profile">
-              <button className="flex items-center gap-2 px-3 md:px-4 py-2.5 bg-white border border-slate-200 rounded-xl hover:border-indigo-300 hover:bg-indigo-50 transition-all shadow-sm hover:shadow-md group">
+              <button data-tour-id="tour-profile-btn" className="flex items-center gap-2 px-3 md:px-4 py-2.5 bg-white border border-slate-200 rounded-xl hover:border-indigo-300 hover:bg-indigo-50 transition-all shadow-sm hover:shadow-md group">
                 <User className="w-4 h-4 text-slate-600 group-hover:text-indigo-600 transition-colors" />
                 <span className="hidden md:inline text-sm font-medium text-slate-700 group-hover:text-indigo-700 transition-colors">
                   Profil
@@ -419,6 +420,7 @@ const HomePage = () => {
 
         {/* New Order CTA — navigates to first next workday */}
         <Link
+          data-tour-id="tour-new-order-btn"
           to={`/order?date=${firstWorkday}`}
           className="group relative block mb-10"
         >
@@ -462,7 +464,7 @@ const HomePage = () => {
                   ? day.predictedMealCount
                   : null;
             return (
-              <div className="mb-8 animate-in slide-in-from-bottom-3 duration-400">
+              <div data-tour-id="tour-today-section" className="mb-8 animate-in slide-in-from-bottom-3 duration-400">
                 <h2 className="text-xl font-bold text-slate-900 mb-4 flex items-center gap-2">
                   <Clock className="w-5 h-5 text-orange-500" />
                   Dnešná objednávka
@@ -554,7 +556,7 @@ const HomePage = () => {
           })()}
 
         {/* ── Plánované objednávky – 5 pracovných dní ── */}
-        <div className="mb-10 animate-in slide-in-from-bottom-5 duration-500">
+        <div data-tour-id="tour-planned-section" className="mb-10 animate-in slide-in-from-bottom-5 duration-500">
           <h2 className="text-xl font-bold text-slate-900 mb-4 flex items-center gap-2">
             <CalendarDays className="w-5 h-5 text-indigo-600" />
             Plánované objednávky
@@ -666,7 +668,7 @@ const HomePage = () => {
         </div>
 
         {/* ── História – posledných 5 minulých ── */}
-        <div className="animate-in slide-in-from-bottom-10 duration-700">
+        <div data-tour-id="tour-history-section" className="animate-in slide-in-from-bottom-10 duration-700">
           <h2 className="text-xl font-bold text-slate-900 mb-4 flex items-center gap-2">
             <History className="w-5 h-5 text-slate-500" />
             História (Posledných 5)
@@ -759,6 +761,7 @@ const HomePage = () => {
         />
 
       </div>
+      <TourOverlay />
     </div>
   );
 };

--- a/frontend/src/pages/client/pages/OrderPage.test.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.test.tsx
@@ -36,6 +36,24 @@ vi.mock("../../../context/auth", () => ({
   ),
 }));
 
+// Mock OnboardingContext
+vi.mock("../../../context/OnboardingContext", () => ({
+  useOnboarding: vi.fn(() => ({
+    isTourActive: false,
+    currentStep: 0,
+    totalSteps: 9,
+    startTour: vi.fn(),
+    nextStep: vi.fn(),
+    prevStep: vi.fn(),
+    completeTour: vi.fn(),
+    skipTour: vi.fn(),
+    resetTour: vi.fn(),
+  })),
+  OnboardingProvider: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
 // Mock OrderService with implementation that allows actual data structure usage
 vi.mock("../services/OrderService", async (importOriginal) => {
   const actual =

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -110,8 +110,7 @@ const OrderPage = () => {
     if (isEditable && !activeMeals[key]) {
       toggleMeal(key);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isTourActive, currentStep]);
+  }, [isTourActive, currentStep, visibleMealsList, selectedDate, globalDeadlines, activeMeals, toggleMeal]);
 
   const meals: {
     key: keyof DailyOrder;

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -11,6 +11,8 @@ import ConfirmationModal from "../components/ui/ConfirmationModal";
 import OrderService, { DailyOrder } from "../services/OrderService";
 import { useToast } from "../../../context/ToastContext";
 import { OrderRequestError } from "../hooks/useOrder";
+import TourOverlay from "../components/onboarding/TourOverlay";
+import { useOnboarding } from "../../../context/OnboardingContext";
 
 const OrderPage = () => {
   const [searchParams] = useSearchParams();
@@ -34,6 +36,8 @@ const OrderPage = () => {
     loadBreakfastFromPrevLunch,
     copyOlovrantFromCurrentLunch,
   } = useApp();
+
+  const { isTourActive, currentStep } = useOnboarding();
 
   const [activeDietModal, setActiveDietModal] = useState<{
     meal: "breakfast" | "lunch" | "olovrant";
@@ -95,6 +99,19 @@ const OrderPage = () => {
       };
     }
   }, [currentOrder, selectedDate]);
+
+  // ── Tour: auto-expand first meal when reaching the CategoryRow step (7) ─────
+  useEffect(() => {
+    if (!isTourActive || currentStep !== 7) return;
+    const firstMeal = visibleMealsList[0];
+    if (!firstMeal) return;
+    const key = firstMeal.key as "breakfast" | "lunch" | "olovrant";
+    const isEditable = OrderService.checkDeadline(selectedDate, key, globalDeadlines);
+    if (isEditable && !activeMeals[key]) {
+      toggleMeal(key);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isTourActive, currentStep]);
 
   const meals: {
     key: keyof DailyOrder;
@@ -270,10 +287,12 @@ const OrderPage = () => {
       </div>
 
       <div className="max-w-6xl mx-auto space-y-6">
-        <DaySelector selectedDate={selectedDate} onChange={setSelectedDate} />
+        <div data-tour-id="tour-day-selector">
+          <DaySelector selectedDate={selectedDate} onChange={setSelectedDate} />
+        </div>
 
         <div className="space-y-6">
-          {visibleMealsList.map((mealItem) => {
+          {visibleMealsList.map((mealItem, mealIndex) => {
             const { key: rawKey, label, icon } = mealItem;
             const key = rawKey as "breakfast" | "lunch" | "olovrant";
             // Check deadline - assuming OrderService is available
@@ -292,6 +311,7 @@ const OrderPage = () => {
                 onToggle={() => isEditable && toggleMeal(key)} // Block toggle if not editable
                 copyAction={isEditable ? handleCopyTrigger(key) : null} // Hide copy if not editable
                 className={!isEditable ? "opacity-75" : ""} // Visual feedback
+                tourId={mealIndex === 0 ? "tour-meal-card" : undefined}
                 statusMessage={
                   !isEditable ? (
                     <div className="text-xs text-amber-700 bg-amber-50 px-2 py-1 rounded border border-amber-100 flex items-center gap-2 inline-flex mb-2">
@@ -304,7 +324,7 @@ const OrderPage = () => {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {CATEGORIES.filter((category) =>
                     enabledCategories.includes(category),
-                  ).map((category) => {
+                  ).map((category, catIndex) => {
                     const data = currentOrder[key]?.[category];
                     if (!data) return null;
 
@@ -330,6 +350,7 @@ const OrderPage = () => {
                         }
                         disabled={!isEditable}
                         visibleMenus={adminVisibleMenus}
+                        tourId={mealIndex === 0 && catIndex === 0 ? "tour-category-row" : undefined}
                       />
                     );
                   })}
@@ -339,6 +360,7 @@ const OrderPage = () => {
           })}
         </div>
 
+        <div data-tour-id="tour-order-summary">
         <OrderSummary
           onSubmit={handleSubmit}
           onReset={
@@ -367,6 +389,7 @@ const OrderPage = () => {
           }
           disabledMessage="Na tento deň už nie je možné vytvoriť objednávku (termín uplynul)."
         />
+        </div>
       </div>
 
       {activeDietModal && (
@@ -421,6 +444,7 @@ const OrderPage = () => {
         cancelText="Zostať"
         variant="warning"
       />
+      <TourOverlay />
     </div>
   );
 };

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -100,18 +100,6 @@ const OrderPage = () => {
     }
   }, [currentOrder, selectedDate]);
 
-  // ── Tour: auto-expand first meal when reaching the CategoryRow step (7) ─────
-  useEffect(() => {
-    if (!isTourActive || currentStep !== 7) return;
-    const firstMeal = visibleMealsList[0];
-    if (!firstMeal) return;
-    const key = firstMeal.key as "breakfast" | "lunch" | "olovrant";
-    const isEditable = OrderService.checkDeadline(selectedDate, key, globalDeadlines);
-    if (isEditable && !activeMeals[key]) {
-      toggleMeal(key);
-    }
-  }, [isTourActive, currentStep, visibleMealsList, selectedDate, globalDeadlines, activeMeals, toggleMeal]);
-
   const meals: {
     key: keyof DailyOrder;
     label: string;
@@ -126,6 +114,18 @@ const OrderPage = () => {
     Array.isArray(adminVisibleMeals) && adminVisibleMeals.length > 0
       ? meals.filter((m) => adminVisibleMeals.includes(m.key))
       : meals;
+
+  // ── Tour: auto-expand first meal when reaching the CategoryRow step (7) ─────
+  useEffect(() => {
+    if (!isTourActive || currentStep !== 7) return;
+    const firstMeal = visibleMealsList[0];
+    if (!firstMeal) return;
+    const key = firstMeal.key as "breakfast" | "lunch" | "olovrant";
+    const isEditable = OrderService.checkDeadline(selectedDate, key, globalDeadlines);
+    if (isEditable && !activeMeals[key]) {
+      toggleMeal(key);
+    }
+  }, [isTourActive, currentStep, visibleMealsList, selectedDate, globalDeadlines, activeMeals, toggleMeal]);
 
   const getFriendlyOrderErrorMessage = (error: unknown) => {
     if (

--- a/frontend/src/pages/client/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/client/pages/ProfilePage.test.tsx
@@ -24,6 +24,20 @@ vi.mock("../../../context/auth", () => ({
   }),
 }));
 
+vi.mock("../../../context/OnboardingContext", () => ({
+  useOnboarding: () => ({
+    isTourActive: false,
+    currentStep: 0,
+    totalSteps: 9,
+    startTour: vi.fn(),
+    nextStep: vi.fn(),
+    prevStep: vi.fn(),
+    completeTour: vi.fn(),
+    skipTour: vi.fn(),
+    resetTour: vi.fn(),
+  }),
+}));
+
 vi.mock("../../../hooks/usePushNotifications", () => ({
   usePushNotifications: () => ({
     permission: pushState.permission,

--- a/frontend/src/pages/client/pages/ProfilePage.tsx
+++ b/frontend/src/pages/client/pages/ProfilePage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
-import { ArrowLeft, User, Mail, Shield, Calendar, Save, Bell, Download, LogOut } from 'lucide-react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ArrowLeft, User, Mail, Shield, Calendar, Save, Bell, Download, LogOut, BookOpen } from 'lucide-react';
 import { useAuth } from '../../../context/auth';
+import { useOnboarding } from '../../../context/OnboardingContext';
 import { usePushNotifications } from '../../../hooks/usePushNotifications';
 import { usePWA } from '../../../hooks/usePWA';
 import ConfirmationModal from '../components/ui/ConfirmationModal';
@@ -31,6 +32,9 @@ interface UserProfile {
 
 const ProfilePage = () => {
     const { apiFetch, logout } = useAuth();
+    const { resetTour } = useOnboarding();
+    const navigate = useNavigate();
+    const [resettingTour, setResettingTour] = useState(false);
     const {
         permission,
         isSubscribed,
@@ -380,6 +384,29 @@ const ProfilePage = () => {
                                 <p className="text-sm font-medium text-slate-700">Dátum registrácie</p>
                                 <p className="text-sm text-slate-600">{profile?.date_joined && formatDate(profile.date_joined)}</p>
                             </div>
+                        </div>
+
+                        <div className="bg-slate-50 rounded-lg p-4 space-y-3">
+                            <div className="flex items-center gap-3">
+                                <BookOpen className="w-5 h-5 text-slate-500" />
+                                <div>
+                                    <p className="text-sm font-medium text-slate-700">Sprievodca aplikáciou</p>
+                                    <p className="text-sm text-slate-600">Znovu spustiť úvodného sprievodcu aplikáciou.</p>
+                                </div>
+                            </div>
+                            <button
+                                type="button"
+                                disabled={resettingTour}
+                                onClick={async () => {
+                                    setResettingTour(true);
+                                    await resetTour();
+                                    setResettingTour(false);
+                                    navigate('/home');
+                                }}
+                                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 text-white text-sm font-medium rounded-lg transition-colors"
+                            >
+                                {resettingTour ? 'Spracúvam...' : 'Spustiť sprievodcu znovu'}
+                            </button>
                         </div>
 
                         <div className="bg-slate-50 rounded-lg p-4 space-y-3">


### PR DESCRIPTION
Introduces OnboardingContext + TourOverlay/TourTooltip components and a step definition list (tourSteps.ts).
Annotates key UI elements on Home/Order pages (and related components) with data-tour-id targets and renders the overlay.
Persists onboarding completion state end-to-end (frontend auth cache + backend model/serializer + migration) and adds a Profile action to reset/restart the tour.