### PR TITLE
feat: celodenná objednávka,inbox správy, špeciálna diéta

### DIFF
--- a/backend/api/migrations/0027_inbox_read_at.py
+++ b/backend/api/migrations/0027_inbox_read_at.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0026_push_notification_reliability"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="pushnotificationattempt",
+            name="read_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddIndex(
+            model_name="pushnotificationattempt",
+            index=models.Index(
+                fields=["user", "read_at"], name="api_pushno_user_id_read_at_idx"
+            ),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -435,6 +435,7 @@ class PushNotificationAttempt(models.Model):
     http_status = models.PositiveIntegerField(null=True, blank=True)
     error_message = models.TextField(blank=True)
     attempt_number = models.PositiveSmallIntegerField(default=1)
+    read_at = models.DateTimeField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
@@ -442,6 +443,7 @@ class PushNotificationAttempt(models.Model):
             models.Index(fields=["created_at"]),
             models.Index(fields=["status", "created_at"]),
             models.Index(fields=["user", "created_at"]),
+            models.Index(fields=["user", "read_at"]),
         ]
         ordering = ["-created_at"]
 

--- a/backend/api/tests/integration/test_order_api.py
+++ b/backend/api/tests/integration/test_order_api.py
@@ -366,23 +366,19 @@ class TestOrderEmpty:
 
     def test_zero_portions_is_empty(self, authenticated_client, user):
         """Order with all zero portions shows as empty."""
-        # Create order for a future workday we know will be in planned orders
         from django.utils import timezone
 
-        today = timezone.now().astimezone(datetime.timezone.utc).date()
-        # Get first workday
-        import datetime as dt
-
+        # Use localdate() to match the view's timezone (Europe/Bratislava).
+        today = timezone.localdate()
         test_date = today
-        while test_date.weekday() >= 5:  # Skip weekends
-            test_date += dt.timedelta(days=1)
+        while test_date.weekday() >= 5:
+            test_date += datetime.timedelta(days=1)
 
         DailyOrder.objects.create(user=user, date=test_date, data=EMPTY_DATA)
 
         url = reverse("planned-orders-list")
         response = authenticated_client.get(url)
 
-        # Find test_date in response
         item = next(
             (item for item in response.data if item["date"] == str(test_date)), None
         )
@@ -393,12 +389,11 @@ class TestOrderEmpty:
         """Order with any positive portion shows as not empty."""
         from django.utils import timezone
 
-        today = timezone.now().astimezone(datetime.timezone.utc).date()
-        import datetime as dt
-
+        # Use localdate() to match the view's timezone (Europe/Bratislava).
+        today = timezone.localdate()
         test_date = today
-        while test_date.weekday() >= 5:  # Skip weekends
-            test_date += dt.timedelta(days=1)
+        while test_date.weekday() >= 5:
+            test_date += datetime.timedelta(days=1)
 
         DailyOrder.objects.create(user=user, date=test_date, data=NON_EMPTY_DATA)
 

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -14,6 +14,7 @@ from .views import (
     EmailTokenObtainPairView,
     GlobalSettingsViewSet,
     HolidayListViewSet,
+    InboxViewSet,
     LogoutView,
     MealTemplateViewSet,
     PasswordResetConfirmView,
@@ -57,6 +58,7 @@ router.register(r"admin/meal-plans", DailyMealPlanViewSet, basename="meal-plan")
 router.register(r"meal-plans", DailyMealPlanViewSet, basename="client-meal-plan")
 router.register(r"admin/holidays", AdminHolidayViewSet, basename="admin-holiday")
 router.register(r"holidays", HolidayListViewSet, basename="holiday")
+router.register(r"inbox", InboxViewSet, basename="inbox")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -24,6 +24,9 @@ from .diet_views import DietViewSet
 # Holiday views
 from .holiday_views import AdminHolidayViewSet, HolidayListViewSet
 
+# Inbox views
+from .inbox_views import InboxViewSet
+
 # Meal plan views
 from .meal_plan_views import (
     DailyMealPlanViewSet,
@@ -77,4 +80,6 @@ __all__ = [
     "VapidPublicKeyView",
     "PushSubscribeView",
     "AdminSendPushView",
+    # Inbox
+    "InboxViewSet",
 ]

--- a/backend/api/views/inbox_views.py
+++ b/backend/api/views/inbox_views.py
@@ -1,0 +1,65 @@
+"""Client inbox: user's received push notifications as in-app messages."""
+
+from django.utils import timezone
+from rest_framework import permissions, serializers, status
+from rest_framework.decorators import action
+from rest_framework.mixins import ListModelMixin
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from ..models import PushNotificationAttempt
+
+
+class InboxMessageSerializer(serializers.ModelSerializer):
+    is_read = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PushNotificationAttempt
+        fields = ["id", "title", "body", "url", "created_at", "read_at", "is_read"]
+
+    def get_is_read(self, obj):
+        return obj.read_at is not None
+
+
+class InboxViewSet(ListModelMixin, GenericViewSet):
+    """
+    Read-only inbox for the authenticated client.
+    Only shows successfully sent messages addressed to this user.
+    """
+
+    serializer_class = InboxMessageSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        return PushNotificationAttempt.objects.filter(
+            user=self.request.user,
+            status=PushNotificationAttempt.STATUS_SENT,
+        ).order_by("-created_at")
+
+    def list(self, request, *args, **kwargs):
+        qs = self.get_queryset()
+        unread_count = qs.filter(read_at__isnull=True).count()
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            response = self.get_paginated_response(serializer.data)
+            response.data["unread_count"] = unread_count
+            return response
+        serializer = self.get_serializer(qs, many=True)
+        return Response({"results": serializer.data, "unread_count": unread_count})
+
+    @action(detail=True, methods=["post"], url_path="read")
+    def mark_read(self, request, pk=None):
+        """POST /api/inbox/{id}/read/ — mark one message read."""
+        msg = self.get_object()
+        if msg.read_at is None:
+            msg.read_at = timezone.now()
+            msg.save(update_fields=["read_at"])
+        return Response(self.get_serializer(msg).data)
+
+    @action(detail=False, methods=["post"], url_path="read-all")
+    def mark_all_read(self, request):
+        """POST /api/inbox/read-all/ — mark all unread messages read."""
+        now = timezone.now()
+        updated = self.get_queryset().filter(read_at__isnull=True).update(read_at=now)
+        return Response({"marked_read": updated}, status=status.HTTP_200_OK)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import MenuPage from "./pages/client/pages/MenuPage";
 import Settings from "./pages/client/pages/Settings";
 import ProfilePage from "./pages/client/pages/ProfilePage";
 import AboutPage from "./pages/client/pages/AboutPage";
+import InboxPage from "./pages/client/pages/InboxPage";
 import ClientLayout from "./pages/client/components/ClientLayout";
 import LoginPage from "./pages/LoginPage";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage";
@@ -203,6 +204,7 @@ export default function App() {
                   <Route path="/order" element={<ErrorBoundary><OrderPage /></ErrorBoundary>} />
                   <Route path="/profile" element={<ErrorBoundary><ProfilePage /></ErrorBoundary>} />
                   <Route path="/about" element={<ErrorBoundary><AboutPage /></ErrorBoundary>} />
+                  <Route path="/inbox" element={<ErrorBoundary><InboxPage /></ErrorBoundary>} />
                 </Route>
                 <Route path="/success" element={<ErrorBoundary><SuccessPage /></ErrorBoundary>} />
               </Route>

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+
+// jsdom doesn't implement window.matchMedia; mock it so hooks using it don't crash.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1016,11 +1016,35 @@ select {
     color: var(--ink-2);
 }
 .zp-special-diet-textarea {
-    margin-top: 12px;
+    margin-top: 8px;
     resize: vertical;
     min-height: 72px;
     font-size: 14px;
     padding: 10px 12px;
+}
+.zp-special-diet-note-box {
+    background: var(--bg-cream-warm);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius-lg);
+    padding: 14px 16px;
+    margin-bottom: 12px;
+}
+.zp-special-diet-note-label {
+    display: block;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--ink-2);
+    margin-bottom: 4px;
+}
+.zp-fullday-info {
+    font-size: 13px;
+    color: var(--ink-2);
+    background: var(--bg-cream-soft);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius-md);
+    padding: 8px 12px;
+    margin-bottom: 10px;
 }
 
 /* Category row inside meal */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1041,6 +1041,25 @@ select {
 .zp-menurow .diet-trigger:hover { background: var(--peach-400); }
 .zp-menurow .spacer { flex: 1; }
 
+.zp-menurow--occupied {
+    opacity: 0.5;
+}
+.zp-menurow--occupied .name {
+    color: var(--ink-3);
+    text-decoration: line-through;
+}
+.zp-menurow-occupied-label {
+    font-family: var(--font-display);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--ink-3);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 3px 8px;
+    border-radius: var(--radius-pill);
+    background: var(--line-soft);
+}
+
 .zp-counter {
     display: flex;
     align-items: center;
@@ -1379,7 +1398,7 @@ select {
     top: 8px;
     bottom: 8px;
     left: 8px;
-    width: calc((100% - 24px) / 3);
+    width: calc((100% - 28px) / 4);
     border-radius: 16px;
     background: var(--bg-cream-soft);
     box-shadow: 0 1px 4px rgba(0,0,0,0.06);
@@ -1669,6 +1688,62 @@ select {
     color: var(--ink-3);
     margin-top: 2px;
     line-height: 1.5;
+}
+
+/* ========================================================== *
+ * Inbox
+ * ========================================================== */
+
+.zp-inbox-msg {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 14px 16px;
+    background: var(--bg-cream-warm);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius-card);
+    text-align: left;
+    cursor: pointer;
+    width: 100%;
+    transition: background 150ms;
+}
+.zp-inbox-msg:hover { background: var(--bg-cream-soft); }
+
+.zp-inbox-msg--unread {
+    background: var(--bg-cream-soft);
+    border-color: var(--green-300);
+}
+.zp-inbox-msg-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: transparent;
+    flex-shrink: 0;
+    margin-top: 5px;
+}
+.zp-inbox-msg--unread .zp-inbox-msg-dot {
+    background: var(--green-600);
+}
+.zp-inbox-msg-body { flex: 1; min-width: 0; }
+.zp-inbox-msg-title {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 14px;
+    color: var(--ink-1);
+    margin-bottom: 3px;
+}
+.zp-inbox-msg--unread .zp-inbox-msg-title { color: var(--green-800); }
+.zp-inbox-msg-text {
+    font-size: 13px;
+    color: var(--ink-2);
+    line-height: 1.5;
+    margin-bottom: 5px;
+}
+.zp-inbox-msg-meta {
+    font-size: 11px;
+    color: var(--ink-3);
+    display: flex;
+    align-items: center;
 }
 
 /* ========================================================== *

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1238,6 +1238,16 @@ select {
     display: flex;
     flex-direction: column;
 }
+.pc-app .zp-sheet-scrim {
+    align-items: center;
+    justify-content: center;
+}
+.pc-app .zp-sheet {
+    width: 420px;
+    border-radius: var(--radius-xl);
+    min-height: unset;
+    max-height: 70vh;
+}
 .zp-sheet-grab {
     width: 44px;
     height: 4px;
@@ -1457,7 +1467,7 @@ select {
     top: 8px;
     bottom: 8px;
     left: 8px;
-    width: calc((100% - 28px) / 4);
+    width: calc((100% - 24px) / 3);
     border-radius: 16px;
     background: var(--bg-cream-soft);
     box-shadow: 0 1px 4px rgba(0,0,0,0.06);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -474,6 +474,14 @@ select {
     transition: all 180ms cubic-bezier(.4,0,.2,1);
 }
 .zp-input::placeholder { color: var(--ink-mute); }
+.zp-input--error {
+    border-color: var(--coral-500);
+    background: var(--bg-cream-warm);
+}
+.zp-input--error:focus {
+    border-color: var(--coral-600);
+    box-shadow: 0 0 0 3px rgba(220,80,60,0.14);
+}
 .zp-input:focus {
     border-color: var(--green-600);
     background: var(--bg-cream-warm);
@@ -987,6 +995,33 @@ select {
     margin-bottom: 12px;
 }
 .zp-copybar .zp-btn { flex: 1; padding: 9px 12px; font-size: 12px; }
+
+/* Special diet section inside meal */
+.zp-special-diet {
+    background: var(--bg-cream-warm);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius-md);
+    padding: 12px 14px;
+    margin-bottom: 10px;
+}
+.zp-special-diet-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.zp-special-diet-label {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--ink-2);
+}
+.zp-special-diet-textarea {
+    margin-top: 12px;
+    resize: vertical;
+    min-height: 72px;
+    font-size: 14px;
+    padding: 10px 12px;
+}
 
 /* Category row inside meal */
 .zp-cat {

--- a/frontend/src/pages/client/components/ClientLayout.tsx
+++ b/frontend/src/pages/client/components/ClientLayout.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
-import { Home, BookOpen, Plus, Bell } from "lucide-react";
+import { Home, BookOpen, Plus } from "lucide-react";
 import { useStableViewportHeight } from "../../../hooks/useStableViewportHeight";
 import { useIsPC } from "../../../hooks/useIsPC";
 import ClientLayoutPC from "./ClientLayoutPC";
@@ -9,17 +9,15 @@ const tabs = [
   { to: "/menu", label: "Jedálniček", icon: BookOpen },
   { to: "/home", label: "Domov", icon: Home },
   { to: "/order", label: "Objednávka", icon: Plus, action: true },
-  { to: "/inbox", label: "Správy", icon: Bell },
 ];
 
 // left position of the indicator pill for each tab index.
-// Derived from: padding=8px, gap=4px, 4 equal tabs.
-// Each tab width = (W-28px)/4  (28 = 16px padding + 12px gaps)
+// Derived from: padding=8px, gap=4px, 3 equal tabs.
+// Each tab width = (W-24px)/3  (24 = 16px padding + 8px gaps)
 // Tab 0: 8px
-// Tab 1: (W-28)/4 + 12 = W/4 + 5 = calc(25% + 5px)
-// Tab 2: 2*(W-28)/4 + 16 = W/2 + 2 = calc(50% + 2px)
-// Tab 3: 3*(W-28)/4 + 20 = 3W/4 - 1 = calc(75% - 1px)
-const INDICATOR_LEFT = ["8px", "calc(25% + 5px)", "calc(50% + 2px)", "calc(75% - 1px)"];
+// Tab 1: (W-24)/3 + 12 = W/3 + 4 = calc(33.333% + 4px)
+// Tab 2: 2*(W-24)/3 + 16 = 2W/3 - 0 = calc(66.666%)
+const INDICATOR_LEFT = ["8px", "calc(33.333% + 4px)", "calc(66.666%)"];
 
 const ClientLayout = () => {
   const location = useLocation();

--- a/frontend/src/pages/client/components/ClientLayout.tsx
+++ b/frontend/src/pages/client/components/ClientLayout.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { Outlet, NavLink, useLocation, useNavigate } from "react-router-dom";
-import { Home, BookOpen, Plus } from "lucide-react";
+import { Home, BookOpen, Plus, Bell } from "lucide-react";
 import { useStableViewportHeight } from "../../../hooks/useStableViewportHeight";
 import { useIsPC } from "../../../hooks/useIsPC";
 import ClientLayoutPC from "./ClientLayoutPC";
@@ -8,15 +8,18 @@ import ClientLayoutPC from "./ClientLayoutPC";
 const tabs = [
   { to: "/menu", label: "Jedálniček", icon: BookOpen },
   { to: "/home", label: "Domov", icon: Home },
-  { to: "/order", label: "Nová objednávka", icon: Plus, action: true },
+  { to: "/order", label: "Objednávka", icon: Plus, action: true },
+  { to: "/inbox", label: "Správy", icon: Bell },
 ];
 
 // left position of the indicator pill for each tab index.
-// Derived from: padding=8px, gap=4px, 3 equal tabs.
-// Tab 0: left=8px
-// Tab 1: left = (W-24px)/3 + 12px = W/3 + 4px = calc(33.333% + 4px)
-// Tab 2: left = 2(W-24px)/3 + 16px = 2W/3 = calc(66.667%)
-const INDICATOR_LEFT = ["8px", "calc(33.333% + 4px)", "calc(66.667%)"];
+// Derived from: padding=8px, gap=4px, 4 equal tabs.
+// Each tab width = (W-28px)/4  (28 = 16px padding + 12px gaps)
+// Tab 0: 8px
+// Tab 1: (W-28)/4 + 12 = W/4 + 5 = calc(25% + 5px)
+// Tab 2: 2*(W-28)/4 + 16 = W/2 + 2 = calc(50% + 2px)
+// Tab 3: 3*(W-28)/4 + 20 = 3W/4 - 1 = calc(75% - 1px)
+const INDICATOR_LEFT = ["8px", "calc(25% + 5px)", "calc(50% + 2px)", "calc(75% - 1px)"];
 
 const ClientLayout = () => {
   const location = useLocation();

--- a/frontend/src/pages/client/components/ClientLayoutPC.tsx
+++ b/frontend/src/pages/client/components/ClientLayoutPC.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { Home, BookOpen, Plus, Settings, LogOut, Bell } from 'lucide-react';
+import { Home, BookOpen, Plus, Settings, LogOut, Mail } from 'lucide-react';
 import { useAuth } from '../../../context/auth';
 import ConfirmationModal from './ui/ConfirmationModal';
 
@@ -8,7 +8,6 @@ const NAV: { to: string; label: string; icon: React.ComponentType<{ style?: Reac
   { to: '/home', label: 'Domov', icon: Home },
   { to: '/order', label: 'Nová objednávka', icon: Plus, cta: true },
   { to: '/menu', label: 'Jedálniček', icon: BookOpen },
-  { to: '/inbox', label: 'Správy', icon: Bell },
   { to: '/settings', label: 'Nastavenia', icon: Settings },
 ];
 
@@ -81,6 +80,14 @@ export default function ClientLayoutPC() {
             <h1>{title.h1}</h1>
           </div>
           <div className="pc-topbar-actions">
+            <NavLink
+              to="/inbox"
+              className="pc-iconbtn"
+              aria-label="Správy"
+              title="Správy"
+            >
+              <Mail style={{ width: 20, height: 20 }} />
+            </NavLink>
             <button
               className="pc-iconbtn"
               aria-label="Odhlásiť sa"

--- a/frontend/src/pages/client/components/ClientLayoutPC.tsx
+++ b/frontend/src/pages/client/components/ClientLayoutPC.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { Home, BookOpen, Plus, Settings, LogOut } from 'lucide-react';
+import { Home, BookOpen, Plus, Settings, LogOut, Bell } from 'lucide-react';
 import { useAuth } from '../../../context/auth';
 import ConfirmationModal from './ui/ConfirmationModal';
 
@@ -8,6 +8,7 @@ const NAV: { to: string; label: string; icon: React.ComponentType<{ style?: Reac
   { to: '/home', label: 'Domov', icon: Home },
   { to: '/order', label: 'Nová objednávka', icon: Plus, cta: true },
   { to: '/menu', label: 'Jedálniček', icon: BookOpen },
+  { to: '/inbox', label: 'Správy', icon: Bell },
   { to: '/settings', label: 'Nastavenia', icon: Settings },
 ];
 
@@ -15,6 +16,7 @@ const PAGE_TITLES: Record<string, { eye: string; h1: string }> = {
   '/home':     { eye: 'Prehľad týždňa', h1: 'Domov' },
   '/menu':     { eye: 'Jedálniček týždňa', h1: 'Jedálniček' },
   '/order':    { eye: 'Plánovanie objednávky', h1: 'Nová objednávka' },
+  '/inbox':    { eye: 'Vaše notifikácie', h1: 'Správy' },
   '/settings': { eye: 'Účet a stravovanie', h1: 'Nastavenia' },
   '/success':  { eye: 'Hotovo', h1: 'Objednávka odoslaná' },
 };

--- a/frontend/src/pages/client/components/order/CategoryRow.tsx
+++ b/frontend/src/pages/client/components/order/CategoryRow.tsx
@@ -7,9 +7,20 @@ interface MenuCounterProps {
     onOpenDiets: (() => void) | null;
     dietCount: number;
     disabled?: boolean;
+    isOccupied?: boolean;
 }
 
-const MenuCounter = ({ type, count, onChange, onOpenDiets, dietCount, disabled }: MenuCounterProps) => {
+const MenuCounter = ({ type, count, onChange, onOpenDiets, dietCount, disabled, isOccupied }: MenuCounterProps) => {
+    if (isOccupied) {
+        return (
+            <div className="zp-menurow zp-menurow--occupied">
+                <span className="name">Menu {type}</span>
+                <span className="spacer"></span>
+                <span className="zp-menurow-occupied-label">zasednutá</span>
+            </div>
+        );
+    }
+
     return (
         <div className="zp-menurow">
             <span className="name">Menu {type}</span>
@@ -51,6 +62,7 @@ interface CategoryRowProps {
     hasDietsEnabled: boolean;
     disabled?: boolean;
     visibleMenus?: string[];
+    occupiedMenus?: Set<string>;
     tourId?: string;
 }
 
@@ -63,6 +75,7 @@ const CategoryRow = ({
     hasDietsEnabled,
     disabled,
     visibleMenus,
+    occupiedMenus,
     tourId,
 }: CategoryRowProps) => {
     let menus = Object.keys(menuCounts || {});
@@ -88,6 +101,7 @@ const CategoryRow = ({
                     onOpenDiets={hasDietsEnabled && menuType === 'A' && !disabled ? onOpenDiets : null}
                     dietCount={dietCount}
                     disabled={disabled}
+                    isOccupied={occupiedMenus?.has(menuType)}
                 />
             ))}
         </div>

--- a/frontend/src/pages/client/config/constants.ts
+++ b/frontend/src/pages/client/config/constants.ts
@@ -2,8 +2,11 @@ export const CATEGORIES = ['Jasle', 'Škôlka', 'ZŠ 1.stupeň', 'ZŠ 2.stupeň'
 
 export const DIETS = [
     'Bez lepku', 'Bez laktózy', 'Vegetariánske', 'Vegánske', 'Diabetické',
-    'Nízky obsah soli', 'Bez orechov', 'Bez vajec', 'Bez sóje', 'Jemná / light'
+    'Nízky obsah soli', 'Bez orechov', 'Bez vajec', 'Bez sóje', 'Jemná / light',
+    'Špeciálna',
 ];
+
+export const SPECIAL_DIET_NAME = 'Špeciálna';
 
 export const GROUP_CONFIG: Record<string, string[]> = {
     'Jasle': ['A'],

--- a/frontend/src/pages/client/hooks/useOrder.ts
+++ b/frontend/src/pages/client/hooks/useOrder.ts
@@ -116,6 +116,11 @@ export const useOrder = () => {
         safeParse(`fullDayOrder_${selectedDate}`, false)
     );
 
+    const defaultSpecialDiets = { breakfast: { enabled: false, note: '' }, lunch: { enabled: false, note: '' }, olovrant: { enabled: false, note: '' } };
+    const [specialDiets, setSpecialDiets] = useState<Record<string, { enabled: boolean; note: string }>>(() =>
+        safeParse(`specialDiets_${selectedDate}`, defaultSpecialDiets)
+    );
+
     const [currentOrder, setCurrentOrder] = useState<DailyOrder>(() => {
         // Use Factory for initial state
         const initial: DailyOrder = {
@@ -158,6 +163,7 @@ export const useOrder = () => {
     useEffect(() => { localStorage.setItem(`order_${selectedDateRef.current}`, JSON.stringify(currentOrder)); }, [currentOrder]);
     useEffect(() => { localStorage.setItem(`activeMeals_${selectedDateRef.current}`, JSON.stringify(activeMeals)); }, [activeMeals]);
     useEffect(() => { localStorage.setItem(`fullDayOrder_${selectedDateRef.current}`, JSON.stringify(fullDayOrder)); }, [fullDayOrder]);
+    useEffect(() => { localStorage.setItem(`specialDiets_${selectedDateRef.current}`, JSON.stringify(specialDiets)); }, [specialDiets]);
 
     // Reset/Re-init on Date Change
     useEffect(() => {
@@ -180,6 +186,7 @@ export const useOrder = () => {
         setActiveMeals(newActive);
         setCurrentOrder(newOrder);
         setFullDayOrderState(safeParse(`fullDayOrder_${selectedDate}`, false));
+        setSpecialDiets(safeParse(`specialDiets_${selectedDate}`, defaultSpecialDiets));
     }, [selectedDate]);
 
     // Fetch Order from API (server authority; merges into local state)
@@ -469,6 +476,13 @@ export const useOrder = () => {
         setFullDayOrderState(prev => !prev);
     };
 
+    const updateSpecialDiet = (mealKey: 'breakfast' | 'lunch' | 'olovrant', field: 'enabled' | 'note', value: boolean | string) => {
+        setSpecialDiets(prev => ({
+            ...prev,
+            [mealKey]: { ...prev[mealKey], [field]: value },
+        }));
+    };
+
 
 
     const updateDiet = (mealKey: 'breakfast' | 'lunch' | 'olovrant', category: string, diet: string, count: number) => {
@@ -511,7 +525,7 @@ export const useOrder = () => {
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ date, status: 'submitted', data: payload })
+                body: JSON.stringify({ date, status: 'submitted', data: { ...payload, special_diets: specialDiets } })
             });
 
             if (!response.ok) {
@@ -654,6 +668,7 @@ export const useOrder = () => {
         selectedDate, setSelectedDate,
         currentOrder, activeMeals, toggleMeal,
         fullDayOrder, toggleFullDay,
+        specialDiets, updateSpecialDiet,
         updateMenuCount, updateDiet,
         getAvailableDiets,
         prevDayLunches,

--- a/frontend/src/pages/client/hooks/useOrder.ts
+++ b/frontend/src/pages/client/hooks/useOrder.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import OrderService, { DailyOrder, MealData } from '../services/OrderService';
 import { useAuth } from '../../../context/auth';
-import { CATEGORIES } from '../config/constants';
+import { CATEGORIES, SPECIAL_DIET_NAME } from '../config/constants';
 import { logger } from '../../../lib/logger';
 
 const API_URL = import.meta.env.VITE_API_URL || '/api';
@@ -116,9 +116,12 @@ export const useOrder = () => {
         safeParse(`fullDayOrder_${selectedDate}`, false)
     );
 
-    const defaultSpecialDiets = { breakfast: { enabled: false, note: '' }, lunch: { enabled: false, note: '' }, olovrant: { enabled: false, note: '' } };
-    const [specialDiets, setSpecialDiets] = useState<Record<string, { enabled: boolean; note: string }>>(() =>
-        safeParse(`specialDiets_${selectedDate}`, defaultSpecialDiets)
+    const [fullDayData, setFullDayData] = useState<MealData>(() =>
+        safeParse(`fullDayData_${selectedDate}`, OrderService.createEmptyMeal())
+    );
+
+    const [specialDietNote, setSpecialDietNote] = useState<string>(() =>
+        safeParse(`specialDietNote_${selectedDate}`, '')
     );
 
     const [currentOrder, setCurrentOrder] = useState<DailyOrder>(() => {
@@ -163,7 +166,8 @@ export const useOrder = () => {
     useEffect(() => { localStorage.setItem(`order_${selectedDateRef.current}`, JSON.stringify(currentOrder)); }, [currentOrder]);
     useEffect(() => { localStorage.setItem(`activeMeals_${selectedDateRef.current}`, JSON.stringify(activeMeals)); }, [activeMeals]);
     useEffect(() => { localStorage.setItem(`fullDayOrder_${selectedDateRef.current}`, JSON.stringify(fullDayOrder)); }, [fullDayOrder]);
-    useEffect(() => { localStorage.setItem(`specialDiets_${selectedDateRef.current}`, JSON.stringify(specialDiets)); }, [specialDiets]);
+    useEffect(() => { localStorage.setItem(`fullDayData_${selectedDateRef.current}`, JSON.stringify(fullDayData)); }, [fullDayData]);
+    useEffect(() => { localStorage.setItem(`specialDietNote_${selectedDateRef.current}`, JSON.stringify(specialDietNote)); }, [specialDietNote]);
 
     // Reset/Re-init on Date Change
     useEffect(() => {
@@ -186,7 +190,8 @@ export const useOrder = () => {
         setActiveMeals(newActive);
         setCurrentOrder(newOrder);
         setFullDayOrderState(safeParse(`fullDayOrder_${selectedDate}`, false));
-        setSpecialDiets(safeParse(`specialDiets_${selectedDate}`, defaultSpecialDiets));
+        setFullDayData(safeParse(`fullDayData_${selectedDate}`, OrderService.createEmptyMeal()));
+        setSpecialDietNote(safeParse(`specialDietNote_${selectedDate}`, ''));
     }, [selectedDate]);
 
     // Fetch Order from API (server authority; merges into local state)
@@ -476,11 +481,22 @@ export const useOrder = () => {
         setFullDayOrderState(prev => !prev);
     };
 
-    const updateSpecialDiet = (mealKey: 'breakfast' | 'lunch' | 'olovrant', field: 'enabled' | 'note', value: boolean | string) => {
-        setSpecialDiets(prev => ({
-            ...prev,
-            [mealKey]: { ...prev[mealKey], [field]: value },
-        }));
+    const updateFullDayMenuCount = (category: string, menuType: string, count: number) => {
+        setFullDayData(prev => {
+            const wrapper = { status: 'draft' as const, breakfast: prev, lunch: OrderService.createEmptyMeal(), olovrant: OrderService.createEmptyMeal() };
+            return OrderService.updateMenuCount(wrapper, 'breakfast', category, menuType, count).breakfast;
+        });
+    };
+
+    const updateFullDayDiet = (category: string, diet: string, count: number) => {
+        setFullDayData(prev => {
+            const wrapper = { status: 'draft' as const, breakfast: prev, lunch: OrderService.createEmptyMeal(), olovrant: OrderService.createEmptyMeal() };
+            return OrderService.updateDiet(wrapper, 'breakfast', category, diet, count).breakfast;
+        });
+    };
+
+    const clearFullDay = () => {
+        setFullDayData(OrderService.createEmptyMeal());
     };
 
 
@@ -513,10 +529,13 @@ export const useOrder = () => {
         const isMealActive = (key: 'breakfast' | 'lunch' | 'olovrant') =>
             fullDayOrder ? adminVisibleMeals.includes(key) : activeMeals[key];
 
+        const mealData = (key: 'breakfast' | 'lunch' | 'olovrant') =>
+            fullDayOrder ? fullDayData : currentOrder[key];
+
         const payload = {
-            breakfast: isMealActive('breakfast') ? currentOrder.breakfast : OrderService.createEmptyMeal(),
-            lunch: isMealActive('lunch') ? currentOrder.lunch : OrderService.createEmptyMeal(),
-            olovrant: isMealActive('olovrant') ? currentOrder.olovrant : OrderService.createEmptyMeal(),
+            breakfast: isMealActive('breakfast') ? mealData('breakfast') : OrderService.createEmptyMeal(),
+            lunch: isMealActive('lunch') ? mealData('lunch') : OrderService.createEmptyMeal(),
+            olovrant: isMealActive('olovrant') ? mealData('olovrant') : OrderService.createEmptyMeal(),
         };
 
         try {
@@ -525,7 +544,7 @@ export const useOrder = () => {
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ date, status: 'submitted', data: { ...payload, special_diets: specialDiets } })
+                body: JSON.stringify({ date, status: 'submitted', data: { ...payload, special_diet_note: specialDietNote || undefined } })
             });
 
             if (!response.ok) {
@@ -606,7 +625,11 @@ export const useOrder = () => {
 
     // Override getAvailableDiets to intersection of enabledDiets (local preference) AND adminVisibleDiets
     const getAvailableDiets = (categoryName: string) => {
-        return OrderService.getAvailableDiets(categoryName, adminVisibleDiets);
+        const diets = OrderService.getAvailableDiets(categoryName, adminVisibleDiets);
+        if (!diets.includes(SPECIAL_DIET_NAME)) {
+            return [...diets, SPECIAL_DIET_NAME];
+        }
+        return diets;
     };
 
 
@@ -668,7 +691,8 @@ export const useOrder = () => {
         selectedDate, setSelectedDate,
         currentOrder, activeMeals, toggleMeal,
         fullDayOrder, toggleFullDay,
-        specialDiets, updateSpecialDiet,
+        fullDayData, updateFullDayMenuCount, updateFullDayDiet, clearFullDay,
+        specialDietNote, setSpecialDietNote,
         updateMenuCount, updateDiet,
         getAvailableDiets,
         prevDayLunches,

--- a/frontend/src/pages/client/hooks/useOrder.ts
+++ b/frontend/src/pages/client/hooks/useOrder.ts
@@ -112,6 +112,10 @@ export const useOrder = () => {
 
     const [activeMeals, setActiveMeals] = useState<Record<string, boolean>>(() => safeParse(`activeMeals_${selectedDate}`, { breakfast: false, lunch: true, olovrant: false }));
 
+    const [fullDayOrder, setFullDayOrderState] = useState<boolean>(() =>
+        safeParse(`fullDayOrder_${selectedDate}`, false)
+    );
+
     const [currentOrder, setCurrentOrder] = useState<DailyOrder>(() => {
         // Use Factory for initial state
         const initial: DailyOrder = {
@@ -153,6 +157,7 @@ export const useOrder = () => {
     useEffect(() => { localStorage.setItem('appSettings', JSON.stringify(settings)); }, [settings]);
     useEffect(() => { localStorage.setItem(`order_${selectedDateRef.current}`, JSON.stringify(currentOrder)); }, [currentOrder]);
     useEffect(() => { localStorage.setItem(`activeMeals_${selectedDateRef.current}`, JSON.stringify(activeMeals)); }, [activeMeals]);
+    useEffect(() => { localStorage.setItem(`fullDayOrder_${selectedDateRef.current}`, JSON.stringify(fullDayOrder)); }, [fullDayOrder]);
 
     // Reset/Re-init on Date Change
     useEffect(() => {
@@ -174,6 +179,7 @@ export const useOrder = () => {
         setTouchedMeals(new Set());
         setActiveMeals(newActive);
         setCurrentOrder(newOrder);
+        setFullDayOrderState(safeParse(`fullDayOrder_${selectedDate}`, false));
     }, [selectedDate]);
 
     // Fetch Order from API (server authority; merges into local state)
@@ -272,6 +278,34 @@ export const useOrder = () => {
         };
         if (user) fetchPortionTypes();
     }, [apiFetch, user]);
+
+    // Meal plan availability: mealKey → Set of available menu_variants; null = no plan = no restriction
+    const [mealPlanAvailability, setMealPlanAvailability] = useState<Record<string, Set<string>> | null>(null);
+
+    useEffect(() => {
+        const fetchMealPlanAvailability = async () => {
+            try {
+                const res = await apiFetch(`${API_URL}/meal-plans/by-date/?date=${selectedDate}`);
+                if (!res.ok) { setMealPlanAvailability(null); return; }
+                const data = await res.json();
+                if (!data.exists || !Array.isArray(data.items) || data.items.length === 0) {
+                    setMealPlanAvailability(null);
+                    return;
+                }
+                const availability: Record<string, Set<string>> = {};
+                for (const item of data.items) {
+                    const mealKey: string = item.category;
+                    if (!availability[mealKey]) availability[mealKey] = new Set();
+                    if (item.menu_variant) availability[mealKey].add(item.menu_variant);
+                }
+                setMealPlanAvailability(availability);
+            } catch (e) {
+                logger.error("Failed to fetch meal plan availability", e);
+                setMealPlanAvailability(null);
+            }
+        };
+        if (user) fetchMealPlanAvailability();
+    }, [selectedDate, apiFetch, user]);
 
     // Holidays: set of date strings "YYYY-MM-DD" that are blocked
     const [holidays, setHolidays] = useState<Set<string>>(new Set());
@@ -431,6 +465,10 @@ export const useOrder = () => {
         setActiveMeals(prev => ({ ...prev, [mealKey]: !prev[mealKey] }));
     };
 
+    const toggleFullDay = () => {
+        setFullDayOrderState(prev => !prev);
+    };
+
 
 
     const updateDiet = (mealKey: 'breakfast' | 'lunch' | 'olovrant', category: string, diet: string, count: number) => {
@@ -458,11 +496,13 @@ export const useOrder = () => {
 
 
     const submitOrder = async (date: string) => {
-        // Prepare payload - only active meals
+        const isMealActive = (key: 'breakfast' | 'lunch' | 'olovrant') =>
+            fullDayOrder ? adminVisibleMeals.includes(key) : activeMeals[key];
+
         const payload = {
-            breakfast: activeMeals.breakfast ? currentOrder.breakfast : OrderService.createEmptyMeal(),
-            lunch: activeMeals.lunch ? currentOrder.lunch : OrderService.createEmptyMeal(),
-            olovrant: activeMeals.olovrant ? currentOrder.olovrant : OrderService.createEmptyMeal(),
+            breakfast: isMealActive('breakfast') ? currentOrder.breakfast : OrderService.createEmptyMeal(),
+            lunch: isMealActive('lunch') ? currentOrder.lunch : OrderService.createEmptyMeal(),
+            olovrant: isMealActive('olovrant') ? currentOrder.olovrant : OrderService.createEmptyMeal(),
         };
 
         try {
@@ -613,6 +653,7 @@ export const useOrder = () => {
         visibleDietDetails,
         selectedDate, setSelectedDate,
         currentOrder, activeMeals, toggleMeal,
+        fullDayOrder, toggleFullDay,
         updateMenuCount, updateDiet,
         getAvailableDiets,
         prevDayLunches,
@@ -625,5 +666,6 @@ export const useOrder = () => {
         globalDeadlines,
         clientContactInfo,
         holidays,
+        mealPlanAvailability,
     };
 };

--- a/frontend/src/pages/client/pages/HomePage.tsx
+++ b/frontend/src/pages/client/pages/HomePage.tsx
@@ -14,6 +14,7 @@ import {
   History,
   ChevronRight,
   Settings,
+  Mail,
 } from "lucide-react";
 import { useApp } from "../context/AppContext";
 import { useAuth } from "../../../context/auth";
@@ -706,14 +707,23 @@ const HomePage = () => {
             alt="Zdravý projekt"
             style={{ height: 32, width: "auto", display: "block" }}
           />
-          <Link
-            to="/settings"
-            className="zp-iconbtn"
-            aria-label="Nastavenia"
-            data-tour-id="tour-profile-btn"
-          >
-            <Settings />
-          </Link>
+          <div style={{ display: "flex", gap: 4 }}>
+            <Link
+              to="/inbox"
+              className="zp-iconbtn"
+              aria-label="Správy"
+            >
+              <Mail />
+            </Link>
+            <Link
+              to="/settings"
+              className="zp-iconbtn"
+              aria-label="Nastavenia"
+              data-tour-id="tour-profile-btn"
+            >
+              <Settings />
+            </Link>
+          </div>
         </div>
 
         {/* Greeting */}

--- a/frontend/src/pages/client/pages/InboxPage.tsx
+++ b/frontend/src/pages/client/pages/InboxPage.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect, useCallback } from "react";
+import { Bell, CheckCheck, ExternalLink } from "lucide-react";
+import { useAuth } from "../../../context/auth";
+import { useNavigate } from "react-router-dom";
+
+const API_URL = import.meta.env.VITE_API_URL || "/api";
+
+interface InboxMessage {
+    id: number;
+    title: string;
+    body: string;
+    url: string;
+    created_at: string;
+    read_at: string | null;
+    is_read: boolean;
+}
+
+const InboxPage = () => {
+    const { apiFetch, user } = useAuth();
+    const navigate = useNavigate();
+    const [messages, setMessages] = useState<InboxMessage[]>([]);
+    const [unreadCount, setUnreadCount] = useState(0);
+    const [loading, setLoading] = useState(true);
+
+    const fetchMessages = useCallback(async () => {
+        try {
+            const res = await apiFetch(`${API_URL}/inbox/`);
+            if (!res.ok) return;
+            const data = await res.json();
+            const results: InboxMessage[] = data.results ?? data;
+            setMessages(results);
+            setUnreadCount(data.unread_count ?? 0);
+        } finally {
+            setLoading(false);
+        }
+    }, [apiFetch]);
+
+    useEffect(() => {
+        if (user) fetchMessages();
+    }, [user, fetchMessages]);
+
+    const markRead = async (id: number) => {
+        const res = await apiFetch(`${API_URL}/inbox/${id}/read/`, { method: "POST" });
+        if (res.ok) {
+            setMessages(prev => prev.map(m => m.id === id ? { ...m, is_read: true, read_at: new Date().toISOString() } : m));
+            setUnreadCount(prev => Math.max(0, prev - 1));
+        }
+    };
+
+    const markAllRead = async () => {
+        const res = await apiFetch(`${API_URL}/inbox/read-all/`, { method: "POST" });
+        if (res.ok) {
+            setMessages(prev => prev.map(m => ({ ...m, is_read: true, read_at: m.read_at ?? new Date().toISOString() })));
+            setUnreadCount(0);
+        }
+    };
+
+    const handleMessageClick = (msg: InboxMessage) => {
+        if (!msg.is_read) markRead(msg.id);
+        if (msg.url && msg.url !== "/home") {
+            navigate(msg.url);
+        }
+    };
+
+    const fmt = (iso: string) => {
+        const d = new Date(iso);
+        return new Intl.DateTimeFormat("sk-SK", { day: "numeric", month: "long", hour: "2-digit", minute: "2-digit" }).format(d);
+    };
+
+    return (
+        <div className="zp-app">
+            <div className="zp-orderpage">
+                <div className="zp-orderbar">
+                    <div>
+                        <h1>Správy</h1>
+                        <p>Vaše notifikácie a správy</p>
+                    </div>
+                    {unreadCount > 0 && (
+                        <button
+                            className="zp-btn zp-btn--secondary zp-btn--sm"
+                            style={{ marginLeft: "auto" }}
+                            onClick={markAllRead}
+                        >
+                            <CheckCheck style={{ width: 14, height: 14 }} />
+                            Označiť všetko
+                        </button>
+                    )}
+                </div>
+
+                {loading ? (
+                    <div style={{ padding: "32px 0", textAlign: "center", color: "var(--ink-3)", fontSize: 14 }}>
+                        Načítavam…
+                    </div>
+                ) : messages.length === 0 ? (
+                    <div className="zp-meal" style={{ textAlign: "center", padding: "40px 24px" }}>
+                        <Bell style={{ width: 36, height: 36, color: "var(--ink-3)", margin: "0 auto 12px" }} />
+                        <div style={{ fontFamily: "var(--font-display)", fontWeight: 700, fontSize: 15, color: "var(--ink-2)" }}>
+                            Žiadne správy
+                        </div>
+                        <div style={{ fontSize: 13, color: "var(--ink-3)", marginTop: 4 }}>
+                            Tu sa zobrazia vaše notifikácie.
+                        </div>
+                    </div>
+                ) : (
+                    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                        {messages.map(msg => (
+                            <button
+                                key={msg.id}
+                                className={`zp-inbox-msg${msg.is_read ? "" : " zp-inbox-msg--unread"}`}
+                                onClick={() => handleMessageClick(msg)}
+                            >
+                                <div className="zp-inbox-msg-dot" />
+                                <div className="zp-inbox-msg-body">
+                                    <div className="zp-inbox-msg-title">{msg.title}</div>
+                                    <div className="zp-inbox-msg-text">{msg.body}</div>
+                                    <div className="zp-inbox-msg-meta">
+                                        {fmt(msg.created_at)}
+                                        {msg.url && msg.url !== "/home" && (
+                                            <ExternalLink style={{ width: 11, height: 11, marginLeft: 4 }} />
+                                        )}
+                                    </div>
+                                </div>
+                            </button>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default InboxPage;

--- a/frontend/src/pages/client/pages/OrderPage.test.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.test.tsx
@@ -426,8 +426,7 @@ describe("OrderPage Logic & Triggers", () => {
     // Verify the POST request has all 3 meals with full-day data
     await waitFor(() => {
       const postCall = mockApiFetch.mock.calls.find(
-        ([url, init]: [string, RequestInit]) =>
-          url.includes("/orders/") && init?.method === "POST",
+        (call) => call[0]?.includes("/orders/") && call[1]?.method === "POST",
       );
       expect(postCall).toBeDefined();
 
@@ -464,8 +463,7 @@ describe("OrderPage Logic & Triggers", () => {
 
     await waitFor(() => {
       const postCall = mockApiFetch.mock.calls.find(
-        ([url, init]: [string, RequestInit]) =>
-          url.includes("/orders/") && init?.method === "POST",
+        (call) => call[0]?.includes("/orders/") && call[1]?.method === "POST",
       );
       expect(postCall).toBeDefined();
 

--- a/frontend/src/pages/client/pages/OrderPage.test.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.test.tsx
@@ -88,6 +88,10 @@ vi.mock("../services/OrderService", async (importOriginal) => {
   };
 });
 
+// Use local date (not UTC) to match what useOrder's selectedDate key uses.
+const localDateStr = (d = new Date()) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
 describe("OrderPage Logic & Triggers", () => {
   // Helper to interact with real localStorage in tests
   const localStorageMock = (function () {
@@ -172,7 +176,7 @@ describe("OrderPage Logic & Triggers", () => {
   };
 
   it("Copy Olovrant: Copies data from Lunch when triggered", async () => {
-    const date = new Date().toISOString().split("T")[0];
+    const date = localDateStr();
     // 1. Seed existing order with Lunch data using VALID category keys (e.g. Škôlka)
     const mockOrder = {
       status: "draft",
@@ -210,10 +214,10 @@ describe("OrderPage Logic & Triggers", () => {
   });
 
   it("Copy Breakfast: Copies from Previous Day Lunch", async () => {
-    const today = new Date().toISOString().split("T")[0];
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    const yesterdayStr = yesterday.toISOString().split("T")[0];
+    const today = localDateStr();
+    const prevDay = new Date();
+    prevDay.setDate(prevDay.getDate() - 1);
+    const yesterdayStr = localDateStr(prevDay);
 
     // 1. Seed YESTERDAY's order
     const prevOrder = {

--- a/frontend/src/pages/client/pages/OrderPage.test.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.test.tsx
@@ -367,4 +367,114 @@ describe("OrderPage Logic & Triggers", () => {
       screen.queryByText("Technicky detail zo servera"),
     ).not.toBeInTheDocument();
   });
+
+  // ── Celodenná objednávka (Full-day order) ───────────────────────────────────
+
+  it("Celodenná: renders the full-day card alongside individual meal cards", () => {
+    renderPage();
+    expect(screen.getAllByText("Celodenná objednávka")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Raňajky")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Obed")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Olovrant")[0]).toBeInTheDocument();
+  });
+
+  it("Celodenná: toggling ON locks all individual meal cards with status message", async () => {
+    renderPage();
+
+    const fullDaySwitch = screen.getByRole("switch", {
+      name: /Celodenná objednávka/i,
+    });
+    fireEvent.click(fullDaySwitch);
+
+    await waitFor(() => {
+      const lockBanners = screen.getAllByText("Celodenná objednávka je aktívna");
+      // One banner per individual meal card (Raňajky, Obed, Olovrant) = 3
+      expect(lockBanners.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it("Celodenná: submitting sends the same full-day data for all three meals", async () => {
+    const date = localDateStr();
+
+    // Seed full-day portion data. fullDayOrder itself cannot be pre-seeded via
+    // localStorage because safeParse/enforceStructure returns the fallback for
+    // primitive (boolean) values. We enable it through the UI toggle instead.
+    localStorageMock.setItem(
+      `fullDayData_${date}`,
+      JSON.stringify({
+        Škôlka: { menuCounts: { A: 7 }, diets: {} },
+      }),
+    );
+
+    renderPage();
+
+    // Enable full-day order via the toggle switch
+    const fullDaySwitch = screen.getByRole("switch", {
+      name: /Celodenná objednávka/i,
+    });
+    fireEvent.click(fullDaySwitch);
+
+    // Wait until individual cards show the lock banner (confirms fullDayOrder is ON)
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Celodenná objednávka je aktívna").length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    fireEvent.click(screen.getByText("Odoslať objednávku"));
+
+    // Verify the POST request has all 3 meals with full-day data
+    await waitFor(() => {
+      const postCall = mockApiFetch.mock.calls.find(
+        ([url, init]: [string, RequestInit]) =>
+          url.includes("/orders/") && init?.method === "POST",
+      );
+      expect(postCall).toBeDefined();
+
+      const body = JSON.parse(postCall![1].body as string);
+
+      // All three meals must carry the identical full-day portion data
+      expect(body.data.breakfast["Škôlka"].menuCounts["A"]).toBe(7);
+      expect(body.data.lunch["Škôlka"].menuCounts["A"]).toBe(7);
+      expect(body.data.olovrant["Škôlka"].menuCounts["A"]).toBe(7);
+    });
+  });
+
+  it("Celodenná: submitting with fullDayOrder OFF sends per-meal data independently", async () => {
+    const date = localDateStr();
+
+    // Full-day order is NOT active; each meal has its own data
+    localStorageMock.setItem(
+      `order_${date}`,
+      JSON.stringify({
+        status: "draft",
+        breakfast: { Škôlka: { menuCounts: { A: 2 }, diets: {} } },
+        lunch: { Škôlka: { menuCounts: { A: 5 }, diets: {} } },
+        olovrant: { Škôlka: { menuCounts: { A: 1 }, diets: {} } },
+      }),
+    );
+    localStorageMock.setItem(
+      `activeMeals_${date}`,
+      JSON.stringify({ breakfast: true, lunch: true, olovrant: true }),
+    );
+
+    renderPage();
+
+    fireEvent.click(screen.getByText("Odoslať objednávku"));
+
+    await waitFor(() => {
+      const postCall = mockApiFetch.mock.calls.find(
+        ([url, init]: [string, RequestInit]) =>
+          url.includes("/orders/") && init?.method === "POST",
+      );
+      expect(postCall).toBeDefined();
+
+      const body = JSON.parse(postCall![1].body as string);
+
+      // Each meal must have its own distinct count — NOT the same value
+      expect(body.data.breakfast["Škôlka"].menuCounts["A"]).toBe(2);
+      expect(body.data.lunch["Škôlka"].menuCounts["A"]).toBe(5);
+      expect(body.data.olovrant["Škôlka"].menuCounts["A"]).toBe(1);
+    });
+  });
 });

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -189,7 +189,7 @@ const OrderPage = () => {
 
   const handleSubmit = async () => {
     if (hasSpecialDietOrdered() && !specialDietNote.trim()) {
-      toast.error('Prosím špecifikujte špeciálnu objednávku pred odoslaním.');
+      toast.error('Prosím špecifikujte špeciálnu diétu pred odoslaním.');
       return;
     }
     try {
@@ -432,11 +432,11 @@ const OrderPage = () => {
   const specialDietNoteContent = hasSpecialDietOrdered() && (
     <div className="zp-special-diet-note-box">
       <label className="zp-special-diet-note-label">
-        Špecifikujte špeciálnu objednávku <span style={{ color: "var(--color-danger)" }}>*</span>
+        Špecifikujte špeciálnu diétu <span style={{ color: "var(--color-danger)" }}>*</span>
       </label>
       <textarea
         className={`zp-input zp-special-diet-textarea${!specialDietNote.trim() ? " zp-input--error" : ""}`}
-        placeholder="Popíšte vašu špeciálnu objednávku"
+        placeholder="Popíšte vašu špeciálnu diétu"
         value={specialDietNote}
         rows={3}
         onChange={e => setSpecialDietNote(e.target.value)}

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -29,8 +29,12 @@ const OrderPage = () => {
     toggleMeal,
     fullDayOrder,
     toggleFullDay,
-    specialDiets,
-    updateSpecialDiet,
+    fullDayData,
+    updateFullDayMenuCount,
+    updateFullDayDiet,
+    clearFullDay,
+    specialDietNote,
+    setSpecialDietNote,
     currentOrder,
     updateMenuCount,
     updateDiet,
@@ -57,7 +61,7 @@ const OrderPage = () => {
   const { isTourActive, currentStep } = useOnboarding();
 
   const [activeDietModal, setActiveDietModal] = useState<{
-    meal: "breakfast" | "lunch" | "olovrant";
+    meal: "breakfast" | "lunch" | "olovrant" | "fullDay";
     category: string;
   } | null>(null);
   const [showUnsavedModal, setShowUnsavedModal] = useState(false);
@@ -173,15 +177,19 @@ const OrderPage = () => {
     return total;
   };
 
-  const handleSubmit = async () => {
-    const mealsWithMissingNote = visibleMealsList.filter(({ key }) => {
-      const mealKey = key as 'breakfast' | 'lunch' | 'olovrant';
-      const sd = specialDiets[mealKey];
-      const isActive = activeMeals[mealKey] || fullDayOrder;
-      return isActive && sd?.enabled && !sd.note.trim();
+  const hasSpecialDietOrdered = (): boolean => {
+    const checkMeal = (meal: Record<string, CategoryData>) =>
+      Object.values(meal).some(cat => (cat.diets?.['Špeciálna'] ?? 0) > 0);
+    if (fullDayOrder) return checkMeal(fullDayData);
+    return visibleMealsList.some(({ key }) => {
+      const mealKey = key as "breakfast" | "lunch" | "olovrant";
+      return activeMeals[mealKey] && checkMeal(currentOrder[mealKey]);
     });
-    if (mealsWithMissingNote.length > 0) {
-      toast.error('Prosím popíšte špeciálnu diétu pred odoslaním objednávky.');
+  };
+
+  const handleSubmit = async () => {
+    if (hasSpecialDietOrdered() && !specialDietNote.trim()) {
+      toast.error('Prosím špecifikujte špeciálnu objednávku pred odoslaním.');
       return;
     }
     try {
@@ -312,30 +320,64 @@ const OrderPage = () => {
   const formattedDate = dateFormatter.format(dateObj);
   const totalPortions = getTotalPortions();
 
+  const fullDayMealLabels = visibleMealsList.map(m => m.label).join(' · ');
+  const isHolidayDay = holidays?.has(selectedDate);
+
   const mealCardsContent = (
     <div
-      style={holidays?.has(selectedDate) ? { opacity: 0.4, pointerEvents: "none" } : {}}
-      aria-disabled={holidays?.has(selectedDate) ? true : undefined}
+      style={isHolidayDay ? { opacity: 0.4, pointerEvents: "none" } : {}}
+      aria-disabled={isHolidayDay ? true : undefined}
     >
+      {/* Celodenná objednávka */}
       <MealCard
         title="Celodenná objednávka"
         icon={CalendarDays}
         isActive={fullDayOrder}
         onToggle={toggleFullDay}
         statusMessage={null}
-        copyAction={null}
+        copyAction={fullDayOrder ? (
+          <button
+            className="zp-btn zp-btn--danger zp-btn--sm"
+            style={{ flex: 1 }}
+            onClick={() => clearFullDay()}
+          >
+            <Trash2 style={{ width: 12, height: 12 }} /> Vymazať
+          </button>
+        ) : null}
       >
-        <div style={{ fontSize: 13, color: "var(--color-text-secondary)", padding: "4px 0" }}>
-          Objedná sa za všetky dostupné jedlá naraz.
+        <div>
+          <div className="zp-fullday-info">
+            Bude objednané: <strong>{fullDayMealLabels}</strong>
+          </div>
+          {CATEGORIES.filter(cat => enabledCategories.includes(cat)).map(category => {
+            const data = fullDayData[category];
+            if (!data) return null;
+            const dietCount = (Object.values(data.diets || {}) as number[]).reduce((a, b) => a + b, 0);
+            const availableDiets = getAvailableDiets(category);
+            return (
+              <CategoryRow
+                key={category}
+                label={category}
+                menuCounts={data.menuCounts}
+                onMenuCountChange={(menuType, val) => updateFullDayMenuCount(category, menuType, val)}
+                hasDietsEnabled={availableDiets.length > 0}
+                dietCount={dietCount}
+                onOpenDiets={() => setActiveDietModal({ meal: "fullDay", category })}
+                disabled={false}
+                visibleMenus={adminVisibleMenus}
+              />
+            );
+          })}
         </div>
       </MealCard>
 
+      {/* Individual meal cards — disabled when fullDayOrder is on */}
       <div style={fullDayOrder ? { opacity: 0.45, pointerEvents: "none" } : {}}>
       {visibleMealsList.map((mealItem, mealIndex) => {
         const { key: rawKey, label, icon } = mealItem;
         const key = rawKey as "breakfast" | "lunch" | "olovrant";
         const isEditable = OrderService.checkDeadline(selectedDate, key, globalDeadlines);
-        const isHoliday = holidays?.has(selectedDate);
+        const isHoliday = isHolidayDay;
 
         return (
           <MealCard
@@ -354,17 +396,11 @@ const OrderPage = () => {
             }
           >
             <div>
-              {CATEGORIES.filter((category) =>
-                enabledCategories.includes(category),
-              ).map((category, catIndex) => {
+              {CATEGORIES.filter(category => enabledCategories.includes(category)).map((category, catIndex) => {
                 const data = currentOrder[key]?.[category];
                 if (!data) return null;
-
-                const dietCount = (
-                  Object.values(data.diets || {}) as number[]
-                ).reduce((a: number, b: number) => a + b, 0);
+                const dietCount = (Object.values(data.diets || {}) as number[]).reduce((a, b) => a + b, 0);
                 const availableDiets = getAvailableDiets(category);
-
                 return (
                   <CategoryRow
                     key={category}
@@ -385,43 +421,26 @@ const OrderPage = () => {
                   />
                 );
               })}
-
-              {/* Special diet toggle */}
-              <div className="zp-special-diet">
-                <div className="zp-special-diet-row">
-                  <span className="zp-special-diet-label">Špeciálna diéta</span>
-                  <div
-                    className={`zp-switch${specialDiets[key]?.enabled ? " zp-switch--on" : ""}`}
-                    role="switch"
-                    aria-checked={!!specialDiets[key]?.enabled}
-                    aria-label="Špeciálna diéta"
-                    tabIndex={0}
-                    onClick={() => isEditable && !isHoliday && updateSpecialDiet(key, 'enabled', !specialDiets[key]?.enabled)}
-                    onKeyDown={(e) => {
-                      if ((e.key === 'Enter' || e.key === ' ') && isEditable && !isHoliday) {
-                        e.preventDefault();
-                        updateSpecialDiet(key, 'enabled', !specialDiets[key]?.enabled);
-                      }
-                    }}
-                    style={!isEditable || isHoliday ? { opacity: 0.5, cursor: 'not-allowed' } : {}}
-                  />
-                </div>
-                {specialDiets[key]?.enabled && (
-                  <textarea
-                    className={`zp-input zp-special-diet-textarea${specialDiets[key]?.enabled && !specialDiets[key]?.note.trim() ? " zp-input--error" : ""}`}
-                    placeholder="Popíšte vašu špeciálnu diétu"
-                    value={specialDiets[key]?.note ?? ''}
-                    rows={3}
-                    disabled={!isEditable || !!isHoliday}
-                    onChange={(e) => updateSpecialDiet(key, 'note', e.target.value)}
-                  />
-                )}
-              </div>
             </div>
           </MealCard>
         );
       })}
       </div>
+    </div>
+  );
+
+  const specialDietNoteContent = hasSpecialDietOrdered() && (
+    <div className="zp-special-diet-note-box">
+      <label className="zp-special-diet-note-label">
+        Špecifikujte špeciálnu objednávku <span style={{ color: "var(--color-danger)" }}>*</span>
+      </label>
+      <textarea
+        className={`zp-input zp-special-diet-textarea${!specialDietNote.trim() ? " zp-input--error" : ""}`}
+        placeholder="Popíšte vašu špeciálnu objednávku"
+        value={specialDietNote}
+        rows={3}
+        onChange={e => setSpecialDietNote(e.target.value)}
+      />
     </div>
   );
 
@@ -455,32 +474,28 @@ const OrderPage = () => {
 
   const modals = (
     <>
-      {activeDietModal && (
-        <DietSelector
-          isOpen={true}
-          onClose={() => setActiveDietModal(null)}
-          categoryLabel={activeDietModal.category}
-          enabledDiets={getAvailableDiets(activeDietModal.category)}
-          diets={
-            currentOrder[activeDietModal.meal as "breakfast" | "lunch" | "olovrant"][
-              activeDietModal.category
-            ].diets
-          }
-          maxPortions={
-            currentOrder[activeDietModal.meal as "breakfast" | "lunch" | "olovrant"][
-              activeDietModal.category
-            ].menuCounts?.["A"] || 0
-          }
-          onUpdateDiet={(diet, count) =>
-            updateDiet(
-              activeDietModal.meal as "breakfast" | "lunch" | "olovrant",
-              activeDietModal.category,
-              diet,
-              count,
-            )
-          }
-        />
-      )}
+      {activeDietModal && (() => {
+        const isFullDay = activeDietModal.meal === "fullDay";
+        const mealData = isFullDay
+          ? fullDayData
+          : currentOrder[activeDietModal.meal as "breakfast" | "lunch" | "olovrant"];
+        const catData = mealData[activeDietModal.category];
+        return (
+          <DietSelector
+            isOpen={true}
+            onClose={() => setActiveDietModal(null)}
+            categoryLabel={activeDietModal.category}
+            enabledDiets={getAvailableDiets(activeDietModal.category)}
+            diets={catData.diets}
+            maxPortions={catData.menuCounts?.["A"] || 0}
+            onUpdateDiet={(diet, count) =>
+              isFullDay
+                ? updateFullDayDiet(activeDietModal.category, diet, count)
+                : updateDiet(activeDietModal.meal as "breakfast" | "lunch" | "olovrant", activeDietModal.category, diet, count)
+            }
+          />
+        );
+      })()}
 
       <ConfirmationModal
         isOpen={showZeroModal}
@@ -534,6 +549,7 @@ const OrderPage = () => {
         <div className="pc-order-grid">
           <div>
             {mealCardsContent}
+            {specialDietNoteContent}
             <p className="zp-thanks">
               Ďakujeme za Vašu objednávku
               <small>Posielame ju priamo do našej kuchyne.</small>
@@ -609,6 +625,8 @@ const OrderPage = () => {
         )}
 
         {mealCardsContent}
+
+        {specialDietNoteContent}
 
         {orderSummaryContent}
 

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -371,26 +371,27 @@ const OrderPage = () => {
         </div>
       </MealCard>
 
-      {/* Individual meal cards — disabled when fullDayOrder is on */}
-      <div style={fullDayOrder ? { opacity: 0.45, pointerEvents: "none" } : {}}>
+      {/* Individual meal cards */}
       {visibleMealsList.map((mealItem, mealIndex) => {
         const { key: rawKey, label, icon } = mealItem;
         const key = rawKey as "breakfast" | "lunch" | "olovrant";
         const isEditable = OrderService.checkDeadline(selectedDate, key, globalDeadlines);
         const isHoliday = isHolidayDay;
+        const blockedByFullDay = fullDayOrder;
 
         return (
           <MealCard
             key={key}
             title={label}
             icon={icon}
-            isActive={isEditable && !isHoliday && activeMeals[key]}
-            onToggle={() => isEditable && !isHoliday && toggleMeal(key)}
-            copyAction={isEditable && !isHoliday ? handleCopyTrigger(key) : null}
-            className={!isEditable || isHoliday ? "" : ""}
+            isActive={!blockedByFullDay && isEditable && !isHoliday && activeMeals[key]}
+            onToggle={() => !blockedByFullDay && isEditable && !isHoliday && toggleMeal(key)}
+            copyAction={!blockedByFullDay && isEditable && !isHoliday ? handleCopyTrigger(key) : null}
             tourId={mealIndex === 0 ? "tour-meal-card" : undefined}
             statusMessage={
-              !isEditable ? (
+              blockedByFullDay ? (
+                <>Celodenná objednávka je aktívna</>
+              ) : !isEditable ? (
                 <>Termín uplynul · Objednávka uzavretá</>
               ) : null
             }
@@ -425,7 +426,6 @@ const OrderPage = () => {
           </MealCard>
         );
       })}
-      </div>
     </div>
   );
 

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -29,6 +29,8 @@ const OrderPage = () => {
     toggleMeal,
     fullDayOrder,
     toggleFullDay,
+    specialDiets,
+    updateSpecialDiet,
     currentOrder,
     updateMenuCount,
     updateDiet,
@@ -172,6 +174,16 @@ const OrderPage = () => {
   };
 
   const handleSubmit = async () => {
+    const mealsWithMissingNote = visibleMealsList.filter(({ key }) => {
+      const mealKey = key as 'breakfast' | 'lunch' | 'olovrant';
+      const sd = specialDiets[mealKey];
+      const isActive = activeMeals[mealKey] || fullDayOrder;
+      return isActive && sd?.enabled && !sd.note.trim();
+    });
+    if (mealsWithMissingNote.length > 0) {
+      toast.error('Prosím popíšte špeciálnu diétu pred odoslaním objednávky.');
+      return;
+    }
     try {
       await submitOrder(selectedDate);
       const total = getTotalPortions();
@@ -373,6 +385,38 @@ const OrderPage = () => {
                   />
                 );
               })}
+
+              {/* Special diet toggle */}
+              <div className="zp-special-diet">
+                <div className="zp-special-diet-row">
+                  <span className="zp-special-diet-label">Špeciálna diéta</span>
+                  <div
+                    className={`zp-switch${specialDiets[key]?.enabled ? " zp-switch--on" : ""}`}
+                    role="switch"
+                    aria-checked={!!specialDiets[key]?.enabled}
+                    aria-label="Špeciálna diéta"
+                    tabIndex={0}
+                    onClick={() => isEditable && !isHoliday && updateSpecialDiet(key, 'enabled', !specialDiets[key]?.enabled)}
+                    onKeyDown={(e) => {
+                      if ((e.key === 'Enter' || e.key === ' ') && isEditable && !isHoliday) {
+                        e.preventDefault();
+                        updateSpecialDiet(key, 'enabled', !specialDiets[key]?.enabled);
+                      }
+                    }}
+                    style={!isEditable || isHoliday ? { opacity: 0.5, cursor: 'not-allowed' } : {}}
+                  />
+                </div>
+                {specialDiets[key]?.enabled && (
+                  <textarea
+                    className={`zp-input zp-special-diet-textarea${specialDiets[key]?.enabled && !specialDiets[key]?.note.trim() ? " zp-input--error" : ""}`}
+                    placeholder="Popíšte vašu špeciálnu diétu"
+                    value={specialDiets[key]?.note ?? ''}
+                    rows={3}
+                    disabled={!isEditable || !!isHoliday}
+                    onChange={(e) => updateSpecialDiet(key, 'note', e.target.value)}
+                  />
+                )}
+              </div>
             </div>
           </MealCard>
         );

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -7,7 +7,7 @@ import MealCard from "../components/order/MealCard";
 import CategoryRow from "../components/order/CategoryRow";
 import DietSelector from "../components/order/DietSelector";
 import OrderSummary from "../components/order/OrderSummary";
-import { Coffee, Utensils, Apple, Trash2, ArrowLeft, Copy, Calendar, Settings } from "lucide-react";
+import { Coffee, Utensils, Apple, Trash2, ArrowLeft, Copy, Calendar, Settings, CalendarDays } from "lucide-react";
 import ConfirmationModal from "../components/ui/ConfirmationModal";
 import OrderService, { CategoryData, DailyOrder } from "../services/OrderService";
 import { useToast } from "../../../context/ToastContext";
@@ -27,6 +27,8 @@ const OrderPage = () => {
     setSelectedDate,
     activeMeals,
     toggleMeal,
+    fullDayOrder,
+    toggleFullDay,
     currentOrder,
     updateMenuCount,
     updateDiet,
@@ -40,7 +42,15 @@ const OrderPage = () => {
     loadBreakfastFromPrevLunch,
     copyOlovrantFromCurrentLunch,
     holidays,
+    mealPlanAvailability,
   } = useApp();
+
+  const getOccupiedMenus = (mealKey: string): Set<string> => {
+    if (!mealPlanAvailability) return new Set();
+    const available = mealPlanAvailability[mealKey];
+    if (!available) return new Set();
+    return new Set(adminVisibleMenus.filter((m: string) => !available.has(m)));
+  };
 
   const { isTourActive, currentStep } = useOnboarding();
 
@@ -295,6 +305,20 @@ const OrderPage = () => {
       style={holidays?.has(selectedDate) ? { opacity: 0.4, pointerEvents: "none" } : {}}
       aria-disabled={holidays?.has(selectedDate) ? true : undefined}
     >
+      <MealCard
+        title="Celodenná objednávka"
+        icon={CalendarDays}
+        isActive={fullDayOrder}
+        onToggle={toggleFullDay}
+        statusMessage={null}
+        copyAction={null}
+      >
+        <div style={{ fontSize: 13, color: "var(--color-text-secondary)", padding: "4px 0" }}>
+          Objedná sa za všetky dostupné jedlá naraz.
+        </div>
+      </MealCard>
+
+      <div style={fullDayOrder ? { opacity: 0.45, pointerEvents: "none" } : {}}>
       {visibleMealsList.map((mealItem, mealIndex) => {
         const { key: rawKey, label, icon } = mealItem;
         const key = rawKey as "breakfast" | "lunch" | "olovrant";
@@ -344,6 +368,7 @@ const OrderPage = () => {
                     }
                     disabled={!isEditable || !!isHoliday}
                     visibleMenus={adminVisibleMenus}
+                    occupiedMenus={getOccupiedMenus(key)}
                     tourId={mealIndex === 0 && catIndex === 0 ? "tour-category-row" : undefined}
                   />
                 );
@@ -352,6 +377,7 @@ const OrderPage = () => {
           </MealCard>
         );
       })}
+      </div>
     </div>
   );
 

--- a/frontend/src/pages/client/pc.css
+++ b/frontend/src/pages/client/pc.css
@@ -139,6 +139,8 @@ body {
     border-bottom: 1px solid var(--line-soft);
     background: rgba(254,249,241,0.72);
     backdrop-filter: blur(8px);
+    position: relative;
+    z-index: 10;
 }
 .pc-topbar .crumb { flex: 1; min-width: 0; }
 .pc-topbar .crumb .eye {


### PR DESCRIPTION
## Summary

- **Celodenná objednávka** — new card at the top of the order page; when toggled on, individual meal cards are disabled. The card has full CategoryRows so users pick quantities and diets per category. Info line shows which meals will be submitted based on `adminVisibleMeals`.
- **Zasednuté porcie** — menus visible in client's `visible_menus` but not in the day's meal plan appear as "zasednutá" (greyed, strikethrough, unclickable counter).
- **In-app správy (Inbox)** — push notification attempts stored as in-app messages with `read_at`. New `/api/inbox/` endpoint with mark-read / mark-all-read actions. Bell tab added to bottom nav and desktop sidebar. `InboxPage` fetches and displays messages with unread dot.
- **Špeciálna diéta** — "Špeciálna" added as the last diet option in `DietSelector`. When any category has it selected (count > 0), a mandatory note box appears before the order summary. Submission is blocked with a toast if the note is empty.

## Test plan

- [ ] Toggle celodenná on → other meal cards grey out and are non-interactive
- [ ] Celodenná card shows correct meal labels (e.g. "Raňajky · Obed") based on client settings
- [ ] Can pick menu counts and diets inside celodenná card; clear button resets all
- [ ] Submit with celodenná on → backend receives all visible meal slots with selected data
- [ ] Menu that is in `visible_menus` but not in the day's meal plan shows "zasednutá" row
- [ ] Inbox tab shows push notifications; tapping marks as read; mark-all-read button works
- [ ] Selecting "Špeciálna" diet and trying to submit without note → toast error shown
- [ ] Filling in the note → submission proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)