### PR TITLE
feat: add holiday management functionality

### DIFF
--- a/backend/api/exceptions.py
+++ b/backend/api/exceptions.py
@@ -261,6 +261,14 @@ class InvalidOrderDataError(ValidationError):
     default_detail = "Order data is invalid."
 
 
+class HolidayOrderNotAllowedError(BaseAPIException):
+    """Raised when a non-staff user tries to place an order on a holiday."""
+
+    status_code = status.HTTP_400_BAD_REQUEST
+    error_code = "holiday"
+    default_detail = "Na tento deň nie je možné zadať objednávku (voľný deň)."
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Token & Verification Errors
 # ──────────────────────────────────────────────────────────────────────────────

--- a/backend/api/migrations/0019_holiday.py
+++ b/backend/api/migrations/0019_holiday.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0018_userprofile_add_onboarding_completed"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Holiday",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("date", models.DateField(db_index=True, unique=True)),
+                ("reason", models.CharField(blank=True, max_length=200)),
+            ],
+            options={
+                "ordering": ["date"],
+            },
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -327,6 +327,23 @@ class EnrolledCount(models.Model):
         return f"{self.meal_plan.date} {self.portion_type.name}: {self.count}"
 
 
+class Holiday(models.Model):
+    """
+    A day on which no orders can be placed.
+    Admin can define individual dates or ranges.
+    """
+
+    date = models.DateField(unique=True, db_index=True)
+    reason = models.CharField(max_length=200, blank=True)
+
+    class Meta:
+        ordering = ["date"]
+
+    def __str__(self) -> str:
+        suffix = f" ({self.reason})" if self.reason else ""
+        return f"Voľný deň {self.date}{suffix}"
+
+
 class PushSubscription(models.Model):
     """
     Web Push subscription for a user device/browser.

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -258,7 +258,7 @@ class DailyOrderSerializer(serializers.ModelSerializer):
         input_status = validated_data.get("status", instance.status)
         new_data = validated_data.get("data", instance.data)
         request = self.context.get("request")
-        user = validated_data.get("user") or (request and request.user) or instance.user
+        user = validated_data.get("user") or instance.user
         is_staff = getattr(getattr(request, "user", None), "is_staff", False)
 
         self._enforce_holiday_restriction(user, input_status, instance.date)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -132,6 +132,15 @@ class DailyOrderSerializer(serializers.ModelSerializer):
                     ),
                 )
 
+    def _enforce_holiday_restriction(
+        self, user: Any, status: str, date: datetime.date
+    ) -> None:
+        """Disallow non-staff, non-draft orders on holidays."""
+        is_staff = getattr(user, "is_staff", False)
+        if not is_staff and status != "draft":
+            if Holiday.objects.filter(date=date).exists():
+                raise HolidayOrderNotAllowedError()
+
     def create(self, validated_data: Dict[str, Any]) -> DailyOrder:
         """
         Upsert a DailyOrder for (user, date).
@@ -156,10 +165,7 @@ class DailyOrderSerializer(serializers.ModelSerializer):
         input_status = validated_data.get("status", "submitted")
         is_staff = getattr(getattr(request, "user", None), "is_staff", False)
 
-        # Prevent orders on holidays (non-staff only, draft/deletion requests are exempt)
-        if not is_staff and input_status != "draft":
-            if Holiday.objects.filter(date=validated_data["date"]).exists():
-                raise HolidayOrderNotAllowedError()
+        self._enforce_holiday_restriction(user, input_status, validated_data["date"])
 
         # If status is passed as 'draft', we treat it as a deletion request
         # because we do not persist drafts.
@@ -245,7 +251,11 @@ class DailyOrderSerializer(serializers.ModelSerializer):
         input_status = validated_data.get("status", instance.status)
         new_data = validated_data.get("data", instance.data)
         request = self.context.get("request")
+        user = validated_data.get("user") or (request and request.user) or instance.user
         is_staff = getattr(getattr(request, "user", None), "is_staff", False)
+
+        date = validated_data.get("date", instance.date)
+        self._enforce_holiday_restriction(user, input_status, date)
 
         if not is_staff:
             self._validate_deadlines(

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -135,8 +135,15 @@ class DailyOrderSerializer(serializers.ModelSerializer):
     def _enforce_holiday_restriction(
         self, user: Any, status: str, date: datetime.date
     ) -> None:
-        """Disallow non-staff, non-draft orders on holidays."""
-        is_staff = getattr(user, "is_staff", False)
+        """Disallow non-staff, non-draft orders on holidays.
+
+        Staff bypass is keyed off the authenticated actor (request.user) so
+        that staff acting on behalf of a client can still submit on holidays.
+        Falls back to the order owner's is_staff if no request context exists.
+        """
+        request = self.context.get("request")
+        actor = getattr(request, "user", None)
+        is_staff = getattr(actor, "is_staff", False) or getattr(user, "is_staff", False)
         if not is_staff and status != "draft":
             if Holiday.objects.filter(date=date).exists():
                 raise HolidayOrderNotAllowedError()

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -261,8 +261,7 @@ class DailyOrderSerializer(serializers.ModelSerializer):
         user = validated_data.get("user") or (request and request.user) or instance.user
         is_staff = getattr(getattr(request, "user", None), "is_staff", False)
 
-        date = validated_data.get("date", instance.date)
-        self._enforce_holiday_restriction(user, input_status, date)
+        self._enforce_holiday_restriction(user, input_status, instance.date)
 
         if not is_staff:
             self._validate_deadlines(

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -9,7 +9,7 @@ from rest_framework import serializers
 
 from .cached_settings_service import get_global_settings
 from .exceptions import OrderDeadlinePassedError
-from .models import DailyOrder
+from .models import DailyOrder, Holiday
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +156,20 @@ class DailyOrderSerializer(serializers.ModelSerializer):
         input_status = validated_data.get("status", "submitted")
         is_staff = getattr(getattr(request, "user", None), "is_staff", False)
 
+        # Prevent orders on holidays (non-staff only)
+        if not is_staff:
+            from .models import Holiday as _Holiday  # local import to avoid circular
+
+            if _Holiday.objects.filter(date=validated_data["date"]).exists():
+                raise serializers.ValidationError(
+                    {
+                        "error": {
+                            "code": "holiday",
+                            "message": "Na tento deň nie je možné zadať objednávku (voľný deň).",
+                        }
+                    }
+                )
+
         # If status is passed as 'draft', we treat it as a deletion request
         # because we do not persist drafts.
         if input_status == "draft":
@@ -301,3 +315,9 @@ class GlobalSettingsSerializer(serializers.ModelSerializer):
         if not is_admin:
             data.pop("report_email_recipients", None)
         return data
+
+
+class HolidaySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Holiday
+        fields = ["id", "date", "reason"]

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from rest_framework import serializers
 
 from .cached_settings_service import get_global_settings
-from .exceptions import OrderDeadlinePassedError
+from .exceptions import HolidayOrderNotAllowedError, OrderDeadlinePassedError
 from .models import DailyOrder, Holiday
 
 logger = logging.getLogger(__name__)
@@ -156,19 +156,10 @@ class DailyOrderSerializer(serializers.ModelSerializer):
         input_status = validated_data.get("status", "submitted")
         is_staff = getattr(getattr(request, "user", None), "is_staff", False)
 
-        # Prevent orders on holidays (non-staff only)
-        if not is_staff:
-            from .models import Holiday as _Holiday  # local import to avoid circular
-
-            if _Holiday.objects.filter(date=validated_data["date"]).exists():
-                raise serializers.ValidationError(
-                    {
-                        "error": {
-                            "code": "holiday",
-                            "message": "Na tento deň nie je možné zadať objednávku (voľný deň).",
-                        }
-                    }
-                )
+        # Prevent orders on holidays (non-staff only, draft/deletion requests are exempt)
+        if not is_staff and input_status != "draft":
+            if Holiday.objects.filter(date=validated_data["date"]).exists():
+                raise HolidayOrderNotAllowedError()
 
         # If status is passed as 'draft', we treat it as a deletion request
         # because we do not persist drafts.

--- a/backend/api/services/order_service.py
+++ b/backend/api/services/order_service.py
@@ -80,7 +80,7 @@ class OrderService:
         This method executes a small, constant number of DB queries regardless
         of the number of planned days (no N+1 queries).
         """
-        today = timezone.now().astimezone(datetime.timezone.utc).date()
+        today = timezone.localdate()
         # Fetch all upcoming holidays once (small table) to avoid repeated queries.
         holiday_set: set[datetime.date] = set(
             Holiday.objects.filter(date__gte=today).values_list("date", flat=True)

--- a/backend/api/services/order_service.py
+++ b/backend/api/services/order_service.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from django.contrib.auth.models import User
 from django.utils import timezone
 
-from ..models import DailyOrder
+from ..models import DailyOrder, Holiday
 from .auto_order_service import _build_auto_data, _is_order_empty, _last_non_empty_order
 
 
@@ -18,12 +18,16 @@ class OrderService:
     # ------------------------------------------------------------------ #
 
     @staticmethod
-    def next_workdays(start: datetime.date, count: int = 5) -> List[datetime.date]:
-        """Return the next *count* Mon–Fri dates starting from *and including* start."""
+    def next_workdays(
+        start: datetime.date,
+        count: int = 5,
+        holidays: Optional[set] = None,
+    ) -> List[datetime.date]:
+        """Return the next *count* Mon–Fri non-holiday dates starting from *and including* start."""
         days: List[datetime.date] = []
         d = start
         while len(days) < count:
-            if d.weekday() < 5:  # 0=Mon … 4=Fri
+            if d.weekday() < 5 and (holidays is None or d not in holidays):
                 days.append(d)
             d += datetime.timedelta(days=1)
         return days
@@ -77,7 +81,14 @@ class OrderService:
         of the number of planned days (no N+1 queries).
         """
         today = timezone.now().astimezone(datetime.timezone.utc).date()
-        workdays = OrderService.next_workdays(today, 5)
+        # Fetch holidays covering the next ~14 days to find 5 workdays safely
+        look_ahead = today + datetime.timedelta(days=14)
+        holiday_set: set = set(
+            Holiday.objects.filter(date__gte=today, date__lte=look_ahead).values_list(
+                "date", flat=True
+            )
+        )
+        workdays = OrderService.next_workdays(today, 5, holiday_set)
 
         existing: Dict[datetime.date, DailyOrder] = {
             o.date: o for o in DailyOrder.objects.filter(user=user, date__in=workdays)

--- a/backend/api/services/order_service.py
+++ b/backend/api/services/order_service.py
@@ -81,23 +81,11 @@ class OrderService:
         of the number of planned days (no N+1 queries).
         """
         today = timezone.now().astimezone(datetime.timezone.utc).date()
-        # Fetch holidays with an expanding window to ensure all dates examined
-        # by next_workdays are covered, even during long holiday stretches.
-        look_ahead_days = 14
-        max_look_ahead_days = 90
-        while True:
-            look_ahead = today + datetime.timedelta(days=look_ahead_days)
-            holiday_set: set[datetime.date] = set(
-                Holiday.objects.filter(
-                    date__gte=today, date__lte=look_ahead
-                ).values_list("date", flat=True)
-            )
-            workdays = OrderService.next_workdays(today, 5, holiday_set)
-            if not workdays or workdays[-1] <= look_ahead:
-                break
-            if look_ahead_days >= max_look_ahead_days:
-                break
-            look_ahead_days = min(look_ahead_days * 2, max_look_ahead_days)
+        # Fetch all upcoming holidays once (small table) to avoid repeated queries.
+        holiday_set: set[datetime.date] = set(
+            Holiday.objects.filter(date__gte=today).values_list("date", flat=True)
+        )
+        workdays = OrderService.next_workdays(today, 5, holiday_set)
 
         existing: Dict[datetime.date, DailyOrder] = {
             o.date: o for o in DailyOrder.objects.filter(user=user, date__in=workdays)

--- a/backend/api/services/order_service.py
+++ b/backend/api/services/order_service.py
@@ -21,7 +21,7 @@ class OrderService:
     def next_workdays(
         start: datetime.date,
         count: int = 5,
-        holidays: Optional[set] = None,
+        holidays: Optional[set[datetime.date]] = None,
     ) -> List[datetime.date]:
         """Return the next *count* Mon–Fri non-holiday dates starting from *and including* start."""
         days: List[datetime.date] = []
@@ -81,14 +81,23 @@ class OrderService:
         of the number of planned days (no N+1 queries).
         """
         today = timezone.now().astimezone(datetime.timezone.utc).date()
-        # Fetch holidays covering the next ~14 days to find 5 workdays safely
-        look_ahead = today + datetime.timedelta(days=14)
-        holiday_set: set = set(
-            Holiday.objects.filter(date__gte=today, date__lte=look_ahead).values_list(
-                "date", flat=True
+        # Fetch holidays with an expanding window to ensure all dates examined
+        # by next_workdays are covered, even during long holiday stretches.
+        look_ahead_days = 14
+        max_look_ahead_days = 90
+        while True:
+            look_ahead = today + datetime.timedelta(days=look_ahead_days)
+            holiday_set: set[datetime.date] = set(
+                Holiday.objects.filter(
+                    date__gte=today, date__lte=look_ahead
+                ).values_list("date", flat=True)
             )
-        )
-        workdays = OrderService.next_workdays(today, 5, holiday_set)
+            workdays = OrderService.next_workdays(today, 5, holiday_set)
+            if not workdays or workdays[-1] <= look_ahead:
+                break
+            if look_ahead_days >= max_look_ahead_days:
+                break
+            look_ahead_days = min(look_ahead_days * 2, max_look_ahead_days)
 
         existing: Dict[datetime.date, DailyOrder] = {
             o.date: o for o in DailyOrder.objects.filter(user=user, date__in=workdays)

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -5,6 +5,7 @@ from rest_framework_simplejwt.views import TokenRefreshView
 from .health import health_check
 from .views import (
     AdminAutoOrderViewSet,
+    AdminHolidayViewSet,
     AdminSendPushView,
     AdminSummaryViewSet,
     AdminUserViewSet,
@@ -13,6 +14,7 @@ from .views import (
     DietViewSet,
     EmailTokenObtainPairView,
     GlobalSettingsViewSet,
+    HolidayListViewSet,
     MealTemplateViewSet,
     PasswordResetConfirmView,
     PasswordResetRequestView,
@@ -51,6 +53,8 @@ router.register(
 router.register(r"admin/meal-templates", MealTemplateViewSet, basename="meal-template")
 router.register(r"admin/portion-types", PortionTypeViewSet, basename="portion-type")
 router.register(r"admin/meal-plans", DailyMealPlanViewSet, basename="meal-plan")
+router.register(r"admin/holidays", AdminHolidayViewSet, basename="admin-holiday")
+router.register(r"holidays", HolidayListViewSet, basename="holiday")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -19,6 +19,9 @@ from .auth_views import (
 # Diet views
 from .diet_views import DietViewSet
 
+# Holiday views
+from .holiday_views import AdminHolidayViewSet, HolidayListViewSet
+
 # Meal plan views
 from .meal_plan_views import (
     DailyMealPlanViewSet,
@@ -42,6 +45,9 @@ from .settings_views import GlobalSettingsViewSet, UserProfileViewSet
 __all__ = [
     # Authentication
     "EmailTokenObtainPairSerializer",
+    # Holidays
+    "AdminHolidayViewSet",
+    "HolidayListViewSet",
     "EmailTokenObtainPairView",
     "PasswordResetRequestView",
     "PasswordResetConfirmView",

--- a/backend/api/views/holiday_views.py
+++ b/backend/api/views/holiday_views.py
@@ -1,0 +1,72 @@
+import datetime
+
+from rest_framework import permissions, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from ..models import Holiday
+from ..serializers import HolidaySerializer
+
+
+class AdminHolidayViewSet(viewsets.ModelViewSet):
+    """
+    Admin CRUD for holidays.
+    GET/POST/DELETE /api/admin/holidays/
+    POST /api/admin/holidays/bulk/  { start_date, end_date, reason? }
+    """
+
+    serializer_class = HolidaySerializer
+    permission_classes = [permissions.IsAdminUser]
+
+    def get_queryset(self):
+        return Holiday.objects.all()
+
+    @action(detail=False, methods=["post"], url_path="bulk")
+    def bulk_create(self, request: Request) -> Response:
+        """Create holidays for a continuous date range (weekends included)."""
+        start_str = request.data.get("start_date")
+        end_str = request.data.get("end_date")
+        reason = request.data.get("reason", "")
+
+        try:
+            start = datetime.date.fromisoformat(start_str)
+            end = datetime.date.fromisoformat(end_str)
+        except (ValueError, TypeError):
+            raise ValidationError({"detail": "Invalid date format. Use YYYY-MM-DD."})
+
+        if end < start:
+            raise ValidationError({"detail": "end_date must be >= start_date."})
+
+        created = []
+        skipped = []
+        d = start
+        while d <= end:
+            holiday, was_created = Holiday.objects.get_or_create(
+                date=d, defaults={"reason": reason}
+            )
+            if was_created:
+                created.append(str(d))
+            else:
+                skipped.append(str(d))
+            d += datetime.timedelta(days=1)
+
+        return Response({"created": created, "skipped": skipped})
+
+
+class HolidayListViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Read-only holiday list for authenticated clients.
+    GET /api/holidays/  – returns holidays from 30 days ago up to 60 days ahead.
+    """
+
+    serializer_class = HolidaySerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        today = datetime.date.today()
+        return Holiday.objects.filter(
+            date__gte=today - datetime.timedelta(days=30),
+            date__lte=today + datetime.timedelta(days=60),
+        )

--- a/backend/api/views/holiday_views.py
+++ b/backend/api/views/holiday_views.py
@@ -34,10 +34,10 @@ class AdminHolidayViewSet(viewsets.ModelViewSet):
             start = datetime.date.fromisoformat(start_str)
             end = datetime.date.fromisoformat(end_str)
         except (ValueError, TypeError):
-            raise ValidationError({"detail": "Invalid date format. Use YYYY-MM-DD."})
+            raise ValidationError("Invalid date format. Use YYYY-MM-DD.")
 
         if end < start:
-            raise ValidationError({"detail": "end_date must be >= start_date."})
+            raise ValidationError("end_date must be >= start_date.")
 
         created = []
         skipped = []
@@ -58,7 +58,7 @@ class AdminHolidayViewSet(viewsets.ModelViewSet):
 class HolidayListViewSet(viewsets.ReadOnlyModelViewSet):
     """
     Read-only holiday list for authenticated clients.
-    GET /api/holidays/  – returns holidays from 30 days ago up to 60 days ahead.
+    GET /api/holidays/  – returns holidays from 30 days ago onward (all future holidays included).
     """
 
     serializer_class = HolidaySerializer
@@ -66,7 +66,4 @@ class HolidayListViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         today = datetime.date.today()
-        return Holiday.objects.filter(
-            date__gte=today - datetime.timedelta(days=30),
-            date__lte=today + datetime.timedelta(days=60),
-        )
+        return Holiday.objects.filter(date__gte=today - datetime.timedelta(days=30))

--- a/backend/api/views/holiday_views.py
+++ b/backend/api/views/holiday_views.py
@@ -84,5 +84,5 @@ class HolidayListViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = None
 
     def get_queryset(self):
-        today = timezone.now().astimezone(datetime.timezone.utc).date()
+        today = timezone.localdate()
         return Holiday.objects.filter(date__gte=today - datetime.timedelta(days=30))

--- a/backend/api/views/holiday_views.py
+++ b/backend/api/views/holiday_views.py
@@ -36,16 +36,25 @@ class AdminHolidayViewSet(viewsets.ModelViewSet):
             start = datetime.date.fromisoformat(start_str)
             end = datetime.date.fromisoformat(end_str)
         except (ValueError, TypeError):
-            raise ValidationError("Invalid date format. Use YYYY-MM-DD.")
+            raise ValidationError(
+                {
+                    "start_date": ["Invalid date format. Use YYYY-MM-DD."],
+                    "end_date": ["Invalid date format. Use YYYY-MM-DD."],
+                }
+            )
 
         if end < start:
-            raise ValidationError("end_date must be >= start_date.")
+            raise ValidationError({"end_date": ["end_date must be >= start_date."]})
 
         max_days = 365
         total_days = (end - start).days + 1
         if total_days > max_days:
             raise ValidationError(
-                f"Date range too large; maximum is {max_days} days, got {total_days} days."
+                {
+                    "non_field_errors": [
+                        f"Date range too large; maximum is {max_days} days, got {total_days} days."
+                    ]
+                }
             )
 
         created = []
@@ -75,5 +84,5 @@ class HolidayListViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = None
 
     def get_queryset(self):
-        today = timezone.localdate()
+        today = timezone.now().astimezone(datetime.timezone.utc).date()
         return Holiday.objects.filter(date__gte=today - datetime.timedelta(days=30))

--- a/backend/api/views/holiday_views.py
+++ b/backend/api/views/holiday_views.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.utils import timezone
 from rest_framework import permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -19,6 +20,7 @@ class AdminHolidayViewSet(viewsets.ModelViewSet):
 
     serializer_class = HolidaySerializer
     permission_classes = [permissions.IsAdminUser]
+    pagination_class = None
 
     def get_queryset(self):
         return Holiday.objects.all()
@@ -38,6 +40,13 @@ class AdminHolidayViewSet(viewsets.ModelViewSet):
 
         if end < start:
             raise ValidationError("end_date must be >= start_date.")
+
+        max_days = 365
+        total_days = (end - start).days + 1
+        if total_days > max_days:
+            raise ValidationError(
+                f"Date range too large; maximum is {max_days} days, got {total_days} days."
+            )
 
         created = []
         skipped = []
@@ -63,7 +72,8 @@ class HolidayListViewSet(viewsets.ReadOnlyModelViewSet):
 
     serializer_class = HolidaySerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = None
 
     def get_queryset(self):
-        today = datetime.date.today()
+        today = timezone.localdate()
         return Holiday.objects.filter(date__gte=today - datetime.timedelta(days=30))

--- a/backend/api/views/holiday_views.py
+++ b/backend/api/views/holiday_views.py
@@ -57,18 +57,23 @@ class AdminHolidayViewSet(viewsets.ModelViewSet):
                 }
             )
 
-        created = []
-        skipped = []
-        d = start
-        while d <= end:
-            holiday, was_created = Holiday.objects.get_or_create(
-                date=d, defaults={"reason": reason}
+        all_dates = [
+            start + datetime.timedelta(days=offset)
+            for offset in range((end - start).days + 1)
+        ]
+        existing_dates = set(
+            Holiday.objects.filter(date__range=(start, end)).values_list(
+                "date", flat=True
             )
-            if was_created:
-                created.append(str(d))
-            else:
-                skipped.append(str(d))
-            d += datetime.timedelta(days=1)
+        )
+        missing_dates = [d for d in all_dates if d not in existing_dates]
+        Holiday.objects.bulk_create(
+            [Holiday(date=d, reason=reason) for d in missing_dates],
+            ignore_conflicts=True,
+        )
+        missing_set = set(missing_dates)
+        created = [str(d) for d in all_dates if d in missing_set]
+        skipped = [str(d) for d in all_dates if d not in missing_set]
 
         return Response({"created": created, "skipped": skipped})
 

--- a/backend/tests/test_order_service.py
+++ b/backend/tests/test_order_service.py
@@ -116,7 +116,7 @@ class TestGetPlannedOrders:
 
     @patch("api.services.order_service.timezone")
     def test_no_existing_orders_no_template_all_zeros(self, mock_tz):
-        mock_tz.now.return_value.astimezone.return_value.date.return_value = MONDAY
+        mock_tz.localdate.return_value = MONDAY
         user = self._make_user()
         result = OrderService.get_planned_orders(user, [])
 
@@ -127,7 +127,7 @@ class TestGetPlannedOrders:
 
     @patch("api.services.order_service.timezone")
     def test_existing_order_reflected_in_result(self, mock_tz):
-        mock_tz.now.return_value.astimezone.return_value.date.return_value = MONDAY
+        mock_tz.localdate.return_value = MONDAY
         user = self._make_user()
         self._make_order(user, MONDAY, self.NON_EMPTY)
 
@@ -139,7 +139,7 @@ class TestGetPlannedOrders:
 
     @patch("api.services.order_service.timezone")
     def test_historical_template_used_for_prediction(self, mock_tz):
-        mock_tz.now.return_value.astimezone.return_value.date.return_value = MONDAY
+        mock_tz.localdate.return_value = MONDAY
         user = self._make_user()
         # Historical order one day before the planned window
         historical_date = datetime.date(2025, 1, 5)  # Sunday – still stored
@@ -157,7 +157,7 @@ class TestGetPlannedOrders:
 
     @patch("api.services.order_service.timezone")
     def test_visible_meals_filter_prediction(self, mock_tz):
-        mock_tz.now.return_value.astimezone.return_value.date.return_value = MONDAY
+        mock_tz.localdate.return_value = MONDAY
         user = self._make_user()
         template_data = {
             "breakfast": {"Dospelý": {"menuCounts": {"A": 2}, "diets": {}}},
@@ -177,7 +177,7 @@ class TestGetPlannedOrders:
 
     @patch("api.services.order_service.timezone")
     def test_result_has_five_entries(self, mock_tz):
-        mock_tz.now.return_value.astimezone.return_value.date.return_value = MONDAY
+        mock_tz.localdate.return_value = MONDAY
         user = self._make_user()
         result = OrderService.get_planned_orders(user, [])
         assert len(result) == 5

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ import MealPlanEditor from "./pages/admin/MealPlanEditor";
 import MealPlanTemplates from "./pages/admin/MealPlanTemplates";
 import PortionTypes from "./pages/admin/PortionTypes";
 import PushNotificationsAdmin from "./pages/admin/PushNotifications";
+import HolidaysAdmin from "./pages/admin/HolidaysAdmin";
 
 const ProtectedRoute = () => {
   const { isAuthenticated, isLoading, user } = useAuth();
@@ -147,6 +148,7 @@ export default function App() {
                 <Route path="portion-types" element={<PortionTypes />} />
                 <Route path="settings" element={<SystemSettings />} />
                 <Route path="push-notifications" element={<PushNotificationsAdmin />} />
+                <Route path="holidays" element={<HolidaysAdmin />} />
               </Route>
 
               {/* Client Routes */}

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -38,13 +38,13 @@ const SECTIONS: NavSection[] = [
         id: 'settings',
         label: 'Nastavenia',
         icon: '⚙️',
-        paths: ['/admin/diets', '/admin/meal-plan-templates', '/admin/portion-types', '/admin/settings'],
+        paths: ['/admin/diets', '/admin/meal-plan-templates', '/admin/portion-types', '/admin/settings', '/admin/holidays'],
         items: [
             { to: '/admin/diets', label: 'Diety', icon: '🥗', activeColor: 'text-green-700', activeBg: 'bg-green-50' },
             { to: '/admin/meal-plan-templates', label: 'Šablóny jedál', icon: '📋', activeColor: 'text-lime-700', activeBg: 'bg-lime-50' },
             { to: '/admin/portion-types', label: 'Typy porcií', icon: '🥄', activeColor: 'text-amber-700', activeBg: 'bg-amber-50' },
             { to: '/admin/settings', label: 'Systémové nastavenia', icon: '⚙️', activeColor: 'text-gray-900', activeBg: 'bg-gray-100' },
-            { to: '/admin/holidays', label: 'Voľné dni', icon: '🏖️', activeColor: 'text-sky-700', activeBg: 'bg-sky-50', placeholder: true },
+            { to: '/admin/holidays', label: 'Voľné dni', icon: '🏖️', activeColor: 'text-sky-700', activeBg: 'bg-sky-50' },
         ],
     },
     {
@@ -54,7 +54,6 @@ const SECTIONS: NavSection[] = [
         paths: ['/admin/push-notifications'],
         items: [
             { to: '/admin/push-notifications', label: 'Notifikácie', icon: '🔔', activeColor: 'text-indigo-700', activeBg: 'bg-indigo-50' },
-            { to: '/admin/info', label: 'Info', icon: 'ℹ️', activeColor: 'text-violet-700', activeBg: 'bg-violet-50', placeholder: true },
         ],
     },
     {
@@ -64,8 +63,6 @@ const SECTIONS: NavSection[] = [
         paths: ['/admin/roles'],
         items: [
             { to: '/admin/roles', label: 'Správa adminov', icon: '🛡️', activeColor: 'text-purple-700', activeBg: 'bg-purple-50' },
-            { to: '/admin/admin-notifications', label: 'Admin notifikácie', icon: '🔔', activeColor: 'text-rose-700', activeBg: 'bg-rose-50', placeholder: true },
-            { to: '/admin/roles-permissions', label: 'Roly a oprávnenia', icon: '🔑', activeColor: 'text-pink-700', activeBg: 'bg-pink-50', placeholder: true },
         ],
     },
 ];

--- a/frontend/src/pages/admin/HolidaysAdmin.tsx
+++ b/frontend/src/pages/admin/HolidaysAdmin.tsx
@@ -130,7 +130,8 @@ const HolidaysAdmin: React.FC = () => {
         }
     };
 
-    const today = new Date().toISOString().split('T')[0];
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
     const upcoming = holidays.filter((h) => h.date >= today);
     const past = holidays.filter((h) => h.date < today);

--- a/frontend/src/pages/admin/HolidaysAdmin.tsx
+++ b/frontend/src/pages/admin/HolidaysAdmin.tsx
@@ -336,6 +336,7 @@ const HolidayRow: React.FC<{ holiday: Holiday; onDelete: (id: number) => void; p
                         onClick={() => setConfirming(true)}
                         className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
                         title="Odstrániť"
+                        aria-label="Odstrániť"
                     >
                         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/frontend/src/pages/admin/HolidaysAdmin.tsx
+++ b/frontend/src/pages/admin/HolidaysAdmin.tsx
@@ -39,13 +39,24 @@ const HolidaysAdmin: React.FC = () => {
     const fetchHolidays = React.useCallback(async () => {
         setLoading(true);
         try {
-            const res = await apiFetch(`${API_URL}/admin/holidays/`);
-            if (res.ok) {
-                const data = await res.json();
-                setHolidays(data.results ?? data);
-            } else {
-                error('Nepodarilo sa načítať voľné dni');
+            const allHolidays: Holiday[] = [];
+            let url: string | null = `${API_URL}/admin/holidays/`;
+            while (url) {
+                const res = await apiFetch(url);
+                if (!res.ok) {
+                    error('Nepodarilo sa načítať voľné dni');
+                    return;
+                }
+                const data: Holiday[] | { results: Holiday[]; next: string | null } = await res.json();
+                if (Array.isArray(data)) {
+                    allHolidays.push(...data);
+                    url = null;
+                } else {
+                    allHolidays.push(...(data.results ?? []));
+                    url = data.next ?? null;
+                }
             }
+            setHolidays(allHolidays);
         } catch {
             error('Nepodarilo sa načítať voľné dni');
         } finally {
@@ -73,9 +84,12 @@ const HolidaysAdmin: React.FC = () => {
                 setSingleReason('');
                 fetchHolidays();
             } else {
-                const data = await res.json().catch(() => ({}));
-                if (data?.date) {
+                const data: { error?: { message?: string; details?: { date?: string[] } } } = await res.json().catch(() => ({}));
+                const dateError = data?.error?.details?.date;
+                if (dateError) {
                     error('Tento deň je už nastavený ako voľný');
+                } else if (typeof data?.error?.message === 'string' && data.error.message.trim()) {
+                    error(data.error.message);
                 } else {
                     error('Nepodarilo sa pridať voľný deň');
                 }

--- a/frontend/src/pages/admin/HolidaysAdmin.tsx
+++ b/frontend/src/pages/admin/HolidaysAdmin.tsx
@@ -1,0 +1,335 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '../../context/auth';
+import { useToast } from '../../context/ToastContext';
+
+const API_URL = import.meta.env.VITE_API_URL || '/api';
+
+interface Holiday {
+    id: number;
+    date: string;
+    reason: string;
+}
+
+type Tab = 'single' | 'range';
+
+const formatDate = (dateStr: string) =>
+    new Intl.DateTimeFormat('sk-SK', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' }).format(
+        new Date(`${dateStr}T12:00:00`)
+    );
+
+const HolidaysAdmin: React.FC = () => {
+    const { apiFetch } = useAuth();
+    const { success, error } = useToast();
+
+    const [holidays, setHolidays] = useState<Holiday[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [activeTab, setActiveTab] = useState<Tab>('single');
+
+    // Single day form
+    const [singleDate, setSingleDate] = useState('');
+    const [singleReason, setSingleReason] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+
+    // Range form
+    const [rangeStart, setRangeStart] = useState('');
+    const [rangeEnd, setRangeEnd] = useState('');
+    const [rangeReason, setRangeReason] = useState('');
+    const [rangeSaving, setRangeSaving] = useState(false);
+
+    const fetchHolidays = React.useCallback(async () => {
+        setLoading(true);
+        try {
+            const res = await apiFetch(`${API_URL}/admin/holidays/`);
+            if (res.ok) {
+                const data = await res.json();
+                setHolidays(data.results ?? data);
+            } else {
+                error('Nepodarilo sa načítať voľné dni');
+            }
+        } catch {
+            error('Nepodarilo sa načítať voľné dni');
+        } finally {
+            setLoading(false);
+        }
+    }, [apiFetch, error]);
+
+    useEffect(() => {
+        fetchHolidays();
+    }, [fetchHolidays]);
+
+    const handleAddSingle = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!singleDate) return;
+        setSubmitting(true);
+        try {
+            const res = await apiFetch(`${API_URL}/admin/holidays/`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ date: singleDate, reason: singleReason }),
+            });
+            if (res.ok) {
+                success('Voľný deň bol pridaný');
+                setSingleDate('');
+                setSingleReason('');
+                fetchHolidays();
+            } else {
+                const data = await res.json().catch(() => ({}));
+                if (data?.date) {
+                    error('Tento deň je už nastavený ako voľný');
+                } else {
+                    error('Nepodarilo sa pridať voľný deň');
+                }
+            }
+        } catch {
+            error('Nepodarilo sa pridať voľný deň');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const handleAddRange = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!rangeStart || !rangeEnd) return;
+        setRangeSaving(true);
+        try {
+            const res = await apiFetch(`${API_URL}/admin/holidays/bulk/`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ start_date: rangeStart, end_date: rangeEnd, reason: rangeReason }),
+            });
+            if (res.ok) {
+                const data = await res.json();
+                const count = data.created?.length ?? 0;
+                const skipped = data.skipped?.length ?? 0;
+                success(`Pridaných: ${count} dní${skipped ? `, preskočených (už existujú): ${skipped}` : ''}`);
+                setRangeStart('');
+                setRangeEnd('');
+                setRangeReason('');
+                fetchHolidays();
+            } else {
+                error('Nepodarilo sa pridať voľné dni');
+            }
+        } catch {
+            error('Nepodarilo sa pridať voľné dni');
+        } finally {
+            setRangeSaving(false);
+        }
+    };
+
+    const handleDelete = async (id: number) => {
+        try {
+            const res = await apiFetch(`${API_URL}/admin/holidays/${id}/`, { method: 'DELETE' });
+            if (res.ok || res.status === 204) {
+                success('Voľný deň bol odstránený');
+                setHolidays((prev) => prev.filter((h) => h.id !== id));
+            } else {
+                error('Nepodarilo sa odstrániť voľný deň');
+            }
+        } catch {
+            error('Nepodarilo sa odstrániť voľný deň');
+        }
+    };
+
+    const today = new Date().toISOString().split('T')[0];
+
+    const upcoming = holidays.filter((h) => h.date >= today);
+    const past = holidays.filter((h) => h.date < today);
+
+    return (
+        <div className="space-y-8">
+            <div>
+                <h1 className="text-2xl font-bold text-gray-900">Voľné dni</h1>
+                <p className="text-sm text-gray-500 mt-1">
+                    V tieto dni nie je možné zadať objednávku. Nastavte jednotlivé dni alebo celý úsek.
+                </p>
+            </div>
+
+            {/* Add form */}
+            <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+                {/* Tabs */}
+                <div className="flex border-b border-gray-100">
+                    {(['single', 'range'] as Tab[]).map((tab) => (
+                        <button
+                            key={tab}
+                            onClick={() => setActiveTab(tab)}
+                            className={`flex-1 py-3 text-sm font-medium transition-colors ${
+                                activeTab === tab
+                                    ? 'text-sky-700 border-b-2 border-sky-600 bg-sky-50/50'
+                                    : 'text-gray-500 hover:text-gray-800'
+                            }`}
+                        >
+                            {tab === 'single' ? '+ Pridať deň' : '+ Pridať úsek dní'}
+                        </button>
+                    ))}
+                </div>
+
+                <div className="p-6">
+                    {activeTab === 'single' ? (
+                        <form onSubmit={handleAddSingle} className="space-y-4">
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">Dátum</label>
+                                    <input
+                                        type="date"
+                                        value={singleDate}
+                                        onChange={(e) => setSingleDate(e.target.value)}
+                                        required
+                                        className="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent"
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                                        Poznámka <span className="text-gray-400 font-normal">(nepovinné)</span>
+                                    </label>
+                                    <input
+                                        type="text"
+                                        value={singleReason}
+                                        onChange={(e) => setSingleReason(e.target.value)}
+                                        placeholder="napr. Sviatok, dovolenka…"
+                                        className="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent"
+                                    />
+                                </div>
+                            </div>
+                            <button
+                                type="submit"
+                                disabled={submitting || !singleDate}
+                                className="px-5 py-2 bg-sky-600 hover:bg-sky-700 disabled:opacity-50 text-white rounded-xl text-sm font-medium transition-colors shadow-sm"
+                            >
+                                {submitting ? 'Ukladám…' : 'Pridať deň'}
+                            </button>
+                        </form>
+                    ) : (
+                        <form onSubmit={handleAddRange} className="space-y-4">
+                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">Od</label>
+                                    <input
+                                        type="date"
+                                        value={rangeStart}
+                                        onChange={(e) => setRangeStart(e.target.value)}
+                                        required
+                                        className="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent"
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">Do</label>
+                                    <input
+                                        type="date"
+                                        value={rangeEnd}
+                                        min={rangeStart || undefined}
+                                        onChange={(e) => setRangeEnd(e.target.value)}
+                                        required
+                                        className="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent"
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                                        Poznámka <span className="text-gray-400 font-normal">(nepovinné)</span>
+                                    </label>
+                                    <input
+                                        type="text"
+                                        value={rangeReason}
+                                        onChange={(e) => setRangeReason(e.target.value)}
+                                        placeholder="napr. Vianočné sviatky"
+                                        className="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent"
+                                    />
+                                </div>
+                            </div>
+                            <button
+                                type="submit"
+                                disabled={rangeSaving || !rangeStart || !rangeEnd}
+                                className="px-5 py-2 bg-sky-600 hover:bg-sky-700 disabled:opacity-50 text-white rounded-xl text-sm font-medium transition-colors shadow-sm"
+                            >
+                                {rangeSaving ? 'Ukladám…' : 'Pridať úsek'}
+                            </button>
+                        </form>
+                    )}
+                </div>
+            </div>
+
+            {/* List */}
+            <div className="bg-white rounded-2xl shadow-sm border border-gray-100">
+                <div className="px-6 py-4 border-b border-gray-100">
+                    <h2 className="text-base font-semibold text-gray-800">Nastavené voľné dni</h2>
+                </div>
+
+                {loading ? (
+                    <div className="p-6 text-center text-gray-400 text-sm">Načítavam…</div>
+                ) : holidays.length === 0 ? (
+                    <div className="p-8 text-center text-gray-400 text-sm">Žiadne voľné dni nie sú nastavené.</div>
+                ) : (
+                    <div className="divide-y divide-gray-50">
+                        {upcoming.length > 0 && (
+                            <>
+                                <div className="px-6 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider bg-gray-50/60">
+                                    Nadchádzajúce
+                                </div>
+                                {upcoming.map((h) => (
+                                    <HolidayRow key={h.id} holiday={h} onDelete={handleDelete} />
+                                ))}
+                            </>
+                        )}
+                        {past.length > 0 && (
+                            <>
+                                <div className="px-6 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider bg-gray-50/60">
+                                    Minulé
+                                </div>
+                                {past.map((h) => (
+                                    <HolidayRow key={h.id} holiday={h} onDelete={handleDelete} past />
+                                ))}
+                            </>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+const HolidayRow: React.FC<{ holiday: Holiday; onDelete: (id: number) => void; past?: boolean }> = ({
+    holiday,
+    onDelete,
+    past = false,
+}) => {
+    const [confirming, setConfirming] = useState(false);
+
+    return (
+        <div className={`flex items-center justify-between px-6 py-3 ${past ? 'opacity-50' : ''}`}>
+            <div className="min-w-0">
+                <div className="text-sm font-medium text-gray-800 capitalize">{formatDate(holiday.date)}</div>
+                {holiday.reason && <div className="text-xs text-gray-500 mt-0.5">{holiday.reason}</div>}
+            </div>
+            <div className="flex items-center gap-2 shrink-0 ml-4">
+                {confirming ? (
+                    <>
+                        <span className="text-xs text-red-600 font-medium">Naozaj odstrániť?</span>
+                        <button
+                            onClick={() => onDelete(holiday.id)}
+                            className="px-3 py-1 text-xs bg-red-600 hover:bg-red-700 text-white rounded-lg font-medium transition-colors"
+                        >
+                            Áno
+                        </button>
+                        <button
+                            onClick={() => setConfirming(false)}
+                            className="px-3 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg font-medium transition-colors"
+                        >
+                            Nie
+                        </button>
+                    </>
+                ) : (
+                    <button
+                        onClick={() => setConfirming(true)}
+                        className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                        title="Odstrániť"
+                    >
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default HolidaysAdmin;

--- a/frontend/src/pages/client/components/order/DaySelector.tsx
+++ b/frontend/src/pages/client/components/order/DaySelector.tsx
@@ -15,22 +15,23 @@ const DaySelector = ({ selectedDate, onChange, holidays }: DaySelectorProps) => 
     const isWeekend = (d: Date) => d.getDay() === 0 || d.getDay() === 6;
     const isBlocked = (d: Date) => isWeekend(d) || (holidays?.has(OrderService.toLocalDateString(d)) ?? false);
 
-    const handlePrev = () => {
-        const newDate = new Date(dateObj);
-        newDate.setDate(newDate.getDate() - 1);
-        while (isBlocked(newDate)) {
-            newDate.setDate(newDate.getDate() - 1);
+    const findNextAvailable = (from: Date, direction: 1 | -1, max = 365): Date | null => {
+        const d = new Date(from);
+        for (let i = 0; i < max; i++) {
+            d.setDate(d.getDate() + direction);
+            if (!isBlocked(d)) return d;
         }
-        onChange(OrderService.toLocalDateString(newDate));
+        return null;
+    };
+
+    const handlePrev = () => {
+        const result = findNextAvailable(dateObj, -1);
+        if (result) onChange(OrderService.toLocalDateString(result));
     };
 
     const handleNext = () => {
-        const newDate = new Date(dateObj);
-        newDate.setDate(newDate.getDate() + 1);
-        while (isBlocked(newDate)) {
-            newDate.setDate(newDate.getDate() + 1);
-        }
-        onChange(OrderService.toLocalDateString(newDate));
+        const result = findNextAvailable(dateObj, 1);
+        if (result) onChange(OrderService.toLocalDateString(result));
     };
 
     const dateFormatter = new Intl.DateTimeFormat('sk-SK', {

--- a/frontend/src/pages/client/components/order/DaySelector.tsx
+++ b/frontend/src/pages/client/components/order/DaySelector.tsx
@@ -6,17 +6,19 @@ import OrderService from '../../services/OrderService';
 interface DaySelectorProps {
     selectedDate: string;
     onChange: (date: string) => void;
+    holidays?: Set<string>;
 }
 
-const DaySelector = ({ selectedDate, onChange }: DaySelectorProps) => {
+const DaySelector = ({ selectedDate, onChange, holidays }: DaySelectorProps) => {
     const dateObj = new Date(`${selectedDate}T12:00:00`);
 
     const isWeekend = (d: Date) => d.getDay() === 0 || d.getDay() === 6;
+    const isBlocked = (d: Date) => isWeekend(d) || (holidays?.has(OrderService.toLocalDateString(d)) ?? false);
 
     const handlePrev = () => {
         const newDate = new Date(dateObj);
         newDate.setDate(newDate.getDate() - 1);
-        while (isWeekend(newDate)) {
+        while (isBlocked(newDate)) {
             newDate.setDate(newDate.getDate() - 1);
         }
         onChange(OrderService.toLocalDateString(newDate));
@@ -25,7 +27,7 @@ const DaySelector = ({ selectedDate, onChange }: DaySelectorProps) => {
     const handleNext = () => {
         const newDate = new Date(dateObj);
         newDate.setDate(newDate.getDate() + 1);
-        while (isWeekend(newDate)) {
+        while (isBlocked(newDate)) {
             newDate.setDate(newDate.getDate() + 1);
         }
         onChange(OrderService.toLocalDateString(newDate));

--- a/frontend/src/pages/client/hooks/useOrder.ts
+++ b/frontend/src/pages/client/hooks/useOrder.ts
@@ -229,12 +229,20 @@ export const useOrder = () => {
     useEffect(() => {
         const fetchHolidays = async () => {
             try {
-                const res = await apiFetch(`${API_URL}/holidays/`);
-                if (res.ok) {
+                const allHolidays: { date: string }[] = [];
+                let url: string | null = `${API_URL}/holidays/`;
+                while (url) {
+                    const res = await apiFetch(url);
+                    if (!res.ok) break;
                     const data = await res.json();
-                    const list: { date: string }[] = data.results ?? data;
-                    setHolidays(new Set(list.map((h) => h.date)));
+                    if (Array.isArray(data)) {
+                        allHolidays.push(...data);
+                        break;
+                    }
+                    allHolidays.push(...(data.results ?? []));
+                    url = data.next ?? null;
                 }
+                setHolidays(new Set(allHolidays.map((h) => h.date)));
             } catch (e) {
                 console.error("Failed to fetch holidays", e);
             }

--- a/frontend/src/pages/client/hooks/useOrder.ts
+++ b/frontend/src/pages/client/hooks/useOrder.ts
@@ -223,6 +223,25 @@ export const useOrder = () => {
         if (user) fetchSettings();
     }, [apiFetch, user]);
 
+    // Holidays: set of date strings "YYYY-MM-DD" that are blocked
+    const [holidays, setHolidays] = useState<Set<string>>(new Set());
+
+    useEffect(() => {
+        const fetchHolidays = async () => {
+            try {
+                const res = await apiFetch(`${API_URL}/holidays/`);
+                if (res.ok) {
+                    const data = await res.json();
+                    const list: { date: string }[] = data.results ?? data;
+                    setHolidays(new Set(list.map((h) => h.date)));
+                }
+            } catch (e) {
+                console.error("Failed to fetch holidays", e);
+            }
+        };
+        if (user) fetchHolidays();
+    }, [apiFetch, user]);
+
     // Order persistence: no autosave/debounce writes draft orders to the backend.
     // Draft state is kept only in localStorage (see safeParse logic above) to survive page refreshes.
 
@@ -543,5 +562,6 @@ export const useOrder = () => {
         adminVisibleMenus,
         adminVisibleMeals,
         globalDeadlines,
+        holidays,
     };
 };

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -35,6 +35,7 @@ const OrderPage = () => {
     globalDeadlines,
     loadBreakfastFromPrevLunch,
     copyOlovrantFromCurrentLunch,
+    holidays,
   } = useApp();
 
   const { isTourActive, currentStep } = useOnboarding();
@@ -287,10 +288,20 @@ const OrderPage = () => {
 
       <div className="max-w-6xl mx-auto space-y-6">
         <div data-tour-id="tour-day-selector">
-          <DaySelector selectedDate={selectedDate} onChange={setSelectedDate} />
+          <DaySelector selectedDate={selectedDate} onChange={setSelectedDate} holidays={holidays} />
         </div>
 
-        <div className="space-y-6">
+        {holidays?.has(selectedDate) && (
+          <div className="flex items-center gap-3 bg-sky-50 border border-sky-200 rounded-2xl px-5 py-4 text-sky-800">
+            <span className="text-2xl">🏖️</span>
+            <div>
+              <div className="font-semibold text-sky-900">Voľný deň</div>
+              <div className="text-sm text-sky-700">Na tento deň nie je možné zadať objednávku.</div>
+            </div>
+          </div>
+        )}
+
+        <div className={`space-y-6 ${holidays?.has(selectedDate) ? 'opacity-40 pointer-events-none select-none' : ''}`}>
           {visibleMealsList.map((mealItem, mealIndex) => {
             const { key: rawKey, label, icon } = mealItem;
             const key = rawKey as "breakfast" | "lunch" | "olovrant";
@@ -370,23 +381,30 @@ const OrderPage = () => {
               : undefined
           }
           disabled={
-            !OrderService.checkDeadline(
-              selectedDate,
-              "breakfast",
-              globalDeadlines,
-            ) &&
-            !OrderService.checkDeadline(
-              selectedDate,
-              "lunch",
-              globalDeadlines,
-            ) &&
-            !OrderService.checkDeadline(
-              selectedDate,
-              "olovrant",
-              globalDeadlines,
+            holidays?.has(selectedDate) ||
+            (
+              !OrderService.checkDeadline(
+                selectedDate,
+                "breakfast",
+                globalDeadlines,
+              ) &&
+              !OrderService.checkDeadline(
+                selectedDate,
+                "lunch",
+                globalDeadlines,
+              ) &&
+              !OrderService.checkDeadline(
+                selectedDate,
+                "olovrant",
+                globalDeadlines,
+              )
             )
           }
-          disabledMessage="Na tento deň už nie je možné vytvoriť objednávku (termín uplynul)."
+          disabledMessage={
+            holidays?.has(selectedDate)
+              ? "Voľný deň – objednávky nie sú dostupné."
+              : "Na tento deň už nie je možné vytvoriť objednávku (termín uplynul)."
+          }
         />
         </div>
       </div>

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -303,7 +303,6 @@ const OrderPage = () => {
 
         <div
           className={`space-y-6 ${holidays?.has(selectedDate) ? 'opacity-40 pointer-events-none select-none' : ''}`}
-          inert={holidays?.has(selectedDate) ? true : undefined}
           aria-disabled={holidays?.has(selectedDate) ? true : undefined}
         >
           {visibleMealsList.map((mealItem, mealIndex) => {

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -304,6 +304,7 @@ const OrderPage = () => {
         <div
           className={`space-y-6 ${holidays?.has(selectedDate) ? 'opacity-40 pointer-events-none select-none' : ''}`}
           inert={holidays?.has(selectedDate) ? true : undefined}
+          aria-disabled={holidays?.has(selectedDate) ? true : undefined}
         >
           {visibleMealsList.map((mealItem, mealIndex) => {
             const { key: rawKey, label, icon } = mealItem;
@@ -314,16 +315,17 @@ const OrderPage = () => {
               key,
               globalDeadlines,
             );
+            const isHoliday = holidays?.has(selectedDate);
 
             return (
               <MealCard
                 key={key}
                 title={label}
                 icon={icon}
-                isActive={isEditable && activeMeals[key]}
-                onToggle={() => isEditable && toggleMeal(key)} // Block toggle if not editable
-                copyAction={isEditable ? handleCopyTrigger(key) : null} // Hide copy if not editable
-                className={!isEditable ? "opacity-75" : ""} // Visual feedback
+                isActive={isEditable && !isHoliday && activeMeals[key]}
+                onToggle={() => isEditable && !isHoliday && toggleMeal(key)}
+                copyAction={isEditable && !isHoliday ? handleCopyTrigger(key) : null}
+                className={!isEditable || isHoliday ? "opacity-75" : ""}
                 tourId={mealIndex === 0 ? "tour-meal-card" : undefined}
                 statusMessage={
                   !isEditable ? (
@@ -353,15 +355,17 @@ const OrderPage = () => {
                         menuCounts={data.menuCounts}
                         onMenuCountChange={(menuType, val) =>
                           isEditable &&
+                          !isHoliday &&
                           updateMenuCount(key, category, menuType, val)
                         }
                         hasDietsEnabled={availableDiets.length > 0}
                         dietCount={dietCount}
                         onOpenDiets={() =>
                           isEditable &&
+                          !isHoliday &&
                           setActiveDietModal({ meal: key, category })
                         }
-                        disabled={!isEditable}
+                        disabled={!isEditable || !!isHoliday}
                         visibleMenus={adminVisibleMenus}
                         tourId={mealIndex === 0 && catIndex === 0 ? "tour-category-row" : undefined}
                       />

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -293,7 +293,7 @@ const OrderPage = () => {
 
         {holidays?.has(selectedDate) && (
           <div className="flex items-center gap-3 bg-sky-50 border border-sky-200 rounded-2xl px-5 py-4 text-sky-800">
-            <span className="text-2xl">🏖️</span>
+            <span className="text-2xl" aria-hidden="true">🏖️</span>
             <div>
               <div className="font-semibold text-sky-900">Voľný deň</div>
               <div className="text-sm text-sky-700">Na tento deň nie je možné zadať objednávku.</div>

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -301,7 +301,10 @@ const OrderPage = () => {
           </div>
         )}
 
-        <div className={`space-y-6 ${holidays?.has(selectedDate) ? 'opacity-40 pointer-events-none select-none' : ''}`}>
+        <div
+          className={`space-y-6 ${holidays?.has(selectedDate) ? 'opacity-40 pointer-events-none select-none' : ''}`}
+          inert={holidays?.has(selectedDate) ? true : undefined}
+        >
           {visibleMealsList.map((mealItem, mealIndex) => {
             const { key: rawKey, label, icon } = mealItem;
             const key = rawKey as "breakfast" | "lunch" | "olovrant";


### PR DESCRIPTION
Backend: introduce Holiday model + migration, add admin CRUD endpoints (including bulk create) and a client read-only holidays endpoint.
Backend: update planned-order calculations to skip holidays and add server-side validation to prevent non-staff orders on holidays.
Frontend: fetch holidays for clients, disable ordering UI on blocked dates, and add an Admin UI page + route + navigation entry for managing holidays