### PR TITLE
fix: return 401 (not 403) for auth failures

### DIFF
--- a/backend/api/tests/integration/test_auto_orders.py
+++ b/backend/api/tests/integration/test_auto_orders.py
@@ -377,7 +377,7 @@ class TestAdminTriggerAutoOrders:
         url = reverse("trigger-auto-orders-list")
         response = api_client.post(url, {"date": str(TUESDAY)}, format="json")
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_trigger_without_date_uses_next_workday(self, admin_client, user):
         """Omitting date parameter uses next workday calculation."""

--- a/backend/api/tests/integration/test_order_api.py
+++ b/backend/api/tests/integration/test_order_api.py
@@ -75,7 +75,7 @@ class TestOrderCreation:
         url = reverse("dailyorder-list")
         response = api_client.post(url, {"date": str(MONDAY)}, format="json")
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_staff_cannot_create_orders(self, admin_client, admin_user):
         """Staff/admin users cannot place orders."""
@@ -312,7 +312,7 @@ class TestPlannedOrdersEndpoint:
         url = reverse("planned-orders-list")
         response = api_client.get(url)
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_planned_orders_staff_can_access(self, admin_client):
         """Admin/staff can access planned orders endpoint."""

--- a/backend/api/tests/integration/test_push_api.py
+++ b/backend/api/tests/integration/test_push_api.py
@@ -66,10 +66,10 @@ class TestVapidPublicKeyView:
 
 @pytest.mark.django_db
 class TestPushSubscribePost:
-    def test_unauthenticated_returns_403_forbidden(self, api_client):
-        """Unauthenticated requests are rejected with 403 FORBIDDEN."""
+    def test_unauthenticated_returns_401_unauthorized(self, api_client):
+        """Unauthenticated requests are rejected with 401 UNAUTHORIZED."""
         response = api_client.post(SUBSCRIBE_URL, VALID_SUBSCRIPTION, format="json")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_creates_subscription(self, authenticated_client, user):
         """Valid subscription data is saved to the database."""
@@ -168,13 +168,13 @@ class TestPushSubscribePost:
 
 @pytest.mark.django_db
 class TestPushSubscribeDelete:
-    def test_unauthenticated_returns_403_forbidden(self, api_client):
+    def test_unauthenticated_returns_401_unauthorized(self, api_client):
         response = api_client.delete(
             SUBSCRIBE_URL,
             {"endpoint": "https://example.com/ep"},
             format="json",
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_removes_existing_subscription(self, authenticated_client, user):
         """Deleting a subscription removes it from the database."""
@@ -237,11 +237,11 @@ class TestAdminSendPushView:
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_unauthenticated_returns_403_forbidden(self, api_client):
+    def test_unauthenticated_returns_401_unauthorized(self, api_client):
         response = api_client.post(
             ADMIN_SEND_URL, {"title": "Test", "body": "Hello"}, format="json"
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_missing_title_returns_400(self, admin_client):
         response = admin_client.post(ADMIN_SEND_URL, {"body": "Hello"}, format="json")

--- a/backend/app/settings/base.py
+++ b/backend/app/settings/base.py
@@ -259,8 +259,12 @@ REFRESH_TOKEN_COOKIE_PATH = "/api/token"
 # Django REST Framework
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.SessionAuthentication",
+        # JWT must be first: DRF uses the first authenticator's authenticate_header()
+        # to decide between 401 and 403.  SessionAuthentication returns None (no header)
+        # which causes DRF to emit 403 for all auth failures — including expired tokens —
+        # so the frontend's 401→refresh flow never fires.  JWT first → 401 → refresh. ✓
         "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",

--- a/frontend/src/context/auth.tsx
+++ b/frontend/src/context/auth.tsx
@@ -237,6 +237,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         setUser(userData);
         return userData;
       }
+      // 401 after apiFetch already attempted a refresh → session is truly gone.
+      if (response.status === 401) {
+        await logout();
+      }
       return null;
     } catch (e) {
       if (!isNetworkFetchError(e)) {
@@ -246,7 +250,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     } finally {
       setIsLoading(false);
     }
-  }, [apiFetch]);
+  }, [apiFetch, logout]);
 
   useEffect(() => {
     const existingToken = localStorage.getItem("access_token");


### PR DESCRIPTION
## Summary

- `SessionAuthentication` was first in `DEFAULT_AUTHENTICATION_CLASSES`, causing DRF to return **403** for all unauthenticated/expired-token requests instead of 401
- The frontend's `apiFetch` only retries (and refreshes the JWT) on 401 — so expired tokens left the app permanently broken (all API calls returning 403, no auto-refresh, no logout)
- Fix: move `JWTAuthentication` first → expired access tokens now correctly return 401 → refresh flow fires automatically
- Added 401-only auto-logout in `fetchUserProfile` as defense in depth (403 excluded to avoid false-logouts from WAF/proxy errors)

## Test plan

- [ ] All 296 backend tests pass
- [ ] Open app after 30+ min idle → access token expires → app auto-refreshes silently (no 403 stuck state)
- [ ] Clear refresh cookie manually → app shows login page instead of broken state
- [ ] Admin-only endpoint accessed by regular user still returns 403 (no logout triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)