### PR TITLE
feat: improve push notification reliability

### DIFF
--- a/backend/api/apps.py
+++ b/backend/api/apps.py
@@ -22,6 +22,7 @@ class ApiConfig(AppConfig):
                 _sync_auto_order_schedule,
                 _sync_daily_report_schedule,
                 _sync_push_reminder_schedule,
+                _sync_weekly_reminder_schedule,
             )
 
             global_settings = GlobalSettings.objects.filter(pk=1).first()
@@ -31,6 +32,7 @@ class ApiConfig(AppConfig):
             _sync_auto_order_schedule(global_settings)
             _sync_daily_report_schedule(global_settings)
             _sync_push_reminder_schedule(global_settings)
+            _sync_weekly_reminder_schedule()
             logger.info("Startup periodic-task sync completed.")
         except (OperationalError, ProgrammingError):
             # DB not ready yet (common during migrate/startup); skip silently.

--- a/backend/api/migrations/0026_push_notification_reliability.py
+++ b/backend/api/migrations/0026_push_notification_reliability.py
@@ -1,0 +1,113 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0025_remove_dailyorder_status"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="pushsubscription",
+            name="failure_count",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="pushsubscription",
+            name="last_failure_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="pushsubscription",
+            name="last_seen_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="pushsubscription",
+            name="last_success_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="pushsubscription",
+            name="user_agent",
+            field=models.TextField(blank=True),
+        ),
+        migrations.CreateModel(
+            name="PushNotificationAttempt",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("endpoint", models.TextField()),
+                ("title", models.CharField(max_length=200)),
+                ("body", models.TextField()),
+                ("url", models.CharField(default="/home", max_length=500)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("sent", "Sent"),
+                            ("failed", "Failed"),
+                            ("stale_removed", "Stale removed"),
+                            ("unavailable", "Unavailable"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                ("http_status", models.PositiveIntegerField(blank=True, null=True)),
+                ("error_message", models.TextField(blank=True)),
+                ("attempt_number", models.PositiveSmallIntegerField(default=1)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "subscription",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="notification_attempts",
+                        to="api.pushsubscription",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="push_notification_attempts",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="pushnotificationattempt",
+            index=models.Index(
+                fields=["created_at"], name="api_pushnot_created_34ee7b_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="pushnotificationattempt",
+            index=models.Index(
+                fields=["status", "created_at"], name="api_pushnot_status_b8cb8b_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="pushnotificationattempt",
+            index=models.Index(
+                fields=["user", "created_at"], name="api_pushnot_user_id_b07e64_idx"
+            ),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -380,6 +380,11 @@ class PushSubscription(models.Model):
     endpoint = models.TextField()
     p256dh = models.TextField()
     auth = models.TextField()
+    user_agent = models.TextField(blank=True)
+    last_seen_at = models.DateTimeField(null=True, blank=True)
+    last_success_at = models.DateTimeField(null=True, blank=True)
+    last_failure_at = models.DateTimeField(null=True, blank=True)
+    failure_count = models.PositiveIntegerField(default=0)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -391,3 +396,54 @@ class PushSubscription(models.Model):
 
     def __str__(self) -> str:
         return f"PushSubscription({self.user.email}, …{self.endpoint[-20:]})"
+
+
+class PushNotificationAttempt(models.Model):
+    """Audit trail for Web Push delivery attempts."""
+
+    STATUS_SENT = "sent"
+    STATUS_FAILED = "failed"
+    STATUS_STALE_REMOVED = "stale_removed"
+    STATUS_UNAVAILABLE = "unavailable"
+
+    STATUS_CHOICES = [
+        (STATUS_SENT, "Sent"),
+        (STATUS_FAILED, "Failed"),
+        (STATUS_STALE_REMOVED, "Stale removed"),
+        (STATUS_UNAVAILABLE, "Unavailable"),
+    ]
+
+    subscription = models.ForeignKey(
+        PushSubscription,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="notification_attempts",
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="push_notification_attempts",
+    )
+    endpoint = models.TextField()
+    title = models.CharField(max_length=200)
+    body = models.TextField()
+    url = models.CharField(max_length=500, default="/home")
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES)
+    http_status = models.PositiveIntegerField(null=True, blank=True)
+    error_message = models.TextField(blank=True)
+    attempt_number = models.PositiveSmallIntegerField(default=1)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["created_at"]),
+            models.Index(fields=["status", "created_at"]),
+            models.Index(fields=["user", "created_at"]),
+        ]
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:
+        return f"PushNotificationAttempt({self.status}, …{self.endpoint[-20:]})"

--- a/backend/api/services/push_notification_service.py
+++ b/backend/api/services/push_notification_service.py
@@ -12,8 +12,11 @@ from importlib import import_module
 from typing import Any
 
 from django.conf import settings
+from django.db.models import F
+from django.utils import timezone
 
 logger = logging.getLogger(__name__)
+TRANSIENT_WEB_PUSH_STATUSES = {408, 409, 425, 429, 500, 502, 503, 504}
 
 
 @lru_cache(maxsize=1)
@@ -44,6 +47,62 @@ class PushNotificationService:
         }
 
     @staticmethod
+    def _record_attempt(
+        subscription: Any,
+        title: str,
+        body: str,
+        url: str,
+        status: str,
+        attempt_number: int,
+        http_status: int | None = None,
+        error_message: str = "",
+    ) -> None:
+        from api.models import PushNotificationAttempt
+
+        try:
+            PushNotificationAttempt.objects.create(
+                subscription=(
+                    subscription if getattr(subscription, "pk", None) else None
+                ),
+                user_id=getattr(subscription, "user_id", None),
+                endpoint=getattr(subscription, "endpoint", ""),
+                title=title[:200],
+                body=body,
+                url=url[:500],
+                status=status,
+                http_status=http_status,
+                error_message=error_message[:2000],
+                attempt_number=attempt_number,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to record push notification attempt for subscription pk=%s",
+                getattr(subscription, "pk", None),
+            )
+
+    @staticmethod
+    def _mark_success(subscription: Any) -> None:
+        from api.models import PushSubscription
+
+        PushSubscription.objects.filter(pk=subscription.pk).update(
+            last_success_at=timezone.now(),
+            failure_count=0,
+        )
+
+    @staticmethod
+    def _mark_failure(subscription: Any) -> None:
+        from api.models import PushSubscription
+
+        PushSubscription.objects.filter(pk=subscription.pk).update(
+            last_failure_at=timezone.now(),
+            failure_count=F("failure_count") + 1,
+        )
+
+    @staticmethod
+    def _is_transient_status(status_code: int | None) -> bool:
+        return status_code in TRANSIENT_WEB_PUSH_STATUSES
+
+    @staticmethod
     def send_to_subscription(
         subscription: Any,
         title: str,
@@ -66,45 +125,108 @@ class PushNotificationService:
             logger.error(
                 "pywebpush is not installed; push notifications are unavailable"
             )
+            PushNotificationService._record_attempt(
+                subscription=subscription,
+                title=title,
+                body=body,
+                url=url,
+                status="unavailable",
+                attempt_number=1,
+                error_message="pywebpush is not installed",
+            )
             return False, False
 
-        try:
-            webpush_func(
-                subscription_info=PushNotificationService._build_subscription_info(
-                    subscription
-                ),
-                data=payload,
-                vapid_private_key=settings.VAPID_PRIVATE_KEY,
-                vapid_claims=claims,
-            )
-            return True, False
-        except Exception as exc:
-            if webpush_exception_cls is not None and isinstance(
-                exc, webpush_exception_cls
-            ):
-                response = getattr(exc, "response", None)
-                status = response.status_code if response is not None else None
-                if status in (404, 410):
-                    logger.info(
-                        "Removing stale push subscription pk=%s (HTTP %s)",
-                        subscription.pk,
-                        status,
+        max_attempts = 2
+        for attempt_number in range(1, max_attempts + 1):
+            try:
+                webpush_func(
+                    subscription_info=PushNotificationService._build_subscription_info(
+                        subscription
+                    ),
+                    data=payload,
+                    vapid_private_key=settings.VAPID_PRIVATE_KEY,
+                    vapid_claims=claims,
+                )
+                PushNotificationService._record_attempt(
+                    subscription=subscription,
+                    title=title,
+                    body=body,
+                    url=url,
+                    status="sent",
+                    attempt_number=attempt_number,
+                )
+                PushNotificationService._mark_success(subscription)
+                return True, False
+            except Exception as exc:
+                if webpush_exception_cls is not None and isinstance(
+                    exc, webpush_exception_cls
+                ):
+                    response = getattr(exc, "response", None)
+                    status = response.status_code if response is not None else None
+                    if status in (404, 410):
+                        PushNotificationService._record_attempt(
+                            subscription=subscription,
+                            title=title,
+                            body=body,
+                            url=url,
+                            status="stale_removed",
+                            http_status=status,
+                            error_message=str(exc),
+                            attempt_number=attempt_number,
+                        )
+                        logger.info(
+                            "Removing stale push subscription pk=%s (HTTP %s)",
+                            subscription.pk,
+                            status,
+                        )
+                        subscription.delete()
+                        return False, True
+
+                    PushNotificationService._record_attempt(
+                        subscription=subscription,
+                        title=title,
+                        body=body,
+                        url=url,
+                        status="failed",
+                        http_status=status,
+                        error_message=str(exc),
+                        attempt_number=attempt_number,
                     )
-                    subscription.delete()
-                    return False, True
-                logger.warning(
-                    "Push delivery failed for subscription pk=%s: %s",
+                    PushNotificationService._mark_failure(subscription)
+                    logger.warning(
+                        "Push delivery failed for subscription pk=%s "
+                        "(attempt %d/%d, HTTP %s): %s",
+                        subscription.pk,
+                        attempt_number,
+                        max_attempts,
+                        status,
+                        exc,
+                    )
+                    if (
+                        attempt_number < max_attempts
+                        and PushNotificationService._is_transient_status(status)
+                    ):
+                        continue
+                    return False, False
+
+                PushNotificationService._record_attempt(
+                    subscription=subscription,
+                    title=title,
+                    body=body,
+                    url=url,
+                    status="failed",
+                    error_message=str(exc),
+                    attempt_number=attempt_number,
+                )
+                PushNotificationService._mark_failure(subscription)
+                logger.exception(
+                    "Unexpected error sending push to subscription pk=%s: %s",
                     subscription.pk,
                     exc,
                 )
                 return False, False
 
-            logger.exception(
-                "Unexpected error sending push to subscription pk=%s: %s",
-                subscription.pk,
-                exc,
-            )
-            return False, False
+        return False, False
 
     @staticmethod
     def send_to_user(

--- a/backend/api/tests/factories.py
+++ b/backend/api/tests/factories.py
@@ -12,6 +12,7 @@ from api.models import (
     DailyOrder,
     Diet,
     PasswordResetToken,
+    PushNotificationAttempt,
     PushSubscription,
     UserProfile,
 )
@@ -108,3 +109,16 @@ class PushSubscriptionFactory(DjangoModelFactory):
     )
     p256dh = factory.Sequence(lambda n: f"fake-p256dh-key-{n}")
     auth = factory.Sequence(lambda n: f"fake-auth-{n}")
+
+
+class PushNotificationAttemptFactory(DjangoModelFactory):
+    class Meta:
+        model = PushNotificationAttempt
+
+    subscription = factory.SubFactory(PushSubscriptionFactory)
+    user = factory.SelfAttribute("subscription.user")
+    endpoint = factory.SelfAttribute("subscription.endpoint")
+    title = "Test notification"
+    body = "Test body"
+    url = "/home"
+    status = PushNotificationAttempt.STATUS_SENT

--- a/backend/api/tests/integration/test_push_api.py
+++ b/backend/api/tests/integration/test_push_api.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import pytest
+from django.utils import timezone
 from rest_framework import status
 
 from api.models import PushSubscription
@@ -72,8 +73,12 @@ class TestPushSubscribePost:
 
     def test_creates_subscription(self, authenticated_client, user):
         """Valid subscription data is saved to the database."""
+        before = timezone.now()
         response = authenticated_client.post(
-            SUBSCRIBE_URL, VALID_SUBSCRIPTION, format="json"
+            SUBSCRIBE_URL,
+            VALID_SUBSCRIPTION,
+            format="json",
+            HTTP_USER_AGENT="Test Browser",
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -84,6 +89,9 @@ class TestPushSubscribePost:
         assert sub.endpoint == VALID_SUBSCRIPTION["endpoint"]
         assert sub.p256dh == VALID_SUBSCRIPTION["p256dh"]
         assert sub.auth == VALID_SUBSCRIPTION["auth"]
+        assert sub.user_agent == "Test Browser"
+        assert sub.last_seen_at is not None
+        assert sub.last_seen_at >= before
 
     def test_updates_existing_subscription_for_same_endpoint(
         self, authenticated_client, user
@@ -105,6 +113,7 @@ class TestPushSubscribePost:
         sub = PushSubscription.objects.get(user=user)
         assert sub.p256dh == "new-p256dh"
         assert sub.auth == "new-auth"
+        assert sub.last_seen_at is not None
 
     def test_same_user_can_have_multiple_endpoints(self, authenticated_client, user):
         """One user can subscribe from multiple devices."""

--- a/backend/api/views/push_views.py
+++ b/backend/api/views/push_views.py
@@ -12,6 +12,7 @@ import logging
 from typing import Any
 
 from django.conf import settings
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
@@ -56,7 +57,12 @@ class PushSubscribeView(APIView):
         obj, created = PushSubscription.objects.update_or_create(
             user=request.user,
             endpoint=endpoint,
-            defaults={"p256dh": p256dh, "auth": auth},
+            defaults={
+                "p256dh": p256dh,
+                "auth": auth,
+                "user_agent": request.META.get("HTTP_USER_AGENT", "")[:2000],
+                "last_seen_at": timezone.now(),
+            },
         )
         http_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response({"status": "subscribed"}, status=http_status)

--- a/backend/tests/test_push_service.py
+++ b/backend/tests/test_push_service.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from api.models import PushSubscription
+from api.models import PushNotificationAttempt, PushSubscription
 from api.services.push_notification_service import PushNotificationService
 from api.tests.factories import PushSubscriptionFactory, UserFactory
 
@@ -44,6 +44,8 @@ class TestSendToSubscription:
             )
 
         assert result == (False, False)
+        attempt = PushNotificationAttempt.objects.get(subscription=sub)
+        assert attempt.status == PushNotificationAttempt.STATUS_UNAVAILABLE
 
     def test_returns_true_on_success(self, settings):
         from pywebpush import WebPushException
@@ -63,6 +65,11 @@ class TestSendToSubscription:
         assert result == (True, False)
         mock_wp = mock_loader.return_value[1]
         mock_wp.assert_called_once()
+        sub.refresh_from_db()
+        assert sub.last_success_at is not None
+        assert sub.failure_count == 0
+        attempt = PushNotificationAttempt.objects.get(subscription=sub)
+        assert attempt.status == PushNotificationAttempt.STATUS_SENT
 
     def test_returns_false_and_deletes_on_410(self, settings):
         """HTTP 410 (Gone) marks subscription as stale and removes it."""
@@ -86,6 +93,9 @@ class TestSendToSubscription:
 
         assert result == (False, True)
         assert not PushSubscription.objects.filter(pk=sub_pk).exists()
+        attempt = PushNotificationAttempt.objects.get(endpoint=sub.endpoint)
+        assert attempt.status == PushNotificationAttempt.STATUS_STALE_REMOVED
+        assert attempt.http_status == 410
 
     def test_returns_false_and_deletes_on_404(self, settings):
         """HTTP 404 (endpoint not found) also removes the stale subscription."""
@@ -133,6 +143,48 @@ class TestSendToSubscription:
         assert result == (False, False)
         # Record should still be present
         assert PushSubscription.objects.filter(pk=sub_pk).exists()
+        sub.refresh_from_db()
+        assert sub.last_failure_at is not None
+        assert sub.failure_count == 2
+        assert (
+            PushNotificationAttempt.objects.filter(
+                subscription=sub,
+                status=PushNotificationAttempt.STATUS_FAILED,
+                http_status=500,
+            ).count()
+            == 2
+        )
+
+    def test_retries_transient_http_error_and_succeeds(self, settings):
+        """Transient push provider errors are retried once."""
+        from pywebpush import WebPushException
+
+        settings.VAPID_PRIVATE_KEY = "fake-key"
+        settings.VAPID_ADMIN_EMAIL = "admin@example.com"
+        sub = PushSubscriptionFactory()
+        mock_webpush = MagicMock(side_effect=[_make_push_exception(503), None])
+
+        with patch(
+            "api.services.push_notification_service._load_pywebpush",
+            return_value=(WebPushException, mock_webpush),
+        ):
+            result = PushNotificationService.send_to_subscription(
+                sub, title="Test", body="Body"
+            )
+
+        assert result == (True, False)
+        assert mock_webpush.call_count == 2
+        sub.refresh_from_db()
+        assert sub.last_success_at is not None
+        assert sub.failure_count == 0
+        assert list(
+            PushNotificationAttempt.objects.filter(subscription=sub)
+            .order_by("attempt_number")
+            .values_list("status", "http_status", "attempt_number")
+        ) == [
+            (PushNotificationAttempt.STATUS_FAILED, 503, 1),
+            (PushNotificationAttempt.STATUS_SENT, None, 2),
+        ]
 
     def test_returns_false_on_unexpected_exception(self, settings):
         """Non-WebPushException errors are caught and return False."""

--- a/backend/tests/test_startup_sync.py
+++ b/backend/tests/test_startup_sync.py
@@ -11,7 +11,7 @@ import pytest
 from django_celery_beat.models import PeriodicTask
 
 from api.models import GlobalSettings
-from api.signals import PUSH_REMINDER_TASK_PREFIX
+from api.signals import PUSH_REMINDER_TASK_PREFIX, WEEKLY_REMINDER_TASK_NAME
 
 
 def _make_settings(**kwargs):
@@ -46,6 +46,19 @@ class TestStartupSync:
         assert PeriodicTask.objects.filter(
             name__startswith=PUSH_REMINDER_TASK_PREFIX
         ).exists()
+
+    def test_weekly_reminder_task_created_on_startup(self):
+        """Startup sync also self-heals the Sunday weekly reminder."""
+        from api.signals import _sync_weekly_reminder_schedule
+
+        _make_settings()
+
+        PeriodicTask.objects.filter(name=WEEKLY_REMINDER_TASK_NAME).delete()
+        assert not PeriodicTask.objects.filter(name=WEEKLY_REMINDER_TASK_NAME).exists()
+
+        _sync_weekly_reminder_schedule()
+
+        assert PeriodicTask.objects.filter(name=WEEKLY_REMINDER_TASK_NAME).exists()
 
     def test_startup_sync_is_idempotent(self):
         """Running the startup sync twice does not duplicate tasks."""

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Navigate,
   Outlet,
 } from "react-router-dom";
+import { useEffect } from "react";
 
 import { AppProvider } from "./pages/client/context/AppContext";
 import { AuthProvider, useAuth } from "./context/auth";
@@ -12,6 +13,7 @@ import { OnboardingProvider } from "./context/OnboardingContext";
 import { ToastProvider } from "./context/ToastContext";
 import { PWAProvider } from "./context/PWAContext";
 import { usePWA } from "./hooks/usePWA";
+import { usePushNotifications } from "./hooks/usePushNotifications";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import NotificationGuard from "./components/NotificationGuard";
 import PWAUpdateBanner from "./components/PWAUpdateBanner";
@@ -98,6 +100,28 @@ const AdminRoute = () => {
   return <ErrorBoundary><AdminLayout /></ErrorBoundary>;
 };
 
+function PushSubscriptionReconciler() {
+  const { user, isAuthenticated, isLoading } = useAuth();
+  const { ensureSubscriptionRegistration } = usePushNotifications();
+
+  useEffect(() => {
+    if (
+      isLoading ||
+      !isAuthenticated ||
+      !user ||
+      user.is_staff ||
+      !("Notification" in window) ||
+      Notification.permission !== "granted"
+    ) {
+      return;
+    }
+
+    ensureSubscriptionRegistration();
+  }, [ensureSubscriptionRegistration, isAuthenticated, isLoading, user]);
+
+  return null;
+}
+
 /**
  * AppContent — shown inside all providers.
  * Displays AppLoadingScreen while auth is initialising.
@@ -128,6 +152,7 @@ export default function App() {
         <AuthProvider>
           <ToastProvider>
             <AppContent>
+              <PushSubscriptionReconciler />
               {/* Banner only shown in browser (non-standalone) mode */}
               <PWAUpdateBanner />
               <Routes>

--- a/frontend/src/hooks/usePushNotifications.ts
+++ b/frontend/src/hooks/usePushNotifications.ts
@@ -23,6 +23,7 @@ interface UsePushNotificationsReturn {
   isSubscribed: boolean;
   subscribe: () => Promise<boolean>;
   unsubscribe: () => Promise<boolean>;
+  ensureSubscriptionRegistration: () => Promise<boolean>;
   error: string | null;
 }
 
@@ -43,6 +44,13 @@ function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
     bytes[i] = rawData.charCodeAt(i);
   }
   return bytes.buffer;
+}
+
+function arrayBufferEquals(a: ArrayBuffer | null, b: ArrayBuffer): boolean {
+  if (!a || a.byteLength !== b.byteLength) return false;
+  const aBytes = new Uint8Array(a);
+  const bBytes = new Uint8Array(b);
+  return aBytes.every((value, index) => value === bBytes[index]);
 }
 
 /** Extract the serialisable parts of a PushSubscription for sending to the API. */
@@ -89,6 +97,65 @@ export function usePushNotifications(): UsePushNotificationsReturn {
       .catch(() => { });
   }, []);
 
+  const registerWithBackend = useCallback(async (pushSub: PushSubscription): Promise<boolean> => {
+    try {
+      const serialized = serializeSubscription(pushSub);
+      const response = await apiFetch(`${API_URL}/push/subscribe/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(serialized),
+      });
+
+      if (!response.ok) {
+        let message = 'Nepodarilo sa aktivovať notifikácie. Skúste to znova online.';
+        try {
+          const data = await response.json();
+          if (typeof data?.detail === 'string' && data.detail) {
+            message = data.detail;
+          }
+        } catch {
+          // Ignore invalid/non-JSON error responses.
+        }
+
+        setIsSubscribed(false);
+        setError(message);
+        return false;
+      }
+
+      setIsSubscribed(true);
+      return true;
+    } catch {
+      setIsSubscribed(false);
+      setError('Nepodarilo sa aktivovať notifikácie. Skúste to znova online.');
+      return false;
+    }
+  }, [apiFetch]);
+
+  const getOrCreateBrowserSubscription = useCallback(async (): Promise<PushSubscription | null> => {
+    if (!vapidPublicKey) {
+      setError('VAPID kľúč nie je dostupný. Skúste to neskôr.');
+      return null;
+    }
+
+    const applicationServerKey = urlBase64ToUint8Array(vapidPublicKey);
+    const reg = await navigator.serviceWorker.ready;
+    const existing = await reg.pushManager.getSubscription();
+    const existingKey = existing?.options.applicationServerKey ?? null;
+
+    if (existing && arrayBufferEquals(existingKey, applicationServerKey)) {
+      return existing;
+    }
+
+    if (existing) {
+      await existing.unsubscribe().catch(() => { });
+    }
+
+    return reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey,
+    });
+  }, [vapidPublicKey]);
+
   const subscribe = useCallback(async (): Promise<boolean> => {
     setError(null);
 
@@ -97,8 +164,8 @@ export function usePushNotifications(): UsePushNotificationsReturn {
       return false;
     }
 
-    if (!vapidPublicKey) {
-      setError('VAPID kľúč nie je dostupný. Skúste to neskôr.');
+    if (!('serviceWorker' in navigator)) {
+      setError('Váš prehliadač nepodporuje service worker notifikácie.');
       return false;
     }
 
@@ -108,53 +175,42 @@ export function usePushNotifications(): UsePushNotificationsReturn {
     if (result !== 'granted') return false;
 
     try {
-      const reg = await navigator.serviceWorker.ready;
-      const pushSub = await reg.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
-      });
+      const pushSub = await getOrCreateBrowserSubscription();
+      if (!pushSub) return false;
 
-      const serialized = serializeSubscription(pushSub);
-
-      try {
-        const response = await apiFetch(`${API_URL}/push/subscribe/`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(serialized),
-        });
-
-        if (!response.ok) {
-          let message = 'Nepodarilo sa aktivovať notifikácie. Skúste to znova online.';
-          try {
-            const data = await response.json();
-            if (typeof data?.detail === 'string' && data.detail) {
-              message = data.detail;
-            }
-          } catch {
-            // Ignore invalid/non-JSON error responses.
-          }
-
-          await pushSub.unsubscribe().catch(() => { });
-          setIsSubscribed(false);
-          setError(message);
-          return false;
-        }
-
-        setIsSubscribed(true);
-        return true;
-      } catch {
-        // Keep browser and server subscription state consistent.
+      const registered = await registerWithBackend(pushSub);
+      if (!registered) {
         await pushSub.unsubscribe().catch(() => { });
-        setIsSubscribed(false);
-        setError('Nepodarilo sa aktivovať notifikácie. Skúste to znova online.');
-        return false;
       }
+      return registered;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setError(`Chyba pri prihlasovaní na notifikácie: ${msg}`);
       return false;
     }
-  }, [vapidPublicKey, apiFetch]);
+  }, [getOrCreateBrowserSubscription, registerWithBackend]);
+
+  const ensureSubscriptionRegistration = useCallback(async (): Promise<boolean> => {
+    setError(null);
+
+    if (!('Notification' in window) || !('serviceWorker' in navigator)) {
+      return false;
+    }
+
+    const currentPermission = Notification.permission;
+    setPermission(currentPermission);
+    if (currentPermission !== 'granted') return false;
+
+    try {
+      const pushSub = await getOrCreateBrowserSubscription();
+      if (!pushSub) return false;
+      return registerWithBackend(pushSub);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(`Chyba pri obnove notifikácií: ${msg}`);
+      return false;
+    }
+  }, [getOrCreateBrowserSubscription, registerWithBackend]);
 
   const unsubscribe = useCallback(async (): Promise<boolean> => {
     setError(null);
@@ -181,5 +237,12 @@ export function usePushNotifications(): UsePushNotificationsReturn {
     }
   }, [apiFetch]);
 
-  return { permission, isSubscribed, subscribe, unsubscribe, error };
+  return {
+    permission,
+    isSubscribed,
+    subscribe,
+    unsubscribe,
+    ensureSubscriptionRegistration,
+    error,
+  };
 }


### PR DESCRIPTION
## Summary
- add push subscription health metadata and delivery-attempt audit records
- retry transient Web Push failures while still removing stale 404/410 subscriptions
- re-register granted client browser subscriptions on app start and self-heal weekly reminder scheduling

## Verification
- backend: ./.venv/bin/python -m pytest --no-cov tests/test_push_service.py tests/test_push_notifications.py tests/test_startup_sync.py api/tests/integration/test_push_api.py
- frontend: npm run lint
- frontend: npm run build
- backend: ./.venv/bin/python manage.py makemigrations --check --dry-run