### PR TITLE
chore: httpOnly refresh cookie, rotation, blacklist...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,5 +93,3 @@ check-all.sh
 
 notes.md
 tasks.md
-notes.md
-docs/

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Full-stack web application with Django backend and React frontend, containerized
 ## 🤝 Contributing
 
 **Commit Message Format:**
+
 ```
 <type>(<scope>): <subject>
 ```
 
 **Príklady:**
+
 - `feat(backend): add user authentication`
 - `fix(frontend): resolve navbar issues`
 - `docs: update setup instructions`
@@ -54,6 +56,7 @@ docker compose --env-file .env.dev -f compose/dev.yml up --build
 ```
 
 The application will be available at:
+
 - Frontend: http://localhost:3000
 - Backend API: http://localhost:8000
 - Django Admin: http://localhost:8000/admin
@@ -176,6 +179,10 @@ zdravy-projekt/
 └── README.md
 ```
 
+## 📚 Documentation
+
+- [Architektura a dolezite flows](docs/ARCHITECTURE_AND_FLOWS.md) - modulova mapa, Mermaid diagramy, datovy model, objednavkove/report/push/Celery flows a poznamky k rizikovym miestam.
+
 ## 🔧 Development
 
 ### Backend Development
@@ -233,12 +240,12 @@ pre-commit run --all-files
 
 **Hooks configured:**
 
-| Hook | Tool | What it does |
-|------|------|-------------|
-| `black` | black 25.1.0 | Formats Python code |
-| `isort` | isort 5.13.2 | Sorts imports (black-compatible) |
-| `flake8` | flake8 7.0.0 | Lints for style/logic errors |
-| `mypy` | mypy 1.11.2 | Static type checking |
+| Hook     | Tool         | What it does                     |
+| -------- | ------------ | -------------------------------- |
+| `black`  | black 25.1.0 | Formats Python code              |
+| `isort`  | isort 5.13.2 | Sorts imports (black-compatible) |
+| `flake8` | flake8 7.0.0 | Lints for style/logic errors     |
+| `mypy`   | mypy 1.11.2  | Static type checking             |
 
 **Via Docker (without local Python):**
 
@@ -295,6 +302,7 @@ Deployment is managed by Dokploy (Traefik + Compose stack).
 See [env/dev.example](env/dev.example), [env/staging.example](env/staging.example), [env/prod.example](env/prod.example), and [env/observability.example](env/observability.example) for available environment variables.
 
 Key variables:
+
 - `DJANGO_SECRET_KEY`: Django secret key (generate for production)
 - `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`: Database credentials
 - `POSTGRES_HOST`: Dokploy-managed Postgres hostname for staging/production
@@ -327,6 +335,7 @@ are honored when the stack is deployed through Swarm-compatible deployment
 fields.
 
 Defaults:
+
 - Production runs `BACKEND_REPLICAS=2`, `FRONTEND_REPLICAS=2`, `CELERY_REPLICAS=1`, and one fixed `celery-beat`.
 - Staging runs one replica per service by default.
 - `backend` and `frontend` use `start-first` rolling updates.
@@ -336,6 +345,7 @@ Defaults:
 ### CI/CD Pipeline
 
 GitHub Actions automatically:
+
 1. Runs tests on every pull request
 2. Checks code quality (linting, formatting)
 3. Builds staging images on push to `develop` branch

--- a/backend/api/password_reset_service.py
+++ b/backend/api/password_reset_service.py
@@ -160,6 +160,17 @@ def confirm_password_reset(token: str, new_password: str) -> None:
     reset_token.used = True
     reset_token.save(update_fields=["used"])
 
+    # ── Invalidate all outstanding JWT refresh tokens for this user ────────────
+    # This ensures any session that was active before the password reset cannot
+    # continue — the user must log in again with the new password.
+    from rest_framework_simplejwt.token_blacklist.models import (
+        BlacklistedToken,
+        OutstandingToken,
+    )
+
+    for outstanding in OutstandingToken.objects.filter(user=user):
+        BlacklistedToken.objects.get_or_create(token=outstanding)
+
     # ── Clear rate-limit state so user can log in immediately ─────────────────
     email = user.email.lower()
     cache.delete(_key_attempts(email))

--- a/backend/api/password_reset_service.py
+++ b/backend/api/password_reset_service.py
@@ -161,15 +161,28 @@ def confirm_password_reset(token: str, new_password: str) -> None:
     reset_token.save(update_fields=["used"])
 
     # ── Invalidate all outstanding JWT refresh tokens for this user ────────────
-    # This ensures any session that was active before the password reset cannot
-    # continue — the user must log in again with the new password.
+    # Bulk-insert to avoid N+1 and wrap in atomic so a DB error cannot leave a
+    # partial blacklist (some sessions live, some revoked).
+    from django.db import transaction
+    from django.utils import timezone as tz
     from rest_framework_simplejwt.token_blacklist.models import (
         BlacklistedToken,
         OutstandingToken,
     )
 
-    for outstanding in OutstandingToken.objects.filter(user=user):
-        BlacklistedToken.objects.get_or_create(token=outstanding)
+    with transaction.atomic():
+        token_ids = list(
+            OutstandingToken.objects.filter(
+                user=user,
+                expires_at__gt=tz.now(),
+            )
+            .exclude(blacklistedtoken__isnull=False)
+            .values_list("id", flat=True)
+        )
+        BlacklistedToken.objects.bulk_create(
+            [BlacklistedToken(token_id=tid) for tid in token_ids],
+            ignore_conflicts=True,
+        )
 
     # ── Clear rate-limit state so user can log in immediately ─────────────────
     email = user.email.lower()

--- a/backend/api/tests/integration/test_auth_api.py
+++ b/backend/api/tests/integration/test_auth_api.py
@@ -184,6 +184,19 @@ class TestTokenRefreshFlow:
 
         assert first_refresh != second_refresh
 
+    def test_rotation_preserves_role_based_lifetime(self, api_client, admin_user):
+        """Rotated token must keep the admin's 1-day lifetime, not fall back to 30 days."""
+        _login(api_client, "admin@example.com", "admin123")
+
+        rotate_response = api_client.post(reverse("token_refresh"), format="json")
+        assert rotate_response.status_code == status.HTTP_200_OK
+
+        rotated_cookie = api_client.cookies[COOKIE_NAME].value
+        rotated = RefreshToken(rotated_cookie)
+        lifetime_days = (rotated.payload["exp"] - rotated.payload["iat"]) / 86400
+        # Must still be ~1 day, not 30
+        assert abs(lifetime_days - 1) < 0.1
+
     def test_token_refresh_with_invalid_cookie(self, api_client):
         """An invalid cookie value is rejected."""
         api_client.cookies[COOKIE_NAME] = "invalid-token"

--- a/backend/api/tests/integration/test_auth_api.py
+++ b/backend/api/tests/integration/test_auth_api.py
@@ -1,5 +1,5 @@
 """
-Authentication tests for login, JWT token refresh, and password reset flows.
+Authentication tests for login, JWT token flow, and password reset.
 """
 
 from datetime import timedelta
@@ -16,9 +16,30 @@ from api.models import PasswordResetToken
 
 pytestmark = pytest.mark.integration
 
+COOKIE_NAME = "refresh_token"
+
 
 # ──────────────────────────────────────────────────────────────────────────
-# LOGIN FLOW TESTS
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _login(api_client, email, password):
+    """Perform a login and return the response (cookies are set on api_client)."""
+    return api_client.post(
+        reverse("token_obtain_pair"),
+        {"email": email, "password": password},
+        format="json",
+    )
+
+
+def _get_refresh_cookie(response):
+    """Extract the raw refresh token string from a response's Set-Cookie header."""
+    return response.cookies.get(COOKIE_NAME)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# LOGIN FLOW
 # ──────────────────────────────────────────────────────────────────────────
 
 
@@ -27,55 +48,29 @@ class TestLoginFlow:
     """Test login and JWT token flow."""
 
     def test_login_with_valid_credentials(self, api_client, user):
-        """Test successful login with valid email and password."""
-        url = reverse("token_obtain_pair")
-        response = api_client.post(
-            url,
-            {"email": "client@example.com", "password": "client123"},
-            format="json",
-        )
+        response = _login(api_client, "client@example.com", "client123")
 
         assert response.status_code == status.HTTP_200_OK
+        # Access token is in the body
         assert "access" in response.data
-        assert "refresh" in response.data
-
-        # Verify tokens are valid
-        access_token = response.data["access"]
-        refresh_token = response.data["refresh"]
-
-        assert len(access_token) > 0
-        assert len(refresh_token) > 0
+        # Refresh token must NOT be in the body — it is set as an httpOnly cookie
+        assert "refresh" not in response.data
+        # Cookie must be present
+        assert COOKIE_NAME in response.cookies
+        assert response.cookies[COOKIE_NAME].value
 
     def test_login_with_invalid_password(self, api_client, user):
-        """Test login fails with invalid password."""
-        url = reverse("token_obtain_pair")
-        response = api_client.post(
-            url,
-            {"email": "client@example.com", "password": "wrongpassword"},
-            format="json",
-        )
+        response = _login(api_client, "client@example.com", "wrongpassword")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_login_with_invalid_email(self, api_client):
-        """Test login fails with non-existent email."""
-        url = reverse("token_obtain_pair")
-        response = api_client.post(
-            url,
-            {"email": "nonexistent@example.com", "password": "anypassword"},
-            format="json",
-        )
+        response = _login(api_client, "nonexistent@example.com", "anypassword")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_login_case_insensitive_email(self, api_client, user):
-        """Test login with email of different case."""
-        url = reverse("token_obtain_pair")
-        response = api_client.post(
-            url,
-            {"email": "CLIENT@EXAMPLE.COM", "password": "client123"},
-            format="json",
-        )
+        response = _login(api_client, "CLIENT@EXAMPLE.COM", "client123")
 
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
@@ -83,7 +78,6 @@ class TestLoginFlow:
     def test_login_with_duplicate_email_prefers_matching_active_account(
         self, api_client
     ):
-        """Login should succeed if one duplicate email account is active and matches password."""
         User.objects.create_user(
             username="dup-inactive",
             email="duplicate@example.com",
@@ -97,118 +91,166 @@ class TestLoginFlow:
             is_active=True,
         )
 
-        url = reverse("token_obtain_pair")
-        response = api_client.post(
-            url,
-            {"email": "duplicate@example.com", "password": "active-pass"},
-            format="json",
-        )
+        response = _login(api_client, "duplicate@example.com", "active-pass")
 
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
 
     def test_login_with_inactive_user(self, api_client, user):
-        """Test login fails for inactive user."""
         user.is_active = False
         user.save()
 
-        url = reverse("token_obtain_pair")
-        response = api_client.post(
-            url,
-            {"email": "client@example.com", "password": "client123"},
-            format="json",
-        )
+        response = _login(api_client, "client@example.com", "client123")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_login_missing_email(self, api_client):
-        """Test login fails without email."""
-        url = reverse("token_obtain_pair")
-        response = api_client.post(url, {"password": "anypassword"}, format="json")
-
-        # Missing required field returns 400
+        response = api_client.post(
+            reverse("token_obtain_pair"), {"password": "anypassword"}, format="json"
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_login_missing_password(self, api_client, user):
-        """Test login fails without password."""
-        url = reverse("token_obtain_pair")
-        response = api_client.post(url, {"email": "client@example.com"}, format="json")
-
-        # Missing required field returns 400
+        response = api_client.post(
+            reverse("token_obtain_pair"),
+            {"email": "client@example.com"},
+            format="json",
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_login_empty_email(self, api_client):
-        """Test login fails with empty email."""
-        url = reverse("token_obtain_pair")
         response = api_client.post(
-            url, {"email": "", "password": "anypassword"}, format="json"
+            reverse("token_obtain_pair"),
+            {"email": "", "password": "anypassword"},
+            format="json",
         )
-
-        # Empty email is a serializer validation error for this endpoint.
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_client_gets_30_day_refresh_token(self, api_client, user):
+        """Client users receive a 30-day refresh token."""
+        assert not user.is_staff
+        response = _login(api_client, "client@example.com", "client123")
+
+        assert response.status_code == status.HTTP_200_OK
+        cookie = _get_refresh_cookie(response)
+        assert cookie is not None
+
+        refresh = RefreshToken(cookie.value)
+        lifetime_days = (refresh.payload["exp"] - refresh.payload["iat"]) / 86400
+        assert abs(lifetime_days - 30) < 1  # within 1 day tolerance
+
+    def test_admin_gets_1_day_refresh_token(self, api_client, admin_user):
+        """Admin users receive a 1-day refresh token."""
+        assert admin_user.is_staff
+        response = _login(api_client, "admin@example.com", "admin123")
+
+        assert response.status_code == status.HTTP_200_OK
+        cookie = _get_refresh_cookie(response)
+        assert cookie is not None
+
+        refresh = RefreshToken(cookie.value)
+        lifetime_days = (refresh.payload["exp"] - refresh.payload["iat"]) / 86400
+        assert abs(lifetime_days - 1) < 0.1  # within ~2.5 hours tolerance
 
 
 # ──────────────────────────────────────────────────────────────────────────
-# JWT TOKEN REFRESH TESTS
+# TOKEN REFRESH
 # ──────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.django_db
 class TestTokenRefreshFlow:
-    """Test JWT token refresh flow."""
+    """Test JWT token refresh via httpOnly cookie."""
 
     def test_token_refresh_success(self, api_client, user):
-        """Test successful token refresh."""
-        # Get initial tokens
-        obtain_url = reverse("token_obtain_pair")
-        obtain_response = api_client.post(
-            obtain_url,
-            {"email": "client@example.com", "password": "client123"},
-            format="json",
-        )
-        refresh_token = obtain_response.data["refresh"]
+        # Login to obtain the refresh cookie
+        _login(api_client, "client@example.com", "client123")
 
-        # Refresh the token
         refresh_url = reverse("token_refresh")
-        refresh_response = api_client.post(
-            refresh_url, {"refresh": refresh_token}, format="json"
-        )
+        refresh_response = api_client.post(refresh_url, format="json")
 
         assert refresh_response.status_code == status.HTTP_200_OK
         assert "access" in refresh_response.data
+        # Rotation: new refresh cookie must be set
+        assert COOKIE_NAME in refresh_response.cookies
 
-    def test_token_refresh_with_invalid_token(self, api_client):
-        """Test token refresh fails with invalid token."""
-        url = reverse("token_refresh")
-        response = api_client.post(url, {"refresh": "invalid-token"}, format="json")
+    def test_token_refresh_rotates_cookie(self, api_client, user):
+        """Each refresh call produces a new refresh cookie (rotation)."""
+        _login(api_client, "client@example.com", "client123")
+        first_refresh = api_client.cookies[COOKIE_NAME].value
+
+        api_client.post(reverse("token_refresh"), format="json")
+        second_refresh = api_client.cookies[COOKIE_NAME].value
+
+        assert first_refresh != second_refresh
+
+    def test_token_refresh_with_invalid_cookie(self, api_client):
+        """An invalid cookie value is rejected."""
+        api_client.cookies[COOKIE_NAME] = "invalid-token"
+        response = api_client.post(reverse("token_refresh"), format="json")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_token_refresh_missing_token(self, api_client):
-        """Test token refresh fails without token."""
-        url = reverse("token_refresh")
-        response = api_client.post(url, {}, format="json")
+    def test_token_refresh_missing_cookie(self, api_client):
+        """Missing cookie returns 401."""
+        response = api_client.post(reverse("token_refresh"), format="json")
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_access_token_contains_user_info(self, api_client, user):
-        """Test that access token contains user information."""
-        obtain_url = reverse("token_obtain_pair")
-        obtain_response = api_client.post(
-            obtain_url,
-            {"email": "client@example.com", "password": "client123"},
-            format="json",
-        )
-        access_token_str = obtain_response.data["access"]
+        login_response = _login(api_client, "client@example.com", "client123")
+        access_token_str = login_response.data["access"]
 
-        # Decode token payload (without verification for test)
         token = AccessToken(access_token_str)
-        # user_id is stored as string in token
         assert int(token.payload["user_id"]) == user.id
 
 
 # ──────────────────────────────────────────────────────────────────────────
-# PASSWORD RESET FLOW TESTS
+# LOGOUT
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestLogoutFlow:
+    """Test server-side logout with token blacklisting."""
+
+    def test_logout_blacklists_refresh_token(self, api_client, user):
+        """After logout the refresh cookie can no longer be used to refresh."""
+        login_response = _login(api_client, "client@example.com", "client123")
+        access_token = login_response.data["access"]
+
+        # Logout
+        api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
+        logout_response = api_client.post(reverse("token_logout"), format="json")
+        assert logout_response.status_code == status.HTTP_200_OK
+
+        # The old refresh cookie is now blacklisted — refresh must fail
+        refresh_response = api_client.post(reverse("token_refresh"), format="json")
+        assert refresh_response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_logout_clears_cookie(self, api_client, user):
+        """Logout response deletes the refresh cookie."""
+        login_response = _login(api_client, "client@example.com", "client123")
+        api_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {login_response.data['access']}"
+        )
+
+        logout_response = api_client.post(reverse("token_logout"), format="json")
+
+        # Cookie should be cleared (max-age=0 or explicit deletion)
+        assert logout_response.status_code == status.HTTP_200_OK
+
+    def test_logout_requires_authentication(self, api_client):
+        """Unauthenticated logout is rejected (401 from JWT, 403 from SessionAuthentication)."""
+        response = api_client.post(reverse("token_logout"), format="json")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# PASSWORD RESET
 # ──────────────────────────────────────────────────────────────────────────
 
 
@@ -217,103 +259,100 @@ class TestPasswordResetFlow:
     """Test password reset request and validation."""
 
     def test_password_reset_request_success(self, api_client, user):
-        """Test successful password reset request."""
-        url = reverse("password_reset_request")
-        response = api_client.post(url, {"email": user.email}, format="json")
-
+        response = api_client.post(
+            reverse("password_reset_request"), {"email": user.email}, format="json"
+        )
         assert response.status_code == status.HTTP_200_OK
 
-        # Verify token was created
         token = PasswordResetToken.objects.filter(user=user).first()
         assert token is not None
         assert not token.used
 
     def test_password_reset_request_unknown_email(self, api_client):
-        """Test password reset for unknown email returns 200 (security)."""
-        url = reverse("password_reset_request")
-        response = api_client.post(url, {"email": "unknown@example.com"}, format="json")
-
-        # Should return 200 to avoid email enumeration
+        response = api_client.post(
+            reverse("password_reset_request"),
+            {"email": "unknown@example.com"},
+            format="json",
+        )
         assert response.status_code == status.HTTP_200_OK
 
     def test_password_reset_request_missing_email(self, api_client):
-        """Test password reset fails without email."""
-        url = reverse("password_reset_request")
-        response = api_client.post(url, {}, format="json")
-
+        response = api_client.post(reverse("password_reset_request"), {}, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_password_reset_request_rate_limit(self, api_client, user):
-        """Test rate limiting on password reset requests."""
         url = reverse("password_reset_request")
 
-        # First request succeeds
         response = api_client.post(url, {"email": user.email}, format="json")
         assert response.status_code == status.HTTP_200_OK
 
-        # Subsequent requests are rate-limited due to cooldown
-        # (cooldown is enforced before attempt counter)
         response = api_client.post(url, {"email": user.email}, format="json")
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
-        assert "error" in response.data
-        # Should be either rate_limit_exceeded or too_soon
         assert response.data["error"]["code"] in ["rate_limit_exceeded", "too_soon"]
 
     def test_password_reset_request_cooldown(self, api_client, user):
-        """Test cooldown between password reset requests."""
         url = reverse("password_reset_request")
 
-        # First request succeeds
-        response = api_client.post(url, {"email": user.email}, format="json")
-        assert response.status_code == status.HTTP_200_OK
+        api_client.post(url, {"email": user.email}, format="json")
 
-        # Immediate second request should fail with cooldown error
         response = api_client.post(url, {"email": user.email}, format="json")
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
-        assert "error" in response.data
         assert response.data["error"]["code"] == "too_soon"
         assert "wait_seconds" in response.data["error"]["details"]
 
     def test_password_reset_confirm_success(self, api_client, user):
-        """Test successful password reset confirmation."""
-        # Create reset token
-        token = PasswordResetToken.objects.create(
+        PasswordResetToken.objects.create(
             user=user,
             token="valid-reset-token",
             expires_at=timezone.now() + timedelta(hours=1),
             used=False,
         )
 
-        url = reverse("password_reset_confirm")
         response = api_client.post(
-            url,
+            reverse("password_reset_confirm"),
             {"token": "valid-reset-token", "new_password": "NewPassword123"},
             format="json",
         )
-
         assert response.status_code == status.HTTP_200_OK
 
-        # Token should be marked as used
-        token.refresh_from_db()
+        token = PasswordResetToken.objects.get(token="valid-reset-token")
         assert token.used is True
 
-        # User password should be changed
         user.refresh_from_db()
         assert user.check_password("NewPassword123")
 
-    def test_password_reset_confirm_with_invalid_token(self, api_client):
-        """Test password reset confirmation with invalid token."""
-        url = reverse("password_reset_confirm")
-        response = api_client.post(
-            url,
-            {"token": "invalid-token", "new_password": "NewPassword123"},
+    def test_password_reset_invalidates_existing_sessions(self, api_client, user):
+        """After a password reset all outstanding refresh tokens are blacklisted."""
+        # Log in to create an outstanding refresh token
+        login_response = _login(api_client, "client@example.com", "client123")
+
+        # Reset password
+        PasswordResetToken.objects.create(
+            user=user,
+            token="invalidate-sessions-token",
+            expires_at=timezone.now() + timedelta(hours=1),
+            used=False,
+        )
+        api_client.post(
+            reverse("password_reset_confirm"),
+            {"token": "invalidate-sessions-token", "new_password": "NewPassword456"},
             format="json",
         )
 
+        # The old refresh cookie must now be rejected
+        api_client.cookies[COOKIE_NAME] = api_client.cookies.get(COOKIE_NAME, "")
+        refresh_response = api_client.post(reverse("token_refresh"), format="json")
+        assert refresh_response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_password_reset_confirm_with_invalid_token(self, api_client):
+        response = api_client.post(
+            reverse("password_reset_confirm"),
+            {"token": "invalid-token", "new_password": "NewPassword123"},
+            format="json",
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_password_reset_confirm_with_expired_token(self, api_client, user):
-        """Test password reset confirmation with expired token."""
         PasswordResetToken.objects.create(
             user=user,
             token="expired-reset-token",
@@ -321,17 +360,14 @@ class TestPasswordResetFlow:
             used=False,
         )
 
-        url = reverse("password_reset_confirm")
         response = api_client.post(
-            url,
+            reverse("password_reset_confirm"),
             {"token": "expired-reset-token", "new_password": "NewPassword123"},
             format="json",
         )
-
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_password_reset_confirm_with_already_used_token(self, api_client, user):
-        """Test password reset confirmation with already-used token."""
         PasswordResetToken.objects.create(
             user=user,
             token="used-reset-token",
@@ -339,17 +375,14 @@ class TestPasswordResetFlow:
             used=True,
         )
 
-        url = reverse("password_reset_confirm")
         response = api_client.post(
-            url,
+            reverse("password_reset_confirm"),
             {"token": "used-reset-token", "new_password": "NewPassword123"},
             format="json",
         )
-
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_password_reset_confirm_weak_password(self, api_client, user):
-        """Test password reset fails with weak password."""
         PasswordResetToken.objects.create(
             user=user,
             token="weak-password-token",
@@ -358,63 +391,46 @@ class TestPasswordResetFlow:
         )
 
         for weak_pass in ["123", "password", "weak"]:
-            url = reverse("password_reset_confirm")
             response = api_client.post(
-                url,
+                reverse("password_reset_confirm"),
                 {"token": "weak-password-token", "new_password": weak_pass},
                 format="json",
             )
-
-            # Weak passwords should fail
             if response.status_code != status.HTTP_200_OK:
                 assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_password_reset_confirm_missing_fields(self, api_client):
-        """Test password reset confirmation fails without required fields."""
         url = reverse("password_reset_confirm")
 
-        # Missing token
         response = api_client.post(
             url, {"new_password": "NewPassword123"}, format="json"
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-        # Missing new_password
         response = api_client.post(url, {"token": "some-token"}, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_password_reset_can_login_after_reset(self, api_client, user):
-        """Test user can login with new password after reset."""
-        # Reset password
-        token = PasswordResetToken.objects.create(
+        PasswordResetToken.objects.create(
             user=user,
             token="reset-and-login-token",
             expires_at=timezone.now() + timedelta(hours=1),
             used=False,
         )
 
-        url = reverse("password_reset_confirm")
-        response = api_client.post(
-            url,
+        api_client.post(
+            reverse("password_reset_confirm"),
             {"token": "reset-and-login-token", "new_password": "NewLogin123"},
             format="json",
         )
-        assert response.status_code == status.HTTP_200_OK
 
-        # Try to login with new password
-        login_url = reverse("token_obtain_pair")
-        login_response = api_client.post(
-            login_url,
-            {"email": user.email, "password": "NewLogin123"},
-            format="json",
-        )
-
+        login_response = _login(api_client, user.email, "NewLogin123")
         assert login_response.status_code == status.HTTP_200_OK
         assert "access" in login_response.data
 
 
 # ──────────────────────────────────────────────────────────────────────────
-# EDGE CASES AND SECURITY TESTS
+# EDGE CASES AND SECURITY
 # ──────────────────────────────────────────────────────────────────────────
 
 
@@ -423,56 +439,37 @@ class TestAuthEdgeCases:
     """Test edge cases and security scenarios."""
 
     def test_multiple_failed_login_attempts(self, api_client, user):
-        """Test handling of multiple failed login attempts."""
         url = reverse("token_obtain_pair")
-
-        # Multiple failed attempts should not lock account
-        for i in range(10):
+        for _ in range(10):
             response = api_client.post(
-                url,
-                {"email": user.email, "password": "wrongpass"},
-                format="json",
+                url, {"email": user.email, "password": "wrongpass"}, format="json"
             )
             assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-        # User should still be able to login with correct password
+        # Still able to log in with correct password
         response = api_client.post(
-            url,
-            {"email": user.email, "password": "client123"},
-            format="json",
+            url, {"email": user.email, "password": "client123"}, format="json"
         )
         assert response.status_code == status.HTTP_200_OK
 
     def test_token_expiry_not_accessible(self, api_client, user):
-        """Test that expired tokens cannot be used."""
-        # Create manually expired token
+        """An expired refresh token in the cookie is rejected."""
         refresh = RefreshToken.for_user(user)
         refresh.set_exp(lifetime=timedelta(seconds=-10))
+        api_client.cookies[COOKIE_NAME] = str(refresh)
 
-        url = reverse("token_refresh")
-        response = api_client.post(url, {"refresh": str(refresh)}, format="json")
-
+        response = api_client.post(reverse("token_refresh"), format="json")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_sql_injection_attempt(self, api_client):
-        """Test that SQL injection is prevented in auth endpoints."""
-        url = reverse("token_obtain_pair")
         response = api_client.post(
-            url,
-            {
-                "email": "test' OR '1'='1",
-                "password": "test' OR '1'='1",
-            },
+            reverse("token_obtain_pair"),
+            {"email": "test' OR '1'='1", "password": "test' OR '1'='1"},
             format="json",
         )
-
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_email_whitespace_trimming(self, api_client):
-        """Test that email fields are trimmed of whitespace."""
-        url = reverse("token_obtain_pair")
-
-        # Create user with specific email
         User.objects.create_user(
             username="test@example.com",
             email="test@example.com",
@@ -480,25 +477,19 @@ class TestAuthEdgeCases:
             is_active=True,
         )
 
-        # Test with whitespace
         response = api_client.post(
-            url,
+            reverse("token_obtain_pair"),
             {"email": "  test@example.com  ", "password": "Password123"},
             format="json",
         )
-
         assert response.status_code == status.HTTP_200_OK
 
     def test_password_reset_token_uniqueness(self, api_client, user):
-        """Test that each password reset token is unique."""
         url = reverse("password_reset_request")
-
-        # Request twice while simulating cooldown passage without real sleep.
         tokens = []
         with patch("api.password_reset_service.RESEND_COOLDOWN", 0):
             for _ in range(2):
-                response = api_client.post(url, {"email": user.email}, format="json")
-                assert response.status_code == status.HTTP_200_OK
+                api_client.post(url, {"email": user.email}, format="json")
                 token = PasswordResetToken.objects.filter(user=user).latest(
                     "created_at"
                 )
@@ -508,7 +499,6 @@ class TestAuthEdgeCases:
         assert tokens[0] != tokens[1]
 
     def test_cross_user_token_reuse(self, api_client, user):
-        """Test that tokens from one user cannot be used by another."""
         user2 = User.objects.create_user(
             username="other@example.com",
             email="other@example.com",
@@ -516,45 +506,33 @@ class TestAuthEdgeCases:
             is_active=True,
         )
 
-        # Create reset token for user1
-        token = PasswordResetToken.objects.create(
+        PasswordResetToken.objects.create(
             user=user,
             token="user1-token",
             expires_at=timezone.now() + timedelta(hours=1),
             used=False,
         )
 
-        # Try to use it for user2
-        url = reverse("password_reset_confirm")
         response = api_client.post(
-            url,
+            reverse("password_reset_confirm"),
             {"token": "user1-token", "new_password": "Hacked123"},
             format="json",
         )
-
-        # Should work for user1 but token should be single-use
         assert response.status_code == status.HTTP_200_OK
 
-        # User1's password changed
         user.refresh_from_db()
         assert user.check_password("Hacked123")
 
-        # User2 should not have new password
         user2.refresh_from_db()
         assert not user2.check_password("Hacked123")
 
     def test_long_email_handling(self, api_client):
-        """Test handling of very long email addresses."""
-        url = reverse("token_obtain_pair")
         long_email = "a" * 200 + "@example.com"
-
         response = api_client.post(
-            url,
+            reverse("token_obtain_pair"),
             {"email": long_email, "password": "anypassword"},
             format="json",
         )
-
-        # Should fail gracefully
         assert response.status_code in [
             status.HTTP_401_UNAUTHORIZED,
             status.HTTP_400_BAD_REQUEST,

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -14,6 +14,7 @@ from .views import (
     EmailTokenObtainPairView,
     GlobalSettingsViewSet,
     HolidayListViewSet,
+    LogoutView,
     MealTemplateViewSet,
     PasswordResetConfirmView,
     PasswordResetRequestView,
@@ -61,6 +62,7 @@ urlpatterns = [
     path("", include(router.urls)),
     path("token/", EmailTokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("token/refresh/", SafeTokenRefreshView.as_view(), name="token_refresh"),
+    path("token/logout/", LogoutView.as_view(), name="token_logout"),
     path("health/", health_check, name="health_check"),
     # Password reset (unauthenticated)
     path(

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -12,6 +12,7 @@ from .admin_views import AdminUserViewSet
 from .auth_views import (
     EmailTokenObtainPairSerializer,
     EmailTokenObtainPairView,
+    LogoutView,
     PasswordResetConfirmView,
     PasswordResetRequestView,
     SafeTokenRefreshView,
@@ -50,6 +51,7 @@ __all__ = [
     "AdminHolidayViewSet",
     "HolidayListViewSet",
     "EmailTokenObtainPairView",
+    "LogoutView",
     "PasswordResetRequestView",
     "PasswordResetConfirmView",
     "SafeTokenRefreshView",

--- a/backend/api/views/auth_views.py
+++ b/backend/api/views/auth_views.py
@@ -111,6 +111,10 @@ class EmailTokenObtainPairSerializer(TokenObtainPairSerializer):
         )
         refresh = RefreshToken.for_user(user)
         refresh.set_exp(lifetime=lifetime)
+        # Embed is_staff so rotation can re-apply the correct lifetime without a
+        # DB query (avoids both a per-rotation SELECT and the exception-fallback
+        # path that would silently promote an admin to a 30-day token).
+        refresh["is_staff"] = user.is_staff
 
         # Store on the instance so the view can read the lifetime without re-parsing
         self._refresh = refresh
@@ -174,29 +178,26 @@ class SafeTokenRefreshView(TokenRefreshView):
 
         new_access: str = serializer.validated_data["access"]
         # ROTATE_REFRESH_TOKENS=True → the serializer returns a new refresh token.
-        # SimpleJWT's rotation calls set_exp() without a lifetime argument, so it
-        # always uses the global REFRESH_TOKEN_LIFETIME (30 days) regardless of the
-        # per-role lifetime we set at login.  Re-apply the correct lifetime here.
+        # SimpleJWT's rotation calls set_exp() without a lifetime argument so it
+        # always resets to the global REFRESH_TOKEN_LIFETIME (30 days).  Read the
+        # is_staff claim we embedded at login to re-apply the correct lifetime
+        # without a DB query — no exception-fallback path needed.
         new_refresh: str | None = serializer.validated_data.get("refresh")
 
         response = Response({"access": new_access}, status=status.HTTP_200_OK)
 
         if new_refresh:
-            try:
-                obj = RefreshToken(new_refresh)  # type: ignore[arg-type]
-                user_id = obj.payload.get("user_id")
-                user_obj = User.objects.get(pk=user_id) if user_id else None
-                lifetime = (
-                    _ADMIN_REFRESH_LIFETIME
-                    if (user_obj and user_obj.is_staff)
-                    else _CLIENT_REFRESH_LIFETIME
-                )
-                obj.set_exp(lifetime=lifetime)
-                new_refresh = str(obj)
-                max_age = int(lifetime.total_seconds())
-            except Exception:
-                max_age = int(_CLIENT_REFRESH_LIFETIME.total_seconds())
-            _set_refresh_cookie(response, new_refresh, max_age=max_age)
+            obj = RefreshToken(new_refresh)  # type: ignore[arg-type]
+            lifetime = (
+                _ADMIN_REFRESH_LIFETIME
+                if obj.payload.get("is_staff")
+                else _CLIENT_REFRESH_LIFETIME
+            )
+            obj.set_exp(lifetime=lifetime)
+            new_refresh = str(obj)
+            _set_refresh_cookie(
+                response, new_refresh, max_age=int(lifetime.total_seconds())
+            )
 
         return response
 
@@ -219,8 +220,12 @@ class LogoutView(APIView):
                 token = RefreshToken(refresh_str)
                 token.blacklist()
             except Exception:
-                # Already blacklisted or otherwise invalid — proceed with logout anyway
-                pass
+                # Token already blacklisted, expired, or malformed — all safe to ignore.
+                # Log at WARNING so a DB outage during logout is visible in monitoring.
+                logger.warning(
+                    "Could not blacklist refresh token on logout (already invalid or DB error)",
+                    exc_info=True,
+                )
 
         response = Response(
             {"detail": "Odhlásenie bolo úspešné."}, status=status.HTTP_200_OK

--- a/backend/api/views/auth_views.py
+++ b/backend/api/views/auth_views.py
@@ -1,12 +1,14 @@
 import logging
+from datetime import timedelta
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import QuerySet
 from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_simplejwt.exceptions import InvalidToken
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
@@ -18,6 +20,34 @@ from ..exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Differentiated refresh token lifetimes by role.
+# Admins: 1 day — they use the web admin UI, not the PWA; short lifetime appropriate
+#   given they have access to all client data.
+# Clients: 30 days — they may open the app as infrequently as every two weeks;
+#   rotation resets the clock on each visit so they're only logged out after 30 days
+#   of complete inactivity.
+_ADMIN_REFRESH_LIFETIME = timedelta(days=1)
+_CLIENT_REFRESH_LIFETIME = timedelta(days=30)
+
+_COOKIE_NAME = settings.REFRESH_TOKEN_COOKIE_NAME
+_COOKIE_PATH = settings.REFRESH_TOKEN_COOKIE_PATH
+
+
+def _set_refresh_cookie(response: Response, refresh_str: str, max_age: int) -> None:
+    response.set_cookie(
+        _COOKIE_NAME,
+        refresh_str,
+        max_age=max_age,
+        httponly=True,
+        secure=not settings.DEBUG,
+        samesite="Lax",
+        path=_COOKIE_PATH,
+    )
+
+
+def _delete_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(_COOKIE_NAME, path=_COOKIE_PATH)
 
 
 class EmailTokenObtainPairSerializer(TokenObtainPairSerializer):
@@ -62,18 +92,11 @@ class EmailTokenObtainPairSerializer(TokenObtainPairSerializer):
 
     def validate(self, attrs):
         """
-        Authenticate by email + password and return JWT access/refresh tokens.
+        Authenticate by email + password and return JWT tokens.
 
-        Args:
-            attrs: Dict containing ``email`` and ``password``.
-
-        Returns:
-            Dict with ``access`` and ``refresh`` JWT strings.
-
-        Raises:
-            InvalidCredentialsError: When the email is missing or credentials
-                are invalid.
-            InactiveAccountError: When the user account exists but is inactive.
+        The refresh token is NOT included in the returned dict — the view pops
+        it out and sets it as an httpOnly cookie.  The ``_refresh`` attribute is
+        set on the serializer so the view can compute the correct max_age.
         """
         email = attrs.get("email", "").strip().lower()
         password = attrs.get("password", "")
@@ -83,29 +106,115 @@ class EmailTokenObtainPairSerializer(TokenObtainPairSerializer):
 
         user = self._find_user_for_login(email=email, password=password)
 
+        lifetime = (
+            _ADMIN_REFRESH_LIFETIME if user.is_staff else _CLIENT_REFRESH_LIFETIME
+        )
         refresh = RefreshToken.for_user(user)
+        refresh.set_exp(lifetime=lifetime)
+
+        # Store on the instance so the view can read the lifetime without re-parsing
+        self._refresh = refresh
+
         return {
-            "refresh": str(refresh),
+            "refresh": str(refresh),  # view pops this before returning to client
             "access": str(refresh.access_token),
         }
 
 
 @extend_schema(tags=["auth"])
-class SafeTokenRefreshView(TokenRefreshView):
-    """Token refresh view that returns 401 when the user no longer exists."""
+class EmailTokenObtainPairView(TokenObtainPairView):
+    """JWT login view. Returns access token in body; sets refresh token as httpOnly cookie."""
+
+    serializer_class = EmailTokenObtainPairSerializer
 
     def post(self, request, *args, **kwargs):
-        try:
-            return super().post(request, *args, **kwargs)
-        except User.DoesNotExist:
-            raise InvalidToken("Token neplatný alebo expirovaný.")
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        refresh_str: str = serializer.validated_data["refresh"]
+        access_str: str = serializer.validated_data["access"]
+        refresh_obj: RefreshToken = serializer._refresh
+
+        exp = refresh_obj.payload["exp"]
+        iat = refresh_obj.payload["iat"]
+        max_age = int(exp - iat)
+
+        response = Response({"access": access_str}, status=status.HTTP_200_OK)
+        _set_refresh_cookie(response, refresh_str, max_age=max_age)
+        return response
 
 
 @extend_schema(tags=["auth"])
-class EmailTokenObtainPairView(TokenObtainPairView):
-    """JWT token view that authenticates via email instead of username."""
+class SafeTokenRefreshView(TokenRefreshView):
+    """
+    Token refresh view.
 
-    serializer_class = EmailTokenObtainPairSerializer
+    Reads the refresh token from the httpOnly cookie (not the request body).
+    Returns the new access token in the body and rotates the refresh cookie.
+    """
+
+    def post(self, request, *args, **kwargs):
+        refresh_str = request.COOKIES.get(_COOKIE_NAME)
+        if not refresh_str:
+            raise InvalidToken("Refresh token nenájdený.")
+
+        # Inject the cookie value into request data so the parent serializer can read it
+        data = (
+            request.data.copy() if hasattr(request.data, "copy") else dict(request.data)
+        )
+        data["refresh"] = refresh_str
+
+        serializer = self.get_serializer(data=data)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except TokenError as exc:
+            raise InvalidToken(exc.args[0]) from exc
+        except User.DoesNotExist:
+            raise InvalidToken("Token neplatný alebo expirovaný.")
+
+        new_access: str = serializer.validated_data["access"]
+        # ROTATE_REFRESH_TOKENS=True → the serializer returns a new refresh token
+        new_refresh: str | None = serializer.validated_data.get("refresh")
+
+        response = Response({"access": new_access}, status=status.HTTP_200_OK)
+
+        if new_refresh:
+            try:
+                obj = RefreshToken(new_refresh)  # type: ignore[arg-type]
+                max_age = int(obj.payload["exp"] - obj.payload["iat"])
+            except Exception:
+                max_age = int(_CLIENT_REFRESH_LIFETIME.total_seconds())
+            _set_refresh_cookie(response, new_refresh, max_age=max_age)
+
+        return response
+
+
+@extend_schema(tags=["auth"])
+class LogoutView(APIView):
+    """
+    POST /api/token/logout/
+
+    Blacklists the refresh token from the httpOnly cookie and clears it.
+    Requires a valid access token in the Authorization header.
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        refresh_str = request.COOKIES.get(_COOKIE_NAME)
+        if refresh_str:
+            try:
+                token = RefreshToken(refresh_str)
+                token.blacklist()
+            except Exception:
+                # Already blacklisted or otherwise invalid — proceed with logout anyway
+                pass
+
+        response = Response(
+            {"detail": "Odhlásenie bolo úspešné."}, status=status.HTTP_200_OK
+        )
+        _delete_refresh_cookie(response)
+        return response
 
 
 @extend_schema(tags=["auth"])
@@ -122,12 +231,6 @@ class PasswordResetRequestView(APIView):
     permission_classes = [permissions.AllowAny]
 
     def post(self, request):
-        """
-        Initiate a password-reset flow for the given email address.
-
-        Always returns HTTP 200 even when the email is not registered to
-        avoid user-enumeration. Returns HTTP 429 when rate-limited.
-        """
         from ..exceptions import RateLimitExceeded, TooSoonError
         from ..password_reset_service import request_password_reset
 
@@ -138,7 +241,6 @@ class PasswordResetRequestView(APIView):
         try:
             request_password_reset(email)
         except (RateLimitExceeded, TooSoonError):
-            # Re-raise to let exception handler handle it
             raise
         except Exception:
             logger.exception(
@@ -171,22 +273,13 @@ class PasswordResetConfirmView(APIView):
     POST /api/auth/password-reset/confirm/
     Body: {"token": "<reset_token>", "new_password": "<new_password>"}
 
-    Validates the token and sets the new password.
+    Validates the token, sets the new password, and invalidates all outstanding
+    JWT refresh tokens for the user so existing sessions are terminated.
     """
 
     permission_classes = [permissions.AllowAny]
 
     def post(self, request):
-        """
-        Confirm a password reset by validating the token and setting a new password.
-
-        Args (request body):
-            token: The reset token sent to the user's email.
-            new_password: The desired new password.
-
-        Returns HTTP 200 on success, HTTP 400 when the token is invalid or
-        the password fails validation.
-        """
         from ..password_reset_service import confirm_password_reset
 
         token = request.data.get("token", "").strip()

--- a/backend/api/views/auth_views.py
+++ b/backend/api/views/auth_views.py
@@ -173,7 +173,10 @@ class SafeTokenRefreshView(TokenRefreshView):
             raise InvalidToken("Token neplatný alebo expirovaný.")
 
         new_access: str = serializer.validated_data["access"]
-        # ROTATE_REFRESH_TOKENS=True → the serializer returns a new refresh token
+        # ROTATE_REFRESH_TOKENS=True → the serializer returns a new refresh token.
+        # SimpleJWT's rotation calls set_exp() without a lifetime argument, so it
+        # always uses the global REFRESH_TOKEN_LIFETIME (30 days) regardless of the
+        # per-role lifetime we set at login.  Re-apply the correct lifetime here.
         new_refresh: str | None = serializer.validated_data.get("refresh")
 
         response = Response({"access": new_access}, status=status.HTTP_200_OK)
@@ -181,7 +184,16 @@ class SafeTokenRefreshView(TokenRefreshView):
         if new_refresh:
             try:
                 obj = RefreshToken(new_refresh)  # type: ignore[arg-type]
-                max_age = int(obj.payload["exp"] - obj.payload["iat"])
+                user_id = obj.payload.get("user_id")
+                user_obj = User.objects.get(pk=user_id) if user_id else None
+                lifetime = (
+                    _ADMIN_REFRESH_LIFETIME
+                    if (user_obj and user_obj.is_staff)
+                    else _CLIENT_REFRESH_LIFETIME
+                )
+                obj.set_exp(lifetime=lifetime)
+                new_refresh = str(obj)
+                max_age = int(lifetime.total_seconds())
             except Exception:
                 max_age = int(_CLIENT_REFRESH_LIFETIME.total_seconds())
             _set_refresh_cookie(response, new_refresh, max_age=max_age)

--- a/backend/app/settings/base.py
+++ b/backend/app/settings/base.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "corsheaders",
     "rest_framework_simplejwt",
+    "rest_framework_simplejwt.token_blacklist",
     "django_celery_beat",
     # Local apps
     "api",
@@ -231,16 +232,29 @@ VAPID_ADMIN_EMAIL = env("VAPID_ADMIN_EMAIL", "admin@example.com")
 # JWT – longer lifetimes so the PWA stays logged in across background/resume cycles.
 # Access token: 30 min (default 5 min was too short; phones throttle background
 #   refresh and the token expired before the app could refresh it).
-# Refresh token: 30 days ("remember me" for a PWA used daily).
+# Refresh token: default 30 days (overridden per user at login — admins get 1 day,
+#   clients get 30 days since they may open the app as infrequently as every 2 weeks;
+#   rotation resets the clock on each active visit so clients are never logged out
+#   while actively using the app).
 #
-# Security note: refresh tokens are stored in localStorage (no httpOnly cookie).
-# If you later enable ROTATE_REFRESH_TOKENS + BLACKLIST_AFTER_ROTATION you will
-# also need to add "rest_framework_simplejwt.token_blacklist" to INSTALLED_APPS
-# and run its migration. That would allow server-side revocation on logout.
+# Refresh tokens are stored in an httpOnly, Secure, SameSite=Lax cookie — never
+# accessible to JavaScript, eliminating the XSS exfiltration path.
+# ROTATE_REFRESH_TOKENS + BLACKLIST_AFTER_ROTATION give server-side revocation:
+# each refresh call issues a new token and blacklists the old one so a stolen token
+# becomes useless after the legitimate client refreshes once.
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=30),
+    "REFRESH_TOKEN_LIFETIME": timedelta(
+        days=30
+    ),  # default; overridden per user in login view
+    "ROTATE_REFRESH_TOKENS": True,
+    "BLACKLIST_AFTER_ROTATION": True,
 }
+
+# httpOnly cookie used to transport the refresh token.
+REFRESH_TOKEN_COOKIE_NAME = "refresh_token"
+# Restrict the cookie to token endpoints so it isn't sent on every API request.
+REFRESH_TOKEN_COOKIE_PATH = "/api/token"
 
 # Django REST Framework
 REST_FRAMEWORK = {

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,17 +2,21 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
+COOKIE_NAME = "refresh_token"
+
 
 @pytest.mark.django_db
 class TestAuthentication:
     def test_obtain_token_success(self, api_client, user):
-        """Test able to obtain JWT pair"""
+        """Test able to obtain JWT access token; refresh token is set as cookie."""
         url = reverse("token_obtain_pair")
         data = {"email": "client@example.com", "password": "client123"}
         response = api_client.post(url, data)
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
-        assert "refresh" in response.data
+        # Refresh token lives in the httpOnly cookie, not the body
+        assert "refresh" not in response.data
+        assert COOKIE_NAME in response.cookies
 
     def test_obtain_token_failure(self, api_client, user):
         """Test invalid credentials fail"""
@@ -22,31 +26,27 @@ class TestAuthentication:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_refresh_token(self, api_client, user):
-        """Test refreshing token"""
-        # Get token first
-        url = reverse("token_obtain_pair")
-        data = {"email": "client@example.com", "password": "client123"}
-        response = api_client.post(url, data)
-        refresh_token = response.data["refresh"]
+        """Test refreshing token via cookie."""
+        # Login — cookie is set on api_client automatically
+        api_client.post(
+            reverse("token_obtain_pair"),
+            {"email": "client@example.com", "password": "client123"},
+        )
 
-        # Refresh it
+        # Refresh uses the cookie
         refresh_url = reverse("token_refresh")
-        response = api_client.post(refresh_url, {"refresh": refresh_token})
+        response = api_client.post(refresh_url)
         assert response.status_code == status.HTTP_200_OK
         assert "access" in response.data
 
     def test_refresh_token_returns_401_when_user_deleted(self, api_client, user):
         """Token refresh must return 401 (not 500) when the user no longer exists."""
-        url = reverse("token_obtain_pair")
-        response = api_client.post(
-            url, {"email": "client@example.com", "password": "client123"}
+        api_client.post(
+            reverse("token_obtain_pair"),
+            {"email": "client@example.com", "password": "client123"},
         )
-        assert response.status_code == status.HTTP_200_OK
-        assert "refresh" in response.data
-        refresh_token = response.data["refresh"]
 
         user.delete()
 
-        refresh_url = reverse("token_refresh")
-        response = api_client.post(refresh_url, {"refresh": refresh_token})
+        response = api_client.post(reverse("token_refresh"))
         assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/tests/test_token_refresh.py
+++ b/backend/tests/test_token_refresh.py
@@ -3,65 +3,54 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 from rest_framework import status
 
+COOKIE_NAME = "refresh_token"
+
 
 @pytest.mark.django_db
 class TestTokenRefresh:
     """Tests for JWT token refresh functionality"""
 
+    def _login(self, api_client, email, password):
+        return api_client.post(
+            reverse("token_obtain_pair"), {"email": email, "password": password}
+        )
+
     def test_refresh_token_success(self, api_client):
-        """Valid refresh token returns new access token"""
-        # Create user and get tokens
+        """Valid refresh cookie returns new access token."""
         User.objects.create_user(
             "client@example.com", "client@example.com", "client123"
         )
 
-        # Get initial token pair
-        auth_url = reverse("token_obtain_pair")
-        auth_resp = api_client.post(
-            auth_url, {"email": "client@example.com", "password": "client123"}
-        )
-
+        auth_resp = self._login(api_client, "client@example.com", "client123")
         assert auth_resp.status_code == status.HTTP_200_OK
-        refresh_token = auth_resp.data["refresh"]
+        assert COOKIE_NAME in auth_resp.cookies
 
-        # Use refresh token to get new access token
-        refresh_url = reverse("token_refresh")
-        refresh_resp = api_client.post(refresh_url, {"refresh": refresh_token})
+        refresh_resp = api_client.post(reverse("token_refresh"))
 
         assert refresh_resp.status_code == status.HTTP_200_OK
         assert "access" in refresh_resp.data
         assert refresh_resp.data["access"] != auth_resp.data["access"]
 
     def test_refresh_token_invalid(self, api_client):
-        """Invalid refresh token returns error"""
-        refresh_url = reverse("token_refresh")
-        response = api_client.post(refresh_url, {"refresh": "invalid_token_here"})
+        """Invalid refresh cookie returns 401."""
+        api_client.cookies[COOKIE_NAME] = "invalid_token_here"
+        response = api_client.post(reverse("token_refresh"))
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_access_token_works_after_refresh(self, api_client):
-        """New access token from refresh works for authenticated requests"""
-        # Create user and get tokens
+        """New access token from refresh works for authenticated requests."""
         User.objects.create_user(
             "client@example.com", "client@example.com", "client123"
         )
 
-        # Get initial tokens
-        auth_url = reverse("token_obtain_pair")
-        auth_resp = api_client.post(
-            auth_url, {"email": "client@example.com", "password": "client123"}
-        )
-        refresh_token = auth_resp.data["refresh"]
+        self._login(api_client, "client@example.com", "client123")
 
-        # Refresh to get new access token
-        refresh_url = reverse("token_refresh")
-        refresh_resp = api_client.post(refresh_url, {"refresh": refresh_token})
+        refresh_resp = api_client.post(reverse("token_refresh"))
         new_access_token = refresh_resp.data["access"]
 
-        # Use new access token for authenticated request
         api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {new_access_token}")
-        profile_url = reverse("user-profile")
-        profile_resp = api_client.get(profile_url)
+        profile_resp = api_client.get(reverse("user-profile"))
 
         assert profile_resp.status_code == status.HTTP_200_OK
         assert profile_resp.data["email"] == "client@example.com"

--- a/docs/ARCHITECTURE_AND_FLOWS.md
+++ b/docs/ARCHITECTURE_AND_FLOWS.md
@@ -1,0 +1,590 @@
+# Architektura a dolezite flows
+
+Tato sekcia popisuje, ako spolu komunikuju hlavne casti aplikacie Zdravy Projekt. Je pisana ako orientacna mapa pre vyvoj: kde hladat logiku, kadial tecu data, co je synchronne, co bezia Celery tasky a ktore moduly maju na seba najvacsi dopad.
+
+## Rychly mentalny model
+
+Aplikacia je full-stack system pre objednavanie jedal, spravu klientov, jedalnickov, gramaze, reportov a notifikacii.
+
+- Frontend je React/Vite PWA s oddelenou klientskou a adminskou vetvou.
+- Backend je Django + Django REST Framework API.
+- PostgreSQL je zdroj pravdy pre pouzivatelov, objednavky, nastavenia, jedalnicky, sviatky a push subscriptions.
+- Redis sluzi ako Celery broker/cache a na docasne ulozenie vygenerovanych report suborov.
+- Celery worker spracovava reporty, auto-objednavky, denne email reporty a push notifikacie.
+- Celery Beat planuje ulohy podla `GlobalSettings`; schedule sa synchronizuje cez Django signals.
+
+## Systemovy diagram
+
+```mermaid
+flowchart LR
+    Client[Klient / Admin v prehliadaci] -->|React Router| Frontend[React PWA<br/>frontend/src]
+    Frontend -->|JWT Bearer API calls| API[Django REST API<br/>backend/api/views]
+    Frontend -->|Service worker| SW[public/sw.js]
+    SW -->|Web Push event| Client
+
+    API -->|ORM| DB[(PostgreSQL)]
+    API -->|cache / task result bytes| Redis[(Redis)]
+    API -->|enqueue async work| Celery[Celery worker]
+    Beat[Celery Beat<br/>django-celery-beat] -->|scheduled tasks| Celery
+    Celery -->|ORM| DB
+    Celery -->|cache generated files| Redis
+    Celery -->|SMTP| Mail[SMTP / Mailhog in dev]
+    Celery -->|VAPID Web Push| PushProvider[Browser push service]
+    PushProvider --> Client
+
+    API -->|health / metrics hooks| Observability[Observability<br/>Alloy/Sentry/Prometheus]
+```
+
+## Runtime a deployment komponenty
+
+```mermaid
+flowchart TB
+    subgraph DockerCompose[compose/dev.yml]
+        FrontendDev[frontend<br/>npm run dev<br/>:3000]
+        Backend[backend<br/>Django runserver<br/>:8000]
+        DB[(db<br/>postgres:15)]
+        Redis[(redis:7)]
+        Worker[celery worker]
+        Beat[celery-beat<br/>DatabaseScheduler]
+        Mailhog[mailhog<br/>SMTP :1026<br/>UI :8026]
+    end
+
+    FrontendDev --> Backend
+    Backend --> DB
+    Backend --> Redis
+    Worker --> DB
+    Worker --> Redis
+    Worker --> Mailhog
+    Beat --> Redis
+    Beat --> DB
+```
+
+V staging/production compose stackoch frontend/backend bezia ako kontajnery za reverse proxy vrstvou. Development stack navyse seeduje data a inicializuje role pri starte backendu.
+
+## Hlavne moduly
+
+```mermaid
+flowchart LR
+    subgraph FE[Frontend]
+        App[App.tsx<br/>routing + providers]
+        Auth[context/auth.tsx<br/>JWT, refresh, apiFetch]
+        ClientUI[pages/client<br/>objednavky, profil, menu]
+        AdminUI[pages/admin<br/>klienti, jedalnicky, reporty, nastavenia]
+        PWA[PWAContext + service worker<br/>install/update/push]
+    end
+
+    subgraph API[Backend API]
+        Urls[api/urls.py<br/>router + endpointy]
+        Views[api/views/*<br/>HTTP boundary]
+        Serializers[serializers*.py<br/>validation + shape]
+        Services[api/services/*<br/>business logic]
+        Tasks[api/tasks.py<br/>async jobs]
+        Signals[api/signals.py<br/>schedule/cache sync]
+        Exporters[api/exporters/*<br/>PDF/XLSX]
+        Models[api/models.py<br/>domain model]
+    end
+
+    App --> Auth
+    App --> ClientUI
+    App --> AdminUI
+    App --> PWA
+    Auth -->|apiFetch| Urls
+    ClientUI -->|orders, profile, meal-plans, holidays| Urls
+    AdminUI -->|admin endpoints| Urls
+    Urls --> Views
+    Views --> Serializers
+    Views --> Services
+    Services --> Models
+    Views --> Exporters
+    Views --> Tasks
+    Tasks --> Services
+    Tasks --> Exporters
+    Signals --> Tasks
+    Signals --> Models
+```
+
+Prakticke pravidlo: HTTP detaily patria do `api/views/*`, tvar dat a validacia do serializerov, domenova logika do `api/services/*`, asynchronna praca do `api/tasks.py`.
+
+## API mapa
+
+| Oblast | Frontend pouziva | Backend endpoint / view | Hlavna logika |
+| --- | --- | --- | --- |
+| Login a refresh | `LoginPage`, `AuthProvider` | `POST /api/token/`, `POST /api/token/refresh/` | `auth_views.EmailTokenObtainPairSerializer`, SimpleJWT |
+| Profil klienta | `AuthProvider.fetchUserProfile`, `ProfilePage` | `/api/user/profile/` | `UserProfileViewSet`, `UserProfileSerializer` |
+| Objednavky | `useOrder`, `OrderPage` | `/api/orders/`, `/api/orders/by-date/{date}/` | `DailyOrderViewSet`, `DailyOrderSerializer` |
+| Planovane objednavky | `HomePage` / klientsky prehlad | `/api/orders/planned/` | `OrderService.get_planned_orders` |
+| Mesacny suhrn | klientsky dashboard | `/api/orders/planned/monthly-summary/` | `OrderService.monthly_summary` |
+| Admin klienti | admin UI | `/api/admin/users/` | `AdminUserViewSet`, user/settings/profile modely |
+| System settings | `SystemSettings`, klientsky deadline read | `/api/admin/global-settings/` | `GlobalSettingsViewSet`, cache, signals |
+| Jedalnicky | `MealPlanCalendar`, `MealPlanEditor`, `MenuPage` | `/api/admin/meal-plans/`, `/api/meal-plans/` | `DailyMealPlanViewSet`, `MealPlanService` |
+| Template jedal | admin UI | `/api/admin/meal-templates/` | `MealTemplateViewSet` |
+| Typy porcii | klient aj admin | `/api/admin/portion-types/` | `PortionTypeViewSet` |
+| Sviatky | klient aj admin | `/api/holidays/`, `/api/admin/holidays/` | `HolidayListViewSet`, `AdminHolidayViewSet` |
+| Reporty | admin dashboard | `/api/admin/summary/*` | `AdminSummaryViewSet`, `ReportService`, exporters |
+| Async reporty | admin report task UI | `/api/admin/report-tasks/` | `ReportTaskViewSet`, Celery tasks |
+| Auto orders | admin manual trigger + Beat | `/api/admin/trigger-auto-orders/` | `apply_auto_orders` |
+| Push | PWA + admin UI | `/api/push/*`, `/api/admin/push/send/` | `PushNotificationService`, Celery reminders |
+
+## Domenovy model
+
+```mermaid
+erDiagram
+    User ||--|| UserProfile : has
+    User ||--|| ClientSettings : has
+    User ||--o{ DailyOrder : places
+    User ||--o{ DailyMealPlan : creates
+    User ||--o{ PushSubscription : owns
+
+    ClientSettings }o--o{ Diet : visible_diets
+    Diet ||--o{ MealTemplate : tags
+
+    DailyMealPlan ||--o{ MealPlanItem : contains
+    DailyMealPlan ||--o{ EnrolledCount : has
+    MealTemplate ||--o{ MealPlanItem : selected_as
+    PortionType ||--o{ EnrolledCount : counted_as
+
+    DailyOrder {
+        int id
+        int user_id
+        date date
+        string status
+        json data
+        bool is_auto
+        datetime created_at
+        datetime updated_at
+    }
+
+    UserProfile {
+        int user_id
+        string company_name
+        string client_type
+        string api_identifier
+        bool onboarding_completed
+    }
+
+    ClientSettings {
+        int user_id
+        json visible_menus
+        json visible_meals
+        text admin_order_note
+    }
+
+    GlobalSettings {
+        time deadline_breakfast
+        time deadline_lunch
+        time deadline_olovrant
+        bool deadline_breakfast_is_day_before
+        bool deadline_lunch_is_day_before
+        bool deadline_olovrant_is_day_before
+        json report_email_recipients
+    }
+
+    MealTemplate {
+        string category
+        string name
+        decimal base_weight_grams
+        string menu_variant
+        bool is_active
+    }
+
+    PortionType {
+        string name
+        decimal coefficient
+        int sort_order
+        bool is_active
+    }
+
+    DailyMealPlan {
+        date date
+        text notes
+        int created_by_id
+    }
+
+    MealPlanItem {
+        int meal_plan_id
+        int template_id
+        string category
+        string menu_variant
+    }
+
+    EnrolledCount {
+        int meal_plan_id
+        int portion_type_id
+        int count
+    }
+
+    Holiday {
+        date date
+        string reason
+    }
+
+    PushSubscription {
+        int user_id
+        text endpoint
+        text p256dh
+        text auth
+    }
+```
+
+### Dolezite datove tvary
+
+`DailyOrder.data` je JSON a podporuje dve historicke tvary:
+
+- flat: `{"lunch": {"menuCounts": {"A": 5}}}`
+- nested by portion category: `{"lunch": {"Dospely": {"menuCounts": {"A": 5}, "diets": {...}}}}`
+
+Backendove agregacie v `OrderService`, `ReportService` a `auto_order_service` s tym pocitaju. Pri novom kode je vhodne drzat nested tvar, pretoze frontend pracuje cez kategorie/typy porcii.
+
+`DailyOrder` ma `unique_together = ["user", "date"]`. Serializer/API preto funguje ako submit alebo replace objednavky pre jeden den. `is_auto=True` oznacuje objednavku vytvorenu po deadline z poslednej ne-prazdnej objednavky.
+
+## Flow: autentifikacia a nacitanie profilu
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant FE as LoginPage/AuthProvider
+    participant API as /api/token/
+    participant JWT as SimpleJWT serializer
+    participant Profile as /api/user/profile/
+    participant DB as PostgreSQL
+
+    User->>FE: zada email + heslo
+    FE->>API: POST email/password
+    API->>JWT: EmailTokenObtainPairSerializer.validate
+    JWT->>DB: najdi aktivneho usera podla emailu
+    DB-->>JWT: User
+    JWT-->>API: access + refresh token
+    API-->>FE: JWT tokeny
+    FE->>FE: ulozi tokeny do localStorage
+    FE->>Profile: GET /api/user/profile/ s Bearer tokenom
+    Profile->>DB: User + UserProfile + ClientSettings
+    DB-->>Profile: profil a nastavenia
+    Profile-->>FE: user payload
+    FE->>FE: cache profilu + route guard
+```
+
+`AuthProvider.apiFetch` pridava Bearer token, synchronizuje offset serveroveho casu z HTTP `Date` headera a pri `401/403` sa pokusi refreshnut access token.
+
+## Flow: klient vytvori objednavku
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant UI as OrderPage/useOrder
+    participant Local as localStorage
+    participant API as DailyOrderViewSet
+    participant Ser as DailyOrderSerializer
+    participant DB as DailyOrder
+
+    Client->>UI: vyberie datum a jedla
+    UI->>API: GET /api/orders/by-date/{date}/
+    API->>DB: order pre usera a datum
+    alt objednavka existuje
+        DB-->>API: DailyOrder
+        API-->>UI: server data
+        UI->>Local: ulozi server-authoritative stav
+    else neexistuje
+        API-->>UI: {"data": {}}
+        UI->>Local: pouzije lokalny draft alebo prazdny tvar
+    end
+
+    Client->>UI: upravi pocty menu/diet
+    UI->>Local: draft `order_YYYY-MM-DD`
+    Client->>UI: submit
+    UI->>API: POST /api/orders/ {date, status, data}
+    API->>Ser: validacia + create/update
+    Ser->>DB: update_or_create by user+date
+    DB-->>Ser: DailyOrder
+    API-->>UI: ulozena objednavka
+    UI->>Local: status submitted
+```
+
+Dolezite pravidla:
+
+- Drafty sa neautosavuju na backend; preziju refresh v `localStorage`.
+- Server je autorita po nacitani existujucej objednavky.
+- Frontend kontroluje deadline cez `OrderService.checkDeadline` s casom korigovanym podla servera.
+- Backend pri `POST /api/orders/` viaze objednavku na aktualneho usera; staff moze tvorit objednavku za klienta cez `user_id`.
+
+## Flow: planovane objednavky a auto-predikcia
+
+```mermaid
+sequenceDiagram
+    participant FE as Home/client dashboard
+    participant API as PlannedOrdersViewSet
+    participant Service as OrderService
+    participant Auto as auto_order_service helpers
+    participant DB as DailyOrder + Holiday
+
+    FE->>API: GET /api/orders/planned/
+    API->>Service: get_planned_orders(user, visible_meals)
+    Service->>DB: najblizsie Holidays
+    Service->>Service: vypocitaj 5 pracovnych dni
+    Service->>DB: existujuce objednavky pre tieto dni
+    Service->>Auto: _last_non_empty_order(user, first_day)
+    Auto->>DB: posledna neprazdna objednavka pred planom
+    loop kazdy pracovny den
+        Service->>Service: existuje order? spocitaj totaly
+        Service->>Auto: ak chyba, _build_auto_data(template, visible_meals)
+    end
+    Service-->>API: statusy + predictedData
+    API-->>FE: planovany tyzden
+```
+
+Tento flow je dolezity, lebo pouziva rovnaku predstavu "poslednej neprazdnej objednavky" ako auto-order mechanizmus.
+
+## Flow: Celery auto-orders po deadline
+
+```mermaid
+sequenceDiagram
+    participant Settings as GlobalSettings
+    participant Signal as api.signals
+    participant Beat as Celery Beat
+    participant Task as apply_auto_orders_task
+    participant Service as apply_auto_orders
+    participant DB as PostgreSQL
+
+    Settings->>Signal: post_save
+    Signal->>Beat: create/update PeriodicTask auto-order-daily
+    Note over Signal,Beat: cas = max(deadline_breakfast, deadline_lunch, deadline_olovrant), Mon-Fri
+
+    Beat->>Task: spusti po poslednom deadline
+    Task->>Service: apply_auto_orders(target_date?)
+    Service->>DB: aktivni non-staff klienti + ClientSettings
+    Service->>DB: kto uz ma objednavku pre target_date
+    Service->>DB: posledne neprazdne objednavky pred target_date
+    loop kazdy klient
+        Service->>Service: respektuj visible_meals
+        Service->>DB: atomic get_or_create DailyOrder
+    end
+    Service-->>Task: created/skipped summary
+```
+
+Idempotencia stoji na `unique_together(user, date)`, `transaction.atomic()` a zachyteni `IntegrityError`, takze duplicitne tasky by nemali vytvorit duplicitne objednavky.
+
+## Flow: admin vytvori jedalnicek a gramage report
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant UI as MealPlanEditor
+    participant API as DailyMealPlanViewSet
+    participant Service as MealPlanService
+    participant DB as DailyMealPlan + items + counts
+    participant Export as PDF/XLSX exporter
+
+    Admin->>UI: vyberie datum
+    UI->>API: GET /api/admin/meal-plans/by-date/?date=YYYY-MM-DD
+    API->>DB: plan + items + enrolled counts
+    DB-->>API: plan alebo exists=false
+    API-->>UI: editor state
+
+    Admin->>UI: vyberie template jedal a pocty porcii
+    UI->>API: POST/PUT /api/admin/meal-plans/
+    API->>Service: create_or_replace_plan(date, items, enrolled, notes, user)
+    Service->>DB: atomic upsert planu
+    Service->>DB: delete + recreate MealPlanItem
+    Service->>DB: delete + recreate EnrolledCount
+    DB-->>API: ulozeny plan
+    API-->>UI: plan response
+
+    Admin->>UI: gramage/export
+    UI->>API: GET gramage-report/export-pdf/export-xlsx
+    API->>Service: calculate_gramage(plan)
+    Service->>DB: templates + portion coefficients
+    Service-->>API: structured gramage
+    API->>Export: volitelne PDF/XLSX
+    API-->>UI: JSON alebo file download
+```
+
+Gramaz sa rata vzorcom:
+
+```text
+final_weight = MealTemplate.base_weight_grams * PortionType.coefficient * EnrolledCount.count
+```
+
+`MealPlanService.gramage_dashboard` navyse kombinuje objednavky klientov s jedalnickom, menu variantmi, dietami a typmi porcii pre admin dashboard.
+
+## Flow: synchronne a asynchronne reporty
+
+```mermaid
+flowchart TB
+    AdminUI[Admin dashboard] --> Sync[Sync endpoints<br/>/api/admin/summary/daily-report-pdf<br/>/daily-report-xlsx]
+    Sync --> ReportService[ReportService.get_orders_for_export<br/>or direct DailyOrder query]
+    ReportService --> Exporters[PDFReportExporter / XLSXReportExporter]
+    Exporters --> File[HTTP file response]
+
+    AdminUI --> Async[POST /api/admin/report-tasks/]
+    Async --> CeleryTask[generate_report_pdf_task<br/>generate_report_xlsx_task]
+    CeleryTask --> Exporters
+    CeleryTask --> RedisCache[(Redis cache<br/>report_task:task_id)]
+    AdminUI --> Poll[GET /api/admin/report-tasks/{id}/]
+    Poll --> CeleryResult[AsyncResult status]
+    AdminUI --> Download[GET /api/admin/report-tasks/{id}/download/]
+    Download --> RedisCache
+    RedisCache --> File2[HTTP file response]
+```
+
+Synchronne endpointy su jednoduchsie a vhodne pre mensie reporty. Async report tasky su bezpecnejsie pri vacsich exportoch, pretoze generovanie bezi mimo request threadu a vysledne bytes su docasne ulozene v cache pod klucom konkretneho tasku.
+
+## Flow: denne email reporty
+
+```mermaid
+sequenceDiagram
+    participant Admin as Admin settings
+    participant Settings as GlobalSettings
+    participant Signal as api.signals
+    participant Beat as Celery Beat
+    participant Task as send_daily_report_task
+    participant Cmd as management command send_order_report
+    participant Email as SMTP
+
+    Admin->>Settings: zmeni deadlines alebo recipients
+    Settings->>Signal: post_save
+    Signal->>Beat: sync daily-report-breakfast
+    Signal->>Beat: sync daily-report-all-meals
+    Note over Signal,Beat: tasks vzniknu len ked report_email_recipients nie je prazdne
+
+    Beat->>Task: breakfast deadline -> meals=["breakfast"]
+    Beat->>Task: olovrant deadline -> meals=["breakfast","lunch","olovrant"]
+    Task->>Cmd: call_command send_order_report --date --meals
+    Cmd->>Email: odosle report prijemcom
+```
+
+## Flow: push notifikacie
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant FE as PWA / NotificationGuard
+    participant API as push views
+    participant DB as PushSubscription
+    participant Beat as Celery Beat
+    participant Task as push reminder tasks
+    participant Service as PushNotificationService
+    participant Push as Browser push service
+
+    Client->>FE: povoli notifikacie
+    FE->>API: GET /api/push/vapid-public-key/
+    API-->>FE: public VAPID key
+    FE->>API: POST /api/push/subscribe/ endpoint + keys
+    API->>DB: ulozi PushSubscription
+
+    Beat->>Task: 15 min pred deadline alebo nedela 17:00
+    Task->>DB: najdi subscribed aktivnych non-staff userov
+    Task->>Service: send_to_user(...)
+    Service->>DB: subscriptions usera
+    Service->>Push: webpush(payload, VAPID)
+    alt subscription stale 404/410
+        Service->>DB: delete PushSubscription
+    else delivered
+        Push-->>Client: push event
+    end
+```
+
+Push reminders sa grupuju podla rovnakeho deadline casu a `is_day_before` flagu, aby pouzivatel nedostal viac duplicitnych notifikacii naraz.
+
+## Komunikacia modulov
+
+```mermaid
+graph TD
+    AuthProvider -->|apiFetch + token refresh| ApiViews
+    UseOrder[useOrder] -->|orders/by-date, orders POST| OrderViews
+    UseOrder -->|deadline settings| SettingsViews
+    UseOrder -->|portion types| MealPlanViews
+    UseOrder -->|holidays| HolidayViews
+
+    AdminMealPlan[Admin meal plan UI] --> MealPlanViews
+    AdminReports[Admin report UI] --> ReportViews
+    AdminReports --> ReportTaskViews
+    AdminSettings[SystemSettings] --> SettingsViews
+    AdminPush[PushNotifications admin] --> PushViews
+
+    OrderViews --> OrderService
+    OrderViews --> AutoOrderService
+    MealPlanViews --> MealPlanService
+    ReportViews --> ReportService
+    ReportViews --> Exporters
+    ReportTaskViews --> Tasks
+    Tasks --> ReportService
+    Tasks --> AutoOrderService
+    Tasks --> PushNotificationService
+    SettingsViews --> Signals
+    Signals --> CeleryBeat[(django-celery-beat tables)]
+```
+
+Najdolezitejsie hranice:
+
+- `OrderService` by mal zostat miestom pre objednavkove vypocty, nie komponenty.
+- `MealPlanService` je zdroj pravdy pre gramaz a daily meal plan upsert.
+- `ReportService` agreguje objednavkove data pre dashboard/reporty.
+- `PushNotificationService` izoluje `pywebpush` a mazanie starych subscriptions.
+- `signals.py` je infrastruktura pre schedule/cache sync; nema by obsahovat biznis rozhodnutia, ktore patria do service vrstvy.
+
+## Cache, scheduling a invalidacie
+
+```mermaid
+flowchart LR
+    GlobalSettingsSave[GlobalSettings save] --> ScheduleSync[_sync_auto_order_schedule<br/>_sync_daily_report_schedule<br/>_sync_push_reminder_schedule<br/>_sync_weekly_reminder_schedule]
+    ScheduleSync --> BeatTables[(django_celery_beat<br/>PeriodicTask/CrontabSchedule)]
+    GlobalSettingsSave --> ClearGlobalCache[clear_global_settings_cache]
+
+    ClientSettingsSave[ClientSettings save] --> DefaultDiets[set default visible_diets<br/>pri novych settings]
+    ClientSettingsSave --> ClearClientCache[clear_client_settings_cache(user_id)]
+
+    DietSaveDelete[Diet save/delete] --> ClearDietCache[clear_diet_list_cache]
+
+    DailyStats[Admin daily-stats] --> StatsCache[5 min cache]
+    AsyncReports[Async report tasks] --> ReportCache[Redis cache<br/>1 hodina]
+```
+
+## Testovacia mapa
+
+Existuju dve vrstvy backend testov:
+
+- `backend/tests/*`: starsie alebo sirsie backend testy pre views, services, security, reports, orders, push, auto-orders.
+- `backend/api/tests/*`: strukturovane unit/integration/e2e testy pre API spravanie.
+
+Frontend testy su vo `frontend/src/__tests__` a pri niektorych komponentoch/pages priamo vedla suboru.
+
+Pre zmeny s vyssim rizikom odporucane testy:
+
+| Zmena | Co spustit |
+| --- | --- |
+| Order submit, planned orders, auto orders | `pytest api/tests/integration/test_order_api.py api/tests/integration/test_auto_orders.py tests/test_auto_orders.py` |
+| Deadline alebo settings | `pytest tests/test_orders.py tests/test_startup_sync.py tests/test_push_notifications.py` |
+| Reporty/exporty | `pytest tests/test_report_service.py tests/test_report_email.py tests/test_exporters.py api/tests/integration/test_report_async.py` |
+| Auth/reset/tokeny | `pytest api/tests/integration/test_auth_api.py tests/test_auth.py tests/test_password_reset.py tests/test_token_refresh.py` |
+| Frontend objednavky | `npm test -- OrderService OrderPage` vo `frontend/` |
+| Global frontend sanity | `npm run lint && npm run build` vo `frontend/` |
+
+## Miesta so zvysenou pozornostou
+
+- `DailyOrder.data` ma historicky viac tvarov. Pri refaktoringu treba zachovat podporu flat aj nested shape alebo spravit migraciu.
+- `GlobalSettings` je singleton-like model. Zmena fields v settings moze ovplyvnit Celery Beat schedules, cache aj frontend deadline logiku.
+- `ReportTaskViewSet.download` zavisi od Celery resultu a cache key. Zmena timeoutu alebo backendu cache moze ovplyvnit dostupnost downloadu.
+- Auto-orders sa spustaju po najneskorsom deadline. Ak sa prida novy meal type, treba upravit `signals.py`, `tasks.py`, `OrderService`, frontend `OrderService` a report agregacie.
+- Frontend `useOrder` pouziva localStorage ako draft vrstvu. Zmeny v datovom tvare objednavky musia riesit migraciu/normalizaciu cez `OrderService.enforceStructure`.
+- Push subscriptions su per-device/per-browser. Chybove statusy 404/410 sa mazu automaticky; ine push chyby su iba logovane.
+
+## Kam pridavat novu logiku
+
+```mermaid
+flowchart TD
+    Need[Chcem pridat novu funkcionalitu] --> IsHTTP{Je to HTTP endpoint?}
+    IsHTTP -->|ano| View[api/views/* + serializer]
+    IsHTTP -->|nie| IsBusiness{Je to domenove pravidlo?}
+    IsBusiness -->|ano| Service[api/services/*]
+    IsBusiness -->|nie| IsAsync{Bezi to mimo requestu?}
+    IsAsync -->|ano| Task[api/tasks.py + pripadne signal/schedule]
+    IsAsync -->|nie| Utility[utils/cache/exporter podla zodpovednosti]
+
+    View --> CallsService[View vola service]
+    Service --> Models[Service pracuje s modelmi]
+    Task --> CallsService
+    Task --> Exporter[ak generuje subor, vola exporter]
+```
+
+## Zhrnutie architektury
+
+System dava zmysel: ma jasne oddelene frontend routy, backend viewsety, service vrstvy a async ulohy. Najsilnejsie moduly su objednavky, jedalnicky/gramaz, reporty a notifikacie. Najvacsi dopad pri zmenach maju `DailyOrder.data`, `GlobalSettings` deadlines a Celery Beat synchronizacia, pretoze prepajaju frontend, API, background joby a reportovanie.

--- a/frontend/src/context/auth.tsx
+++ b/frontend/src/context/auth.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useRef,
 } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -43,7 +44,7 @@ interface AuthContextType {
   token: string | null;
   isLoading: boolean;
   login: (accessToken: string) => Promise<User | null>;
-  logout: () => void;
+  logout: () => Promise<void>;
   isAuthenticated: boolean;
   refreshToken: () => Promise<boolean>;
   apiFetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -98,6 +99,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     !!storedToken && !cachedProfile,
   );
   const navigate = useNavigate();
+  // Single in-flight refresh promise shared across all callers.
+  // With ROTATE_REFRESH_TOKENS+BLACKLIST_AFTER_ROTATION, two concurrent refresh
+  // calls using the same cookie cause the second to get 401 and trigger a spurious
+  // logout.  Deduplicating here ensures only one network request is in-flight at a
+  // time — any concurrent caller awaits the same promise instead of racing.
+  const refreshInFlight = useRef<Promise<boolean> | null>(null);
 
   // Logout: blacklist the server-side refresh token cookie, then clear local state.
   const logout = useCallback(async () => {
@@ -129,34 +136,45 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   // Refresh access token using the httpOnly refresh cookie.
   // The browser sends the cookie automatically — no token in the request body.
   const refreshToken = useCallback(async (): Promise<boolean> => {
-    try {
-      const response = await fetch(`${API_URL}/token/refresh/`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include", // sends the httpOnly refresh cookie
-      });
+    // Return the in-flight promise if a refresh is already running so concurrent
+    // callers (setInterval, visibilitychange, apiFetch 401) share one request.
+    if (refreshInFlight.current) return refreshInFlight.current;
 
-      if (response.ok) {
-        const data = await response.json();
-        localStorage.setItem("access_token", data.access);
-        setToken(data.access);
-        return true;
-      } else if (response.status === 401 || response.status === 403) {
-        // Refresh cookie is invalid or blacklisted — session is truly over
-        logout();
+    const doRefresh = async (): Promise<boolean> => {
+      try {
+        const response = await fetch(`${API_URL}/token/refresh/`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include", // sends the httpOnly refresh cookie
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          localStorage.setItem("access_token", data.access);
+          setToken(data.access);
+          return true;
+        } else if (response.status === 401 || response.status === 403) {
+          // Refresh cookie is invalid or blacklisted — session is truly over
+          await logout();
+          return false;
+        } else {
+          // Transient server error (e.g. 500/502). Do NOT log the user out.
+          console.warn("Token refresh failed with non-auth status:", response.status);
+          return false;
+        }
+      } catch (error) {
+        // Network error — do NOT log the user out; the cookie is still valid.
+        if (!isNetworkFetchError(error)) {
+          console.error("Token refresh failed with unexpected error:", error);
+        }
         return false;
-      } else {
-        // Transient server error (e.g. 500/502). Do NOT log the user out.
-        console.warn("Token refresh failed with non-auth status:", response.status);
-        return false;
+      } finally {
+        refreshInFlight.current = null;
       }
-    } catch (error) {
-      // Network error — do NOT log the user out; the cookie is still valid.
-      if (!isNetworkFetchError(error)) {
-        console.error("Token refresh failed with unexpected error:", error);
-      }
-      return false;
-    }
+    };
+
+    refreshInFlight.current = doRefresh();
+    return refreshInFlight.current;
   }, [logout]);
 
   // Custom fetch wrapper that handles auth headers and token refresh

--- a/frontend/src/context/auth.tsx
+++ b/frontend/src/context/auth.tsx
@@ -42,7 +42,7 @@ interface AuthContextType {
   user: User | null;
   token: string | null;
   isLoading: boolean;
-  login: (token: string, refresh: string) => Promise<User | null>;
+  login: (accessToken: string) => Promise<User | null>;
   logout: () => void;
   isAuthenticated: boolean;
   refreshToken: () => Promise<boolean>;
@@ -99,60 +99,59 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   );
   const navigate = useNavigate();
 
-  // Logout function
-  const logout = useCallback(() => {
+  // Logout: blacklist the server-side refresh token cookie, then clear local state.
+  const logout = useCallback(async () => {
+    const currentToken = localStorage.getItem("access_token");
+    if (currentToken) {
+      try {
+        await fetch(`${API_URL}/token/logout/`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${currentToken}` },
+          credentials: "include",
+        });
+      } catch {
+        // Network failure — proceed with local cleanup regardless
+      }
+    }
+
     localStorage.removeItem("access_token");
-    localStorage.removeItem("refresh_token");
     localStorage.removeItem(CACHED_PROFILE_KEY);
-    // Legacy: also clear sessionStorage in case old sessions stored tokens there
+    // Legacy: clear any old refresh tokens that may have been stored in prior versions
+    localStorage.removeItem("refresh_token");
     sessionStorage.removeItem("access_token");
     sessionStorage.removeItem("refresh_token");
-    // Clear per-user order data so next user starts fresh
     clearOrderLocalStorage();
     setToken(null);
     setUser(null);
     navigate("/login");
   }, [navigate]);
 
-  // Refresh access token using refresh token
+  // Refresh access token using the httpOnly refresh cookie.
+  // The browser sends the cookie automatically — no token in the request body.
   const refreshToken = useCallback(async (): Promise<boolean> => {
-    const refresh = localStorage.getItem("refresh_token");
-    if (!refresh) {
-      logout();
-      return false;
-    }
-
     try {
       const response = await fetch(`${API_URL}/token/refresh/`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refresh }),
+        credentials: "include", // sends the httpOnly refresh cookie
       });
 
       if (response.ok) {
         const data = await response.json();
         localStorage.setItem("access_token", data.access);
         setToken(data.access);
-        // If the backend rotates refresh tokens, update it here
-        if (data.refresh) {
-          localStorage.setItem("refresh_token", data.refresh);
-        }
         return true;
       } else if (response.status === 401 || response.status === 403) {
-        // Server explicitly rejected the refresh token — session is truly invalid,
-        // log the user out.
+        // Refresh cookie is invalid or blacklisted — session is truly over
         logout();
         return false;
       } else {
-        // Transient server error (e.g. 500/502). Do NOT log the user out so the
-        // app can retry later without destroying a valid session.
+        // Transient server error (e.g. 500/502). Do NOT log the user out.
         console.warn("Token refresh failed with non-auth status:", response.status);
         return false;
       }
     } catch (error) {
-      // Network error (e.g. phone just woke up and connection isn't ready yet).
-      // Do NOT log the user out — the refresh token is still valid. The next
-      // API call will retry the refresh once the network is available.
+      // Network error — do NOT log the user out; the cookie is still valid.
       if (!isNetworkFetchError(error)) {
         console.error("Token refresh failed with unexpected error:", error);
       }
@@ -170,10 +169,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         headers.set("Authorization", `Bearer ${currentToken}`);
       }
 
-      // Prevent browser from caching API responses. Note: this cache option does not affect CORS preflight.
+      // Prevent browser from caching API responses.
       const config = { ...init, headers, cache: "no-store" as RequestCache };
 
-      // First attempt
       let response = await fetch(input, config);
 
       const syncServerTimeOffset = (res: Response) => {
@@ -181,7 +179,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         if (!serverDate) return;
         const serverMs = Date.parse(serverDate);
         if (Number.isNaN(serverMs)) return;
-        // Keep in sessionStorage — OrderService reads it from there
         sessionStorage.setItem(
           "server_time_offset_ms",
           String(serverMs - Date.now()),
@@ -190,7 +187,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
       syncServerTimeOffset(response);
 
-      // If unauthorized, try to refresh and retry
+      // 401 = expired/missing access token → refresh and retry
       if (response.status === 401) {
         const refreshed = await refreshToken();
         if (refreshed) {
@@ -203,31 +200,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
           });
           syncServerTimeOffset(response);
         }
-      } else if (response.status === 403) {
-        // Forbidden — may be caused by an expired JWT that the backend returns as 403.
-        // Attempt a token refresh and retry. If the refresh or the retried request still
-        // results in 403/failure, treat it as an invalid session and redirect to login.
-        const refreshed = await refreshToken();
-        if (refreshed) {
-          const newToken = localStorage.getItem("access_token");
-          headers.set("Authorization", `Bearer ${newToken}`);
-          const retried = await fetch(input, {
-            ...init,
-            headers,
-            cache: "no-store" as RequestCache,
-          });
-          syncServerTimeOffset(retried);
-          if (retried.status === 403) {
-            // Valid token but still forbidden → session/account issue, force logout.
-            logout();
-          }
-          response = retried;
-        }
-        // If refresh failed, refreshToken() already called logout().
       }
+      // 403 = permission denial for a valid session — do NOT logout.
+      // The API uses 401 for auth/token issues and 403 for authorization failures.
+
       return response;
     },
-    [logout, refreshToken],
+    [refreshToken],
   );
 
   const fetchUserProfile = useCallback(async (): Promise<User | null> => {
@@ -251,30 +230,28 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [apiFetch]);
 
   useEffect(() => {
-    // Determine initial auth state
     const existingToken = localStorage.getItem("access_token");
     if (existingToken) {
       setToken(existingToken);
       fetchUserProfile();
     }
 
-    // Set up token refresh interval (every 14 minutes, access tokens expire in 30 minutes)
+    // Proactively refresh the access token every 14 minutes (it expires in 30).
     const refreshInterval = setInterval(
       () => {
-        if (localStorage.getItem("refresh_token")) {
+        if (localStorage.getItem("access_token")) {
           refreshToken();
         }
       },
       14 * 60 * 1000,
-    ); // 14 minutes
+    );
 
-    // When the PWA returns to the foreground after being backgrounded, mobile
-    // browsers throttle/pause setInterval so the token may be stale. Refresh
-    // proactively on visibility restore so the first user action doesn't block.
+    // On PWA foreground restore the access token may be stale — refresh immediately
+    // so the first user action doesn't block on an expired token.
     const handleVisibilityChange = () => {
       if (
         document.visibilityState === "visible" &&
-        localStorage.getItem("refresh_token")
+        localStorage.getItem("access_token")
       ) {
         refreshToken();
       }
@@ -296,18 +273,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     });
   }, []);
 
-  const login = async (
-    accessToken: string,
-    refreshTokenStr: string,
-  ): Promise<User | null> => {
-    // Wipe previous user's local order data and cached profile before loading new user
+  // login() accepts only the access token — the refresh token arrives as an
+  // httpOnly cookie set by the server and is never visible to JavaScript.
+  const login = async (accessToken: string): Promise<User | null> => {
     clearOrderLocalStorage();
     localStorage.removeItem(CACHED_PROFILE_KEY);
     localStorage.setItem("access_token", accessToken);
-    localStorage.setItem("refresh_token", refreshTokenStr);
     setToken(accessToken);
     setIsLoading(true);
-    // Await profile so callers can navigate based on role (e.g. is_staff)
     const userData = await fetchUserProfile();
     return userData;
   };

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -41,6 +41,7 @@ const LoginPage: React.FC = () => {
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: "include", // allows the httpOnly refresh cookie to be set
         body: JSON.stringify({ email, password }),
       });
 
@@ -57,13 +58,14 @@ const LoginPage: React.FC = () => {
 
       const data = await response.json();
 
-      if (!data.access || !data.refresh) {
+      if (!data.access) {
         setError("Prihlásenie zlyhalo. Neplatná odpoveď servera.");
         return;
       }
 
+      // Refresh token arrives as an httpOnly cookie — only access token is in body.
       // login() fetches the profile; the useEffect above will navigate once user is set
-      await login(data.access, data.refresh);
+      await login(data.access);
     } catch (err) {
       setError(
         "Nepodarilo sa pripojiť k serveru. Skontrolujte pripojenie na internet.",

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -282,7 +282,7 @@ const AdminLayout: React.FC = () => {
                             Zrušiť
                         </button>
                         <button
-                            onClick={() => { setShowLogoutModal(false); logout(); }}
+                            onClick={() => { setShowLogoutModal(false); void logout(); }}
                             className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg font-medium transition-colors shadow-sm"
                         >
                             Odhlásiť sa


### PR DESCRIPTION
…, per-role lifetimes

- Add rest_framework_simplejwt.token_blacklist to INSTALLED_APPS
- Enable ROTATE_REFRESH_TOKENS + BLACKLIST_AFTER_ROTATION in SIMPLE_JWT
- Move refresh token from localStorage to httpOnly, Secure, SameSite=Lax cookie scoped to /api/token so it is never sent on regular API calls or accessible to JS
- Per-role refresh token lifetimes: clients 30 days (open app ~bi-weekly), admins 1 day (web UI only, access to all client data)
- Add POST /api/token/logout/ that blacklists the refresh token server-side and clears the cookie — logout is now fully effective server-side
- Invalidate all outstanding JWT refresh tokens on password reset
- Frontend: remove all refresh_token localStorage handling; logout calls server endpoint before clearing local state; refresh and login use credentials:include
- Update all auth tests to cookie-based flow; add tests for rotation, blacklist, logout, per-role lifetimes, and password-reset session invalidation