### PR TITLE
feat: Edupage uploads and Jedálniček import

### DIFF
--- a/backend/api/migrations/0028_edupage_schools.py
+++ b/backend/api/migrations/0028_edupage_schools.py
@@ -1,0 +1,100 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0027_inbox_read_at"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="School",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=200, unique=True)),
+                ("is_active", models.BooleanField(default=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "ordering": ["name"],
+            },
+        ),
+        migrations.CreateModel(
+            name="EdupageUpload",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "school",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="uploads",
+                        to="api.school",
+                    ),
+                ),
+                (
+                    "date",
+                    models.DateField(
+                        db_index=True, help_text="Date the orders are for"
+                    ),
+                ),
+                ("filename", models.CharField(max_length=500)),
+                ("file", models.FileField(upload_to="edupage_uploads/%Y/%m/")),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Čaká na spracovanie"),
+                            ("processed", "Spracovaný"),
+                            ("error", "Chyba"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("error_message", models.TextField(blank=True)),
+                (
+                    "uploaded_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="edupage_uploads",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                ("uploaded_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "ordering": ["-uploaded_at"],
+                "indexes": [
+                    models.Index(
+                        fields=["date", "school"], name="api_edupage_date_school_idx"
+                    ),
+                    models.Index(
+                        fields=["date", "status"], name="api_edupage_date_status_idx"
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/backend/api/migrations/0029_jedalnicek_upload.py
+++ b/backend/api/migrations/0029_jedalnicek_upload.py
@@ -1,0 +1,147 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0028_edupage_schools"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="JedalnicekUpload",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "week_start",
+                    models.DateField(
+                        db_index=True, help_text="Monday of the week this plan covers"
+                    ),
+                ),
+                ("filename", models.CharField(max_length=500)),
+                ("file", models.FileField(upload_to="jedalnicek_uploads/%Y/%m/")),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Čaká na spracovanie"),
+                            ("processed", "Spracovaný"),
+                            ("error", "Chyba"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("error_message", models.TextField(blank=True)),
+                (
+                    "uploaded_by",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="jedalnicek_uploads",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                ("uploaded_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "ordering": ["-uploaded_at"],
+                "indexes": [
+                    models.Index(
+                        fields=["week_start", "status"],
+                        name="api_jedal_upload_week_status_idx",
+                    ),
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name="JedalnicekEntry",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "upload",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="entries",
+                        to="api.jedalnicekupload",
+                    ),
+                ),
+                ("date", models.DateField(db_index=True)),
+                (
+                    "category",
+                    models.CharField(
+                        choices=[
+                            ("breakfast", "Raňajky"),
+                            ("lunch", "Obed"),
+                            ("snack", "Olovrant"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "menu_variant",
+                    models.CharField(
+                        blank=True,
+                        max_length=10,
+                        help_text="Leave blank for breakfast/snack. E.g. 'A', 'B'.",
+                    ),
+                ),
+                (
+                    "diet",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="jedalnicek_entries",
+                        to="api.diet",
+                        help_text="Null means the entry applies to all diets / is the default.",
+                    ),
+                ),
+                (
+                    "name",
+                    models.CharField(max_length=500, help_text="Name of the meal"),
+                ),
+                (
+                    "weight_grams",
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        max_digits=8,
+                        null=True,
+                        help_text="Gram weight for this diet (replaces base_weight × coefficient)",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["date", "category", "menu_variant", "diet__name"],
+                "indexes": [
+                    models.Index(
+                        fields=["date", "category", "menu_variant"],
+                        name="api_jedal_entry_date_cat_var_idx",
+                    ),
+                    models.Index(
+                        fields=["date", "diet"], name="api_jedal_entry_date_diet_idx"
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -449,3 +449,157 @@ class PushNotificationAttempt(models.Model):
 
     def __str__(self) -> str:
         return f"PushNotificationAttempt({self.status}, …{self.endpoint[-20:]})"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Edupage integration
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class School(models.Model):
+    name = models.CharField(max_length=200, unique=True)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class JedalnicekUpload(models.Model):
+    """Weekly meal plan file uploaded by admin (format TBD, parsed later)."""
+
+    STATUS_PENDING = "pending"
+    STATUS_PROCESSED = "processed"
+    STATUS_ERROR = "error"
+
+    STATUS_CHOICES = [
+        (STATUS_PENDING, "Čaká na spracovanie"),
+        (STATUS_PROCESSED, "Spracovaný"),
+        (STATUS_ERROR, "Chyba"),
+    ]
+
+    week_start = models.DateField(
+        db_index=True, help_text="Monday of the week this plan covers"
+    )
+    filename = models.CharField(max_length=500)
+    file = models.FileField(upload_to="jedalnicek_uploads/%Y/%m/")
+    status = models.CharField(
+        max_length=20, choices=STATUS_CHOICES, default=STATUS_PENDING
+    )
+    error_message = models.TextField(blank=True)
+    uploaded_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="jedalnicek_uploads",
+    )
+    uploaded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-uploaded_at"]
+        indexes = [
+            models.Index(fields=["week_start", "status"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"JedalnicekUpload({self.week_start}, {self.filename})"
+
+    @property
+    def week_end(self) -> "datetime.date":
+        return self.week_start + datetime.timedelta(days=6)
+
+
+class JedalnicekEntry(models.Model):
+    """
+    One meal+diet combination for a specific day, parsed from a JedalnicekUpload.
+
+    Indexed by (date, category, menu_variant, diet) so the client and admin
+    can query a day's full menu in a single DB round-trip.
+    """
+
+    upload = models.ForeignKey(
+        JedalnicekUpload,
+        on_delete=models.CASCADE,
+        related_name="entries",
+    )
+    date = models.DateField(db_index=True)
+    category = models.CharField(max_length=20, choices=MealCategory.choices)
+    menu_variant = models.CharField(
+        max_length=10,
+        blank=True,
+        help_text="Leave blank for breakfast/snack. E.g. 'A', 'B'.",
+    )
+    diet = models.ForeignKey(
+        "Diet",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="jedalnicek_entries",
+        help_text="Null means the entry applies to all diets / is the default.",
+    )
+    name = models.CharField(max_length=500, help_text="Name of the meal")
+    weight_grams = models.DecimalField(
+        max_digits=8,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        help_text="Gram weight for this diet (replaces base_weight × coefficient)",
+    )
+
+    class Meta:
+        ordering = ["date", "category", "menu_variant", "diet__name"]
+        indexes = [
+            models.Index(fields=["date", "category", "menu_variant"]),
+            models.Index(fields=["date", "diet"]),
+        ]
+
+    def __str__(self) -> str:
+        diet_name = self.diet.name if self.diet else "všetky"
+        return (
+            f"{self.date} {self.category}{self.menu_variant} [{diet_name}]: {self.name}"
+        )
+
+
+class EdupageUpload(models.Model):
+    STATUS_PENDING = "pending"
+    STATUS_PROCESSED = "processed"
+    STATUS_ERROR = "error"
+
+    STATUS_CHOICES = [
+        (STATUS_PENDING, "Čaká na spracovanie"),
+        (STATUS_PROCESSED, "Spracovaný"),
+        (STATUS_ERROR, "Chyba"),
+    ]
+
+    school = models.ForeignKey(
+        School,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="uploads",
+    )
+    date = models.DateField(db_index=True, help_text="Date the orders are for")
+    filename = models.CharField(max_length=500)
+    file = models.FileField(upload_to="edupage_uploads/%Y/%m/")
+    status = models.CharField(
+        max_length=20, choices=STATUS_CHOICES, default=STATUS_PENDING
+    )
+    error_message = models.TextField(blank=True)
+    uploaded_by = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, related_name="edupage_uploads"
+    )
+    uploaded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-uploaded_at"]
+        indexes = [
+            models.Index(fields=["date", "school"]),
+            models.Index(fields=["date", "status"]),
+        ]
+
+    def __str__(self) -> str:
+        school_name = self.school.name if self.school else "?"
+        return f"EdupageUpload({school_name}, {self.date}, {self.filename})"

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -4,7 +4,10 @@ from rest_framework.routers import DefaultRouter
 from .health import health_check
 from .views import (
     AdminAutoOrderViewSet,
+    AdminEdupageUploadViewSet,
     AdminHolidayViewSet,
+    AdminJedalnicekUploadViewSet,
+    AdminSchoolViewSet,
     AdminSendPushView,
     AdminSummaryViewSet,
     AdminUserViewSet,
@@ -59,6 +62,15 @@ router.register(r"meal-plans", DailyMealPlanViewSet, basename="client-meal-plan"
 router.register(r"admin/holidays", AdminHolidayViewSet, basename="admin-holiday")
 router.register(r"holidays", HolidayListViewSet, basename="holiday")
 router.register(r"inbox", InboxViewSet, basename="inbox")
+router.register(r"admin/schools", AdminSchoolViewSet, basename="admin-school")
+router.register(
+    r"admin/edupage-uploads", AdminEdupageUploadViewSet, basename="admin-edupage-upload"
+)
+router.register(
+    r"admin/jedalnicek-uploads",
+    AdminJedalnicekUploadViewSet,
+    basename="admin-jedalnicek-upload",
+)
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -21,11 +21,17 @@ from .auth_views import (
 # Diet views
 from .diet_views import DietViewSet
 
+# Edupage views
+from .edupage_views import AdminEdupageUploadViewSet, AdminSchoolViewSet
+
 # Holiday views
 from .holiday_views import AdminHolidayViewSet, HolidayListViewSet
 
 # Inbox views
 from .inbox_views import InboxViewSet
+
+# Jedálniček import views
+from .jedalnicek_import_views import AdminJedalnicekUploadViewSet
 
 # Meal plan views
 from .meal_plan_views import (
@@ -64,6 +70,11 @@ __all__ = [
     "AdminAutoOrderViewSet",
     # Admin
     "AdminUserViewSet",
+    # Edupage
+    "AdminSchoolViewSet",
+    "AdminEdupageUploadViewSet",
+    # Jedálniček import
+    "AdminJedalnicekUploadViewSet",
     # Reports
     "AdminSummaryViewSet",
     "ReportTaskViewSet",

--- a/backend/api/views/edupage_views.py
+++ b/backend/api/views/edupage_views.py
@@ -1,0 +1,135 @@
+import logging
+
+from django.db.models import Count, Q
+from rest_framework import permissions, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.parsers import MultiPartParser
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from ..models import EdupageUpload, School
+
+logger = logging.getLogger(__name__)
+
+
+class SchoolSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = School
+        fields = ["id", "name", "is_active", "created_at"]
+        read_only_fields = ["id", "created_at"]
+
+
+class EdupageUploadSerializer(serializers.ModelSerializer):
+    school_name = serializers.CharField(
+        source="school.name", read_only=True, allow_null=True
+    )
+
+    class Meta:
+        model = EdupageUpload
+        fields = [
+            "id",
+            "school",
+            "school_name",
+            "date",
+            "filename",
+            "status",
+            "error_message",
+            "uploaded_at",
+        ]
+        read_only_fields = ["id", "filename", "status", "error_message", "uploaded_at"]
+
+
+class AdminSchoolViewSet(viewsets.ModelViewSet):
+    queryset = School.objects.all()
+    serializer_class = SchoolSerializer
+    permission_classes = [permissions.IsAdminUser]
+
+
+class AdminEdupageUploadViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = EdupageUpload.objects.select_related("school", "uploaded_by").all()
+    serializer_class = EdupageUploadSerializer
+    permission_classes = [permissions.IsAdminUser]
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        date = self.request.query_params.get("date")
+        if date:
+            qs = qs.filter(date=date)
+        return qs
+
+    @action(detail=False, methods=["post"], parser_classes=[MultiPartParser])
+    def upload(self, request: Request) -> Response:
+        date = request.data.get("date")
+        school_id = request.data.get("school_id")
+        file = request.FILES.get("file")
+
+        if not date or not file:
+            return Response(
+                {"error": "date and file are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        school = None
+        if school_id:
+            try:
+                school = School.objects.get(pk=school_id)
+            except School.DoesNotExist:
+                return Response(
+                    {"error": f"School {school_id} not found"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        upload = EdupageUpload.objects.create(
+            school=school,
+            date=date,
+            filename=file.name,
+            file=file,
+            status=EdupageUpload.STATUS_PENDING,
+            uploaded_by=request.user,
+        )
+
+        return Response(
+            EdupageUploadSerializer(upload).data, status=status.HTTP_201_CREATED
+        )
+
+    @action(detail=False, methods=["get"])
+    def status_by_date(self, request: Request) -> Response:
+        """Returns per-school upload status for a given date."""
+        date = request.query_params.get("date")
+        if not date:
+            return Response(
+                {"error": "date is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        schools = School.objects.filter(is_active=True).annotate(
+            upload_count=Count("uploads", filter=Q(uploads__date=date))
+        )
+
+        result = [
+            {
+                "id": s.id,
+                "name": s.name,
+                "uploaded": s.upload_count > 0,
+                "upload_count": s.upload_count,
+            }
+            for s in schools
+        ]
+
+        total = len(result)
+        uploaded = sum(1 for s in result if s["uploaded"])
+
+        return Response(
+            {
+                "date": date,
+                "total_schools": total,
+                "uploaded_schools": uploaded,
+                "schools": result,
+            }
+        )
+
+    @action(detail=True, methods=["delete"])
+    def remove(self, request: Request, pk: int | None = None) -> Response:
+        upload = self.get_object()
+        upload.file.delete(save=False)
+        upload.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/api/views/edupage_views.py
+++ b/backend/api/views/edupage_views.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 from django.db.models import Count, Q
@@ -69,6 +70,14 @@ class AdminEdupageUploadViewSet(viewsets.ReadOnlyModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        try:
+            parsed_date = datetime.date.fromisoformat(date)
+        except ValueError:
+            return Response(
+                {"error": "date must be YYYY-MM-DD"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         school = None
         if school_id:
             try:
@@ -81,7 +90,7 @@ class AdminEdupageUploadViewSet(viewsets.ReadOnlyModelViewSet):
 
         upload = EdupageUpload.objects.create(
             school=school,
-            date=date,
+            date=parsed_date,
             filename=file.name,
             file=file,
             status=EdupageUpload.STATUS_PENDING,
@@ -130,6 +139,12 @@ class AdminEdupageUploadViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=["delete"])
     def remove(self, request: Request, pk: int | None = None) -> Response:
         upload = self.get_object()
-        upload.file.delete(save=False)
+        file_to_delete = upload.file
         upload.delete()
+        try:
+            file_to_delete.delete(save=False)
+        except Exception:
+            logger.exception(
+                "Failed to delete file %s after DB record removed", file_to_delete.name
+            )
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/api/views/jedalnicek_import_views.py
+++ b/backend/api/views/jedalnicek_import_views.py
@@ -120,8 +120,14 @@ class AdminJedalnicekUploadViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=["delete"])
     def remove(self, request: Request, pk: int | None = None) -> Response:
         upload = self.get_object()
-        upload.file.delete(save=False)
+        file_to_delete = upload.file
         upload.delete()
+        try:
+            file_to_delete.delete(save=False)
+        except Exception:
+            logger.exception(
+                "Failed to delete file %s after DB record removed", file_to_delete.name
+            )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=False, methods=["get"])
@@ -133,7 +139,7 @@ class AdminJedalnicekUploadViewSet(viewsets.ReadOnlyModelViewSet):
                 {"error": "date is required"}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        entries = (
+        entry_list = list(
             JedalnicekEntry.objects.filter(date=date_str)
             .select_related("diet")
             .order_by("category", "menu_variant", "diet__name")
@@ -142,13 +148,17 @@ class AdminJedalnicekUploadViewSet(viewsets.ReadOnlyModelViewSet):
         return Response(
             {
                 "date": date_str,
-                "has_import": entries.exists(),
-                "entries": JedalnicekEntrySerializer(entries, many=True).data,
+                "has_import": bool(entry_list),
+                "entries": JedalnicekEntrySerializer(entry_list, many=True).data,
             }
         )
 
     @action(detail=False, methods=["get"])
     def week_status(self, request: Request) -> Response:
         """Returns upload status for weeks, showing which weeks have uploads."""
-        uploads = JedalnicekUpload.objects.order_by("-week_start")[:20]
+        from django.db.models import Count
+
+        uploads = JedalnicekUpload.objects.annotate(
+            entry_count=Count("entries")
+        ).order_by("-week_start")[:20]
         return Response(JedalnicekUploadSerializer(uploads, many=True).data)

--- a/backend/api/views/jedalnicek_import_views.py
+++ b/backend/api/views/jedalnicek_import_views.py
@@ -1,0 +1,154 @@
+import datetime
+import logging
+
+from rest_framework import permissions, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.parsers import MultiPartParser
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from ..models import JedalnicekEntry, JedalnicekUpload
+
+logger = logging.getLogger(__name__)
+
+
+class JedalnicekUploadSerializer(serializers.ModelSerializer):
+    week_end = serializers.DateField(read_only=True)
+    entry_count = serializers.IntegerField(read_only=True, default=0)
+
+    class Meta:
+        model = JedalnicekUpload
+        fields = [
+            "id",
+            "week_start",
+            "week_end",
+            "filename",
+            "status",
+            "error_message",
+            "uploaded_at",
+            "entry_count",
+        ]
+        read_only_fields = [
+            "id",
+            "filename",
+            "status",
+            "error_message",
+            "uploaded_at",
+            "week_end",
+        ]
+
+
+class JedalnicekEntrySerializer(serializers.ModelSerializer):
+    diet_name = serializers.CharField(
+        source="diet.name", read_only=True, allow_null=True
+    )
+    category_display = serializers.CharField(
+        source="get_category_display", read_only=True
+    )
+
+    class Meta:
+        model = JedalnicekEntry
+        fields = [
+            "id",
+            "upload",
+            "date",
+            "category",
+            "category_display",
+            "menu_variant",
+            "diet",
+            "diet_name",
+            "name",
+            "weight_grams",
+        ]
+        read_only_fields = ["id", "upload"]
+
+
+class AdminJedalnicekUploadViewSet(viewsets.ReadOnlyModelViewSet):
+    permission_classes = [permissions.IsAdminUser]
+
+    def get_queryset(self):
+        from django.db.models import Count
+
+        qs = JedalnicekUpload.objects.annotate(entry_count=Count("entries")).order_by(
+            "-uploaded_at"
+        )
+        week_start = self.request.query_params.get("week_start")
+        if week_start:
+            qs = qs.filter(week_start=week_start)
+        return qs
+
+    def get_serializer_class(self):
+        return JedalnicekUploadSerializer
+
+    @action(detail=False, methods=["post"], parser_classes=[MultiPartParser])
+    def upload(self, request: Request) -> Response:
+        week_start = request.data.get("week_start")
+        file = request.FILES.get("file")
+
+        if not week_start or not file:
+            return Response(
+                {"error": "week_start and file are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Validate week_start is a Monday
+        try:
+            d = datetime.date.fromisoformat(week_start)
+        except ValueError:
+            return Response(
+                {"error": "week_start must be YYYY-MM-DD"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if d.weekday() != 0:
+            return Response(
+                {"error": "week_start must be a Monday"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        upload = JedalnicekUpload.objects.create(
+            week_start=d,
+            filename=file.name,
+            file=file,
+            status=JedalnicekUpload.STATUS_PENDING,
+            uploaded_by=request.user,
+        )
+
+        return Response(
+            JedalnicekUploadSerializer(upload).data, status=status.HTTP_201_CREATED
+        )
+
+    @action(detail=True, methods=["delete"])
+    def remove(self, request: Request, pk: int | None = None) -> Response:
+        upload = self.get_object()
+        upload.file.delete(save=False)
+        upload.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(detail=False, methods=["get"])
+    def by_date(self, request: Request) -> Response:
+        """Returns JedalnicekEntry records for a specific date."""
+        date_str = request.query_params.get("date")
+        if not date_str:
+            return Response(
+                {"error": "date is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        entries = (
+            JedalnicekEntry.objects.filter(date=date_str)
+            .select_related("diet")
+            .order_by("category", "menu_variant", "diet__name")
+        )
+
+        return Response(
+            {
+                "date": date_str,
+                "has_import": entries.exists(),
+                "entries": JedalnicekEntrySerializer(entries, many=True).data,
+            }
+        )
+
+    @action(detail=False, methods=["get"])
+    def week_status(self, request: Request) -> Response:
+        """Returns upload status for weeks, showing which weeks have uploads."""
+        uploads = JedalnicekUpload.objects.order_by("-week_start")[:20]
+        return Response(JedalnicekUploadSerializer(uploads, many=True).data)

--- a/backend/api/views/meal_plan_views.py
+++ b/backend/api/views/meal_plan_views.py
@@ -148,26 +148,38 @@ class DailyMealPlanViewSet(viewsets.ModelViewSet):
         )
         import_data = JedalnicekEntrySerializer(import_entry_list, many=True).data
 
+        has_import = bool(import_entry_list)
+
         try:
             plan = self.get_queryset().get(date=date)
         except DailyMealPlan.DoesNotExist:
-            return Response(
+            payload = {
+                "exists": False,
+                "date": date_str,
+                "notes": "",
+                "items": [],
+            }
+            if has_import:
+                payload.update(
+                    {
+                        "import_entries": import_data,
+                        "has_import": True,
+                    }
+                )
+            return Response(payload)
+
+        payload = {
+            "exists": True,
+            **DailyMealPlanSerializer(plan, context={"request": request}).data,
+        }
+        if has_import:
+            payload.update(
                 {
-                    "exists": False,
-                    "date": date_str,
-                    "notes": "",
-                    "items": [],
                     "import_entries": import_data,
-                    "has_import": bool(import_entry_list),
+                    "has_import": True,
                 }
             )
-        return Response(
-            {
-                **DailyMealPlanSerializer(plan, context={"request": request}).data,
-                "import_entries": import_data,
-                "has_import": bool(import_entry_list),
-            }
-        )
+        return Response(payload)
 
     @action(detail=True, methods=["get"], url_path="gramage-report")
     def gramage_report(self, request, pk=None):

--- a/backend/api/views/meal_plan_views.py
+++ b/backend/api/views/meal_plan_views.py
@@ -141,12 +141,12 @@ class DailyMealPlanViewSet(viewsets.ModelViewSet):
             )
         date = parse_date_param(date_str)
 
-        import_entries = (
+        import_entry_list = list(
             JedalnicekEntry.objects.filter(date=date)
             .select_related("diet")
             .order_by("category", "menu_variant", "diet__name")
         )
-        import_data = JedalnicekEntrySerializer(import_entries, many=True).data
+        import_data = JedalnicekEntrySerializer(import_entry_list, many=True).data
 
         try:
             plan = self.get_queryset().get(date=date)
@@ -158,15 +158,14 @@ class DailyMealPlanViewSet(viewsets.ModelViewSet):
                     "notes": "",
                     "items": [],
                     "import_entries": import_data,
-                    "has_import": len(import_data) > 0,
+                    "has_import": bool(import_entry_list),
                 }
             )
         return Response(
             {
-                "exists": True,
-                "import_entries": import_data,
-                "has_import": len(import_data) > 0,
                 **DailyMealPlanSerializer(plan, context={"request": request}).data,
+                "import_entries": import_data,
+                "has_import": bool(import_entry_list),
             }
         )
 

--- a/backend/api/views/meal_plan_views.py
+++ b/backend/api/views/meal_plan_views.py
@@ -11,7 +11,13 @@ from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from ..models import DailyMealPlan, MealPlanItem, MealTemplate, PortionType
+from ..models import (
+    DailyMealPlan,
+    JedalnicekEntry,
+    MealPlanItem,
+    MealTemplate,
+    PortionType,
+)
 from ..order_data import OrderData, safe_count
 from ..serializers_menu import (
     DailyMealPlanSerializer,
@@ -125,6 +131,8 @@ class DailyMealPlanViewSet(viewsets.ModelViewSet):
     @action(detail=False, methods=["get"], url_path="by-date")
     def by_date(self, request):
         """GET /api/admin/meal-plans/by-date/?date=YYYY-MM-DD"""
+        from ..views.jedalnicek_import_views import JedalnicekEntrySerializer
+
         date_str = request.query_params.get("date")
         if not date_str:
             return Response(
@@ -132,6 +140,14 @@ class DailyMealPlanViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         date = parse_date_param(date_str)
+
+        import_entries = (
+            JedalnicekEntry.objects.filter(date=date)
+            .select_related("diet")
+            .order_by("category", "menu_variant", "diet__name")
+        )
+        import_data = JedalnicekEntrySerializer(import_entries, many=True).data
+
         try:
             plan = self.get_queryset().get(date=date)
         except DailyMealPlan.DoesNotExist:
@@ -141,11 +157,15 @@ class DailyMealPlanViewSet(viewsets.ModelViewSet):
                     "date": date_str,
                     "notes": "",
                     "items": [],
+                    "import_entries": import_data,
+                    "has_import": len(import_data) > 0,
                 }
             )
         return Response(
             {
                 "exists": True,
+                "import_entries": import_data,
+                "has_import": len(import_data) > 0,
                 **DailyMealPlanSerializer(plan, context={"request": request}).data,
             }
         )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,8 @@ import MealPlanTemplates from "./pages/admin/MealPlanTemplates";
 import PortionTypes from "./pages/admin/PortionTypes";
 import PushNotificationsAdmin from "./pages/admin/PushNotifications";
 import HolidaysAdmin from "./pages/admin/HolidaysAdmin";
+import EdupageUpload from "./pages/admin/EdupageUpload";
+import JedalnicekImport from "./pages/admin/JedalnicekImport";
 
 const ProtectedRoute = () => {
   const { isAuthenticated, isLoading, user } = useAuth();
@@ -192,6 +194,8 @@ export default function App() {
                 <Route path="settings" element={<ErrorBoundary><SystemSettings /></ErrorBoundary>} />
                 <Route path="push-notifications" element={<ErrorBoundary><PushNotificationsAdmin /></ErrorBoundary>} />
                 <Route path="holidays" element={<ErrorBoundary><HolidaysAdmin /></ErrorBoundary>} />
+                <Route path="edupage" element={<ErrorBoundary><EdupageUpload /></ErrorBoundary>} />
+                <Route path="jedalnicek-import" element={<ErrorBoundary><JedalnicekImport /></ErrorBoundary>} />
               </Route>
 
               {/* Client Routes */}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -61,6 +61,21 @@ export class ApiClient {
     return response.json();
   }
 
+  async postForm<T>(endpoint: string, data: FormData): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      method: 'POST',
+      credentials: 'include',
+      body: data,
+    });
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error((err as { error?: string }).error || response.statusText);
+    }
+
+    return response.json();
+  }
+
   async delete(endpoint: string): Promise<void> {
     const response = await fetch(`${this.baseUrl}${endpoint}`, {
       method: 'DELETE',

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -35,6 +35,16 @@ const SECTIONS: NavSection[] = [
         ],
     },
     {
+        id: 'edupage',
+        label: 'Edupage',
+        icon: '🏫',
+        paths: ['/admin/edupage', '/admin/jedalnicek-import'],
+        items: [
+            { to: '/admin/edupage', label: 'Objednávky (Edupage)', icon: '📤', activeColor: 'text-indigo-700', activeBg: 'bg-indigo-50' },
+            { to: '/admin/jedalnicek-import', label: 'Jedálniček (import)', icon: '📅', activeColor: 'text-teal-700', activeBg: 'bg-teal-50' },
+        ],
+    },
+    {
         id: 'settings',
         label: 'Nastavenia',
         icon: '⚙️',

--- a/frontend/src/pages/admin/EdupageUpload.tsx
+++ b/frontend/src/pages/admin/EdupageUpload.tsx
@@ -1,0 +1,471 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { apiClient } from '../../api/client';
+
+interface School {
+    id: number;
+    name: string;
+    is_active: boolean;
+    created_at: string;
+}
+
+interface SchoolStatus {
+    id: number;
+    name: string;
+    uploaded: boolean;
+    upload_count: number;
+}
+
+interface StatusByDate {
+    date: string;
+    total_schools: number;
+    uploaded_schools: number;
+    schools: SchoolStatus[];
+}
+
+interface Upload {
+    id: number;
+    school: number | null;
+    school_name: string | null;
+    date: string;
+    filename: string;
+    status: 'pending' | 'processed' | 'error';
+    error_message: string;
+    uploaded_at: string;
+}
+
+interface QueuedFile {
+    id: string;
+    file: File;
+    schoolId: string;
+    uploading: boolean;
+    done: boolean;
+    error: string | null;
+}
+
+type Tab = 'upload' | 'schools';
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+export default function EdupageUpload() {
+    const [tab, setTab] = useState<Tab>('upload');
+
+    // Upload tab
+    const [date, setDate] = useState(today());
+    const [status, setStatus] = useState<StatusByDate | null>(null);
+    const [uploads, setUploads] = useState<Upload[]>([]);
+    const [queue, setQueue] = useState<QueuedFile[]>([]);
+    const [schools, setSchools] = useState<School[]>([]);
+    const [isDragging, setIsDragging] = useState(false);
+    const [loadingStatus, setLoadingStatus] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    // Schools tab
+    const [newSchoolName, setNewSchoolName] = useState('');
+    const [savingSchool, setSavingSchool] = useState(false);
+    const [schoolError, setSchoolError] = useState('');
+
+    const loadSchools = useCallback(async () => {
+        const data = await apiClient.get<School[]>('/admin/schools/');
+        setSchools(data);
+    }, []);
+
+    const loadStatusAndUploads = useCallback(async (d: string) => {
+        setLoadingStatus(true);
+        try {
+            const [s, u] = await Promise.all([
+                apiClient.get<StatusByDate>(`/admin/edupage-uploads/status_by_date/?date=${d}`),
+                apiClient.get<Upload[]>(`/admin/edupage-uploads/?date=${d}`),
+            ]);
+            setStatus(s);
+            setUploads(u);
+        } finally {
+            setLoadingStatus(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void loadSchools();
+    }, [loadSchools]);
+
+    useEffect(() => {
+        void loadStatusAndUploads(date);
+    }, [date, loadStatusAndUploads]);
+
+    const addFiles = (files: FileList | File[]) => {
+        const newItems: QueuedFile[] = Array.from(files).map((f) => ({
+            id: `${f.name}-${Date.now()}-${Math.random()}`,
+            file: f,
+            schoolId: '',
+            uploading: false,
+            done: false,
+            error: null,
+        }));
+        setQueue((prev) => [...prev, ...newItems]);
+    };
+
+    const onDrop = (e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragging(false);
+        if (e.dataTransfer.files.length) addFiles(e.dataTransfer.files);
+    };
+
+    const uploadFile = async (item: QueuedFile) => {
+        setQueue((prev) => prev.map((q) => (q.id === item.id ? { ...q, uploading: true, error: null } : q)));
+        try {
+            const form = new FormData();
+            form.append('date', date);
+            form.append('file', item.file);
+            if (item.schoolId) form.append('school_id', item.schoolId);
+
+            const response = await fetch('/api/admin/edupage-uploads/upload/', {
+                method: 'POST',
+                credentials: 'include',
+                body: form,
+            });
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error((err as { error?: string }).error || response.statusText);
+            }
+            setQueue((prev) => prev.map((q) => (q.id === item.id ? { ...q, uploading: false, done: true } : q)));
+            await loadStatusAndUploads(date);
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : 'Neznáma chyba';
+            setQueue((prev) => prev.map((q) => (q.id === item.id ? { ...q, uploading: false, error: msg } : q)));
+        }
+    };
+
+    const uploadAll = async () => {
+        const pending = queue.filter((q) => !q.done && !q.uploading);
+        for (const item of pending) {
+            await uploadFile(item);
+        }
+    };
+
+    const removeFromQueue = (id: string) => setQueue((prev) => prev.filter((q) => q.id !== id));
+    const clearDone = () => setQueue((prev) => prev.filter((q) => !q.done));
+
+    const deleteUpload = async (id: number) => {
+        await apiClient.delete(`/admin/edupage-uploads/${id}/remove/`);
+        await loadStatusAndUploads(date);
+    };
+
+    const addSchool = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!newSchoolName.trim()) return;
+        setSavingSchool(true);
+        setSchoolError('');
+        try {
+            await apiClient.post('/admin/schools/', { name: newSchoolName.trim(), is_active: true });
+            setNewSchoolName('');
+            await loadSchools();
+            await loadStatusAndUploads(date);
+        } catch {
+            setSchoolError('Chyba pri ukladaní. Overte či škola s týmto názvom už neexistuje.');
+        } finally {
+            setSavingSchool(false);
+        }
+    };
+
+    const toggleSchoolActive = async (school: School) => {
+        await apiClient.put(`/admin/schools/${school.id}/`, { ...school, is_active: !school.is_active });
+        await loadSchools();
+        await loadStatusAndUploads(date);
+    };
+
+    const pendingCount = queue.filter((q) => !q.done).length;
+    const doneCount = queue.filter((q) => q.done).length;
+
+    return (
+        <div>
+            <div className="mb-6">
+                <h1 className="text-2xl font-bold text-gray-900">Edupage</h1>
+                <p className="text-gray-500 mt-1 text-sm">Nahrávanie objednávok z Edupage exportov</p>
+            </div>
+
+            {/* Tabs */}
+            <div className="flex gap-1 mb-6 border-b border-gray-200">
+                {(['upload', 'schools'] as Tab[]).map((t) => (
+                    <button
+                        key={t}
+                        onClick={() => setTab(t)}
+                        className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+                            tab === t
+                                ? 'border-indigo-600 text-indigo-600'
+                                : 'border-transparent text-gray-500 hover:text-gray-800'
+                        }`}
+                    >
+                        {t === 'upload' ? 'Nahrávanie' : 'Školy'}
+                    </button>
+                ))}
+            </div>
+
+            {tab === 'upload' && (
+                <div className="space-y-6">
+                    {/* Date picker + status summary */}
+                    <div className="flex flex-wrap items-center gap-4">
+                        <div>
+                            <label className="block text-xs font-medium text-gray-500 mb-1">Dátum objednávok</label>
+                            <input
+                                type="date"
+                                value={date}
+                                onChange={(e) => setDate(e.target.value)}
+                                className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                            />
+                        </div>
+
+                        {status && !loadingStatus && (
+                            <div className="flex items-center gap-2 mt-4">
+                                <span className={`text-2xl font-bold ${status.uploaded_schools === status.total_schools && status.total_schools > 0 ? 'text-green-600' : 'text-gray-900'}`}>
+                                    {status.uploaded_schools}/{status.total_schools}
+                                </span>
+                                <span className="text-sm text-gray-500">škôl nahratých</span>
+                            </div>
+                        )}
+                        {loadingStatus && <div className="mt-4 text-sm text-gray-400">Načítavam...</div>}
+                    </div>
+
+                    {/* School status grid */}
+                    {status && status.total_schools > 0 && (
+                        <div>
+                            <h2 className="text-sm font-semibold text-gray-700 mb-3">Stav škôl pre {date}</h2>
+                            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+                                {status.schools.map((s) => (
+                                    <div
+                                        key={s.id}
+                                        className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-sm ${
+                                            s.uploaded
+                                                ? 'bg-green-50 border-green-200 text-green-800'
+                                                : 'bg-gray-50 border-gray-200 text-gray-600'
+                                        }`}
+                                    >
+                                        <span className="text-base">{s.uploaded ? '✅' : '⬜'}</span>
+                                        <span className="truncate font-medium">{s.name}</span>
+                                        {s.upload_count > 1 && (
+                                            <span className="ml-auto shrink-0 text-xs bg-green-200 text-green-800 px-1.5 rounded-full">
+                                                {s.upload_count}×
+                                            </span>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {status && status.total_schools === 0 && (
+                        <div className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3">
+                            Najprv pridaj školy v záložke <strong>Školy</strong>.
+                        </div>
+                    )}
+
+                    {/* Drop zone */}
+                    <div>
+                        <h2 className="text-sm font-semibold text-gray-700 mb-3">Nahrať súbory</h2>
+                        <div
+                            onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+                            onDragLeave={() => setIsDragging(false)}
+                            onDrop={onDrop}
+                            onClick={() => fileInputRef.current?.click()}
+                            className={`cursor-pointer rounded-2xl border-2 border-dashed px-8 py-12 text-center transition-colors ${
+                                isDragging
+                                    ? 'border-indigo-400 bg-indigo-50'
+                                    : 'border-gray-300 bg-gray-50 hover:border-indigo-300 hover:bg-indigo-50/50'
+                            }`}
+                        >
+                            <div className="text-4xl mb-3">📂</div>
+                            <p className="text-gray-600 font-medium">Presuň súbory sem alebo klikni pre výber</p>
+                            <p className="text-xs text-gray-400 mt-1">Môžeš nahrať viac súborov naraz</p>
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                multiple
+                                className="hidden"
+                                onChange={(e) => e.target.files && addFiles(e.target.files)}
+                            />
+                        </div>
+                    </div>
+
+                    {/* Queue */}
+                    {queue.length > 0 && (
+                        <div>
+                            <div className="flex items-center justify-between mb-3">
+                                <h2 className="text-sm font-semibold text-gray-700">
+                                    Fronta ({pendingCount} čakajú, {doneCount} hotových)
+                                </h2>
+                                <div className="flex gap-2">
+                                    {doneCount > 0 && (
+                                        <button
+                                            onClick={clearDone}
+                                            className="text-xs text-gray-500 hover:text-gray-800 px-3 py-1.5 rounded-lg hover:bg-gray-100"
+                                        >
+                                            Zmazať hotové
+                                        </button>
+                                    )}
+                                    {pendingCount > 0 && (
+                                        <button
+                                            onClick={uploadAll}
+                                            className="text-xs bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-1.5 rounded-lg font-medium transition-colors"
+                                        >
+                                            Nahrať všetky ({pendingCount})
+                                        </button>
+                                    )}
+                                </div>
+                            </div>
+
+                            <div className="space-y-2">
+                                {queue.map((item) => (
+                                    <div
+                                        key={item.id}
+                                        className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${
+                                            item.done
+                                                ? 'bg-green-50 border-green-200'
+                                                : item.error
+                                                ? 'bg-red-50 border-red-200'
+                                                : 'bg-white border-gray-200'
+                                        }`}
+                                    >
+                                        <span className="text-lg shrink-0">
+                                            {item.done ? '✅' : item.error ? '❌' : item.uploading ? '⏳' : '📄'}
+                                        </span>
+
+                                        <div className="min-w-0 flex-1">
+                                            <p className="text-sm font-medium text-gray-900 truncate">{item.file.name}</p>
+                                            {item.error && (
+                                                <p className="text-xs text-red-600 mt-0.5">{item.error}</p>
+                                            )}
+                                        </div>
+
+                                        {!item.done && (
+                                            <select
+                                                value={item.schoolId}
+                                                onChange={(e) =>
+                                                    setQueue((prev) =>
+                                                        prev.map((q) =>
+                                                            q.id === item.id ? { ...q, schoolId: e.target.value } : q
+                                                        )
+                                                    )
+                                                }
+                                                disabled={item.uploading}
+                                                className="text-sm border border-gray-300 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                                            >
+                                                <option value="">-- škola --</option>
+                                                {schools.filter((s) => s.is_active).map((s) => (
+                                                    <option key={s.id} value={s.id}>{s.name}</option>
+                                                ))}
+                                            </select>
+                                        )}
+
+                                        {!item.done && !item.uploading && (
+                                            <button
+                                                onClick={() => void uploadFile(item)}
+                                                className="text-xs bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-1.5 rounded-lg font-medium transition-colors shrink-0"
+                                            >
+                                                Nahrať
+                                            </button>
+                                        )}
+
+                                        {!item.uploading && (
+                                            <button
+                                                onClick={() => removeFromQueue(item.id)}
+                                                className="text-gray-400 hover:text-gray-700 p-1 shrink-0"
+                                                aria-label="Odstrániť"
+                                            >
+                                                ✕
+                                            </button>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Already uploaded files for this date */}
+                    {uploads.length > 0 && (
+                        <div>
+                            <h2 className="text-sm font-semibold text-gray-700 mb-3">Nahrané súbory pre {date}</h2>
+                            <div className="divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white overflow-hidden">
+                                {uploads.map((u) => (
+                                    <div key={u.id} className="flex items-center gap-3 px-4 py-3">
+                                        <span className="text-base shrink-0">
+                                            {u.status === 'processed' ? '✅' : u.status === 'error' ? '❌' : '⏳'}
+                                        </span>
+                                        <div className="min-w-0 flex-1">
+                                            <p className="text-sm font-medium text-gray-900 truncate">{u.filename}</p>
+                                            <p className="text-xs text-gray-400">
+                                                {u.school_name ?? <em>bez školy</em>} · {new Date(u.uploaded_at).toLocaleString('sk-SK')}
+                                            </p>
+                                            {u.error_message && (
+                                                <p className="text-xs text-red-500 mt-0.5">{u.error_message}</p>
+                                            )}
+                                        </div>
+                                        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                                            u.status === 'processed' ? 'bg-green-100 text-green-700'
+                                            : u.status === 'error' ? 'bg-red-100 text-red-700'
+                                            : 'bg-amber-100 text-amber-700'
+                                        }`}>
+                                            {u.status === 'processed' ? 'Spracovaný' : u.status === 'error' ? 'Chyba' : 'Čaká'}
+                                        </span>
+                                        <button
+                                            onClick={() => void deleteUpload(u.id)}
+                                            className="ml-2 text-xs text-red-500 hover:text-red-700 hover:bg-red-50 px-2 py-1 rounded-lg transition-colors shrink-0"
+                                        >
+                                            Zmazať
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {tab === 'schools' && (
+                <div className="space-y-6">
+                    <div>
+                        <h2 className="text-sm font-semibold text-gray-700 mb-3">Pridať školu</h2>
+                        <form onSubmit={(e) => void addSchool(e)} className="flex gap-2">
+                            <input
+                                type="text"
+                                value={newSchoolName}
+                                onChange={(e) => setNewSchoolName(e.target.value)}
+                                placeholder="Názov školy..."
+                                className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                            />
+                            <button
+                                type="submit"
+                                disabled={savingSchool || !newSchoolName.trim()}
+                                className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+                            >
+                                {savingSchool ? 'Ukladám...' : 'Pridať'}
+                            </button>
+                        </form>
+                        {schoolError && <p className="text-xs text-red-600 mt-2">{schoolError}</p>}
+                    </div>
+
+                    <div>
+                        <h2 className="text-sm font-semibold text-gray-700 mb-3">
+                            Školy ({schools.length})
+                        </h2>
+                        {schools.length === 0 ? (
+                            <p className="text-sm text-gray-400">Žiadne školy zatiaľ.</p>
+                        ) : (
+                            <div className="divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white overflow-hidden">
+                                {schools.map((s) => (
+                                    <div key={s.id} className="flex items-center gap-3 px-4 py-3">
+                                        <span className={`w-2 h-2 rounded-full shrink-0 ${s.is_active ? 'bg-green-500' : 'bg-gray-300'}`} />
+                                        <span className="flex-1 text-sm font-medium text-gray-900">{s.name}</span>
+                                        <button
+                                            onClick={() => void toggleSchoolActive(s)}
+                                            className="text-xs text-gray-500 hover:text-gray-800 px-3 py-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+                                        >
+                                            {s.is_active ? 'Deaktivovať' : 'Aktivovať'}
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/admin/EdupageUpload.tsx
+++ b/frontend/src/pages/admin/EdupageUpload.tsx
@@ -117,15 +117,7 @@ export default function EdupageUpload() {
             form.append('file', item.file);
             if (item.schoolId) form.append('school_id', item.schoolId);
 
-            const response = await fetch('/api/admin/edupage-uploads/upload/', {
-                method: 'POST',
-                credentials: 'include',
-                body: form,
-            });
-            if (!response.ok) {
-                const err = await response.json().catch(() => ({}));
-                throw new Error((err as { error?: string }).error || response.statusText);
-            }
+            await apiClient.postForm('/admin/edupage-uploads/upload/', form);
             setQueue((prev) => prev.map((q) => (q.id === item.id ? { ...q, uploading: false, done: true } : q)));
             await loadStatusAndUploads(date);
         } catch (e) {
@@ -145,8 +137,12 @@ export default function EdupageUpload() {
     const clearDone = () => setQueue((prev) => prev.filter((q) => !q.done));
 
     const deleteUpload = async (id: number) => {
-        await apiClient.delete(`/admin/edupage-uploads/${id}/remove/`);
-        await loadStatusAndUploads(date);
+        try {
+            await apiClient.delete(`/admin/edupage-uploads/${id}/remove/`);
+            await loadStatusAndUploads(date);
+        } catch (e) {
+            alert(e instanceof Error ? e.message : 'Nepodarilo sa zmazať súbor');
+        }
     };
 
     const addSchool = async (e: React.FormEvent) => {
@@ -157,8 +153,7 @@ export default function EdupageUpload() {
         try {
             await apiClient.post('/admin/schools/', { name: newSchoolName.trim(), is_active: true });
             setNewSchoolName('');
-            await loadSchools();
-            await loadStatusAndUploads(date);
+            await Promise.all([loadSchools(), loadStatusAndUploads(date)]);
         } catch {
             setSchoolError('Chyba pri ukladaní. Overte či škola s týmto názvom už neexistuje.');
         } finally {
@@ -168,11 +163,10 @@ export default function EdupageUpload() {
 
     const toggleSchoolActive = async (school: School) => {
         await apiClient.put(`/admin/schools/${school.id}/`, { ...school, is_active: !school.is_active });
-        await loadSchools();
-        await loadStatusAndUploads(date);
+        await Promise.all([loadSchools(), loadStatusAndUploads(date)]);
     };
 
-    const pendingCount = queue.filter((q) => !q.done).length;
+    const pendingCount = queue.filter((q) => !q.done && !q.uploading).length;
     const doneCount = queue.filter((q) => q.done).length;
 
     return (

--- a/frontend/src/pages/admin/JedalnicekImport.tsx
+++ b/frontend/src/pages/admin/JedalnicekImport.tsx
@@ -22,11 +22,14 @@ interface QueuedFile {
 }
 
 const getMondayOfWeek = (date: Date): string => {
-    const d = new Date(date);
-    const day = d.getDay();
+    const day = date.getDay();
     const diff = day === 0 ? -6 : 1 - day;
-    d.setDate(d.getDate() + diff);
-    return d.toISOString().slice(0, 10);
+    const monday = new Date(date);
+    monday.setDate(date.getDate() + diff);
+    const y = monday.getFullYear();
+    const m = String(monday.getMonth() + 1).padStart(2, '0');
+    const d = String(monday.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
 };
 
 const formatWeekRange = (weekStart: string, weekEnd: string) => {
@@ -97,15 +100,7 @@ export default function JedalnicekImport() {
             form.append('week_start', item.weekStart);
             form.append('file', item.file);
 
-            const response = await fetch('/api/admin/jedalnicek-uploads/upload/', {
-                method: 'POST',
-                credentials: 'include',
-                body: form,
-            });
-            if (!response.ok) {
-                const err = await response.json().catch(() => ({}));
-                throw new Error((err as { error?: string }).error || response.statusText);
-            }
+            await apiClient.postForm('/admin/jedalnicek-uploads/upload/', form);
             setQueue((prev) => prev.map((q) => (q.id === item.id ? { ...q, uploading: false, done: true } : q)));
             await loadUploads();
         } catch (e) {
@@ -122,8 +117,12 @@ export default function JedalnicekImport() {
     };
 
     const deleteUpload = async (id: number) => {
-        await apiClient.delete(`/admin/jedalnicek-uploads/${id}/remove/`);
-        await loadUploads();
+        try {
+            await apiClient.delete(`/admin/jedalnicek-uploads/${id}/remove/`);
+            await loadUploads();
+        } catch (e) {
+            alert(e instanceof Error ? e.message : 'Nepodarilo sa zmazať súbor');
+        }
     };
 
     const removeFromQueue = (id: string) => setQueue((prev) => prev.filter((q) => q.id !== id));
@@ -230,8 +229,8 @@ export default function JedalnicekImport() {
                                             type="date"
                                             value={item.weekStart}
                                             onChange={(e) => {
-                                                const d = new Date(e.target.value);
-                                                // snap to Monday
+                                                // noon prevents UTC midnight → wrong weekday in UTC- timezones
+                                                const d = new Date(e.target.value + 'T12:00:00');
                                                 const monday = getMondayOfWeek(d);
                                                 setQueue((prev) =>
                                                     prev.map((q) =>

--- a/frontend/src/pages/admin/JedalnicekImport.tsx
+++ b/frontend/src/pages/admin/JedalnicekImport.tsx
@@ -1,0 +1,339 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { apiClient } from '../../api/client';
+
+interface JedalnicekUpload {
+    id: number;
+    week_start: string;
+    week_end: string;
+    filename: string;
+    status: 'pending' | 'processed' | 'error';
+    error_message: string;
+    uploaded_at: string;
+    entry_count: number;
+}
+
+interface QueuedFile {
+    id: string;
+    file: File;
+    weekStart: string;
+    uploading: boolean;
+    done: boolean;
+    error: string | null;
+}
+
+const getMondayOfWeek = (date: Date): string => {
+    const d = new Date(date);
+    const day = d.getDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    d.setDate(d.getDate() + diff);
+    return d.toISOString().slice(0, 10);
+};
+
+const formatWeekRange = (weekStart: string, weekEnd: string) => {
+    const start = new Date(weekStart);
+    const end = new Date(weekEnd);
+    const fmt = (d: Date) =>
+        d.toLocaleDateString('sk-SK', { day: 'numeric', month: 'numeric' });
+    return `${fmt(start)} – ${fmt(end)} ${end.getFullYear()}`;
+};
+
+const STATUS_LABEL: Record<string, string> = {
+    pending: 'Čaká',
+    processed: 'Spracovaný',
+    error: 'Chyba',
+};
+
+const STATUS_COLOR: Record<string, string> = {
+    pending: 'bg-amber-100 text-amber-700',
+    processed: 'bg-green-100 text-green-700',
+    error: 'bg-red-100 text-red-700',
+};
+
+export default function JedalnicekImport() {
+    const [uploads, setUploads] = useState<JedalnicekUpload[]>([]);
+    const [queue, setQueue] = useState<QueuedFile[]>([]);
+    const [isDragging, setIsDragging] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const defaultWeekStart = getMondayOfWeek(new Date());
+
+    const loadUploads = useCallback(async () => {
+        setLoading(true);
+        try {
+            const data = await apiClient.get<JedalnicekUpload[]>('/admin/jedalnicek-uploads/');
+            setUploads(data);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void loadUploads();
+    }, [loadUploads]);
+
+    const addFiles = (files: FileList | File[]) => {
+        const newItems: QueuedFile[] = Array.from(files).map((f) => ({
+            id: `${f.name}-${Date.now()}-${Math.random()}`,
+            file: f,
+            weekStart: defaultWeekStart,
+            uploading: false,
+            done: false,
+            error: null,
+        }));
+        setQueue((prev) => [...prev, ...newItems]);
+    };
+
+    const onDrop = (e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragging(false);
+        if (e.dataTransfer.files.length) addFiles(e.dataTransfer.files);
+    };
+
+    const uploadFile = async (item: QueuedFile) => {
+        setQueue((prev) => prev.map((q) => (q.id === item.id ? { ...q, uploading: true, error: null } : q)));
+        try {
+            const form = new FormData();
+            form.append('week_start', item.weekStart);
+            form.append('file', item.file);
+
+            const response = await fetch('/api/admin/jedalnicek-uploads/upload/', {
+                method: 'POST',
+                credentials: 'include',
+                body: form,
+            });
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error((err as { error?: string }).error || response.statusText);
+            }
+            setQueue((prev) => prev.map((q) => (q.id === item.id ? { ...q, uploading: false, done: true } : q)));
+            await loadUploads();
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : 'Neznáma chyba';
+            setQueue((prev) => prev.map((q) => (q.id === item.id ? { ...q, uploading: false, error: msg } : q)));
+        }
+    };
+
+    const uploadAll = async () => {
+        const pending = queue.filter((q) => !q.done && !q.uploading);
+        for (const item of pending) {
+            await uploadFile(item);
+        }
+    };
+
+    const deleteUpload = async (id: number) => {
+        await apiClient.delete(`/admin/jedalnicek-uploads/${id}/remove/`);
+        await loadUploads();
+    };
+
+    const removeFromQueue = (id: string) => setQueue((prev) => prev.filter((q) => q.id !== id));
+    const clearDone = () => setQueue((prev) => prev.filter((q) => !q.done));
+
+    const pendingCount = queue.filter((q) => !q.done).length;
+    const doneCount = queue.filter((q) => q.done).length;
+
+    // Group uploads by week
+    const byWeek = uploads.reduce<Record<string, JedalnicekUpload[]>>((acc, u) => {
+        const key = u.week_start;
+        if (!acc[key]) acc[key] = [];
+        acc[key].push(u);
+        return acc;
+    }, {});
+
+    return (
+        <div>
+            <div className="mb-6">
+                <h1 className="text-2xl font-bold text-gray-900">Jedálniček – import</h1>
+                <p className="text-gray-500 mt-1 text-sm">
+                    Nahrávanie týždenných jedálničkov s gramážami pre všetky diety
+                </p>
+            </div>
+
+            {/* Drop zone */}
+            <div className="mb-8">
+                <div
+                    onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+                    onDragLeave={() => setIsDragging(false)}
+                    onDrop={onDrop}
+                    onClick={() => fileInputRef.current?.click()}
+                    className={`cursor-pointer rounded-2xl border-2 border-dashed px-8 py-12 text-center transition-colors ${
+                        isDragging
+                            ? 'border-teal-400 bg-teal-50'
+                            : 'border-gray-300 bg-gray-50 hover:border-teal-300 hover:bg-teal-50/50'
+                    }`}
+                >
+                    <div className="text-4xl mb-3">📅</div>
+                    <p className="text-gray-600 font-medium">Presuň súbory s jedálničkom sem alebo klikni pre výber</p>
+                    <p className="text-xs text-gray-400 mt-1">Jeden súbor = jeden týždeň · môžeš nahrať viacero naraz</p>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        className="hidden"
+                        onChange={(e) => e.target.files && addFiles(e.target.files)}
+                    />
+                </div>
+            </div>
+
+            {/* Queue */}
+            {queue.length > 0 && (
+                <div className="mb-8">
+                    <div className="flex items-center justify-between mb-3">
+                        <h2 className="text-sm font-semibold text-gray-700">
+                            Fronta ({pendingCount} čakajú{doneCount > 0 ? `, ${doneCount} hotových` : ''})
+                        </h2>
+                        <div className="flex gap-2">
+                            {doneCount > 0 && (
+                                <button
+                                    onClick={clearDone}
+                                    className="text-xs text-gray-500 hover:text-gray-800 px-3 py-1.5 rounded-lg hover:bg-gray-100"
+                                >
+                                    Zmazať hotové
+                                </button>
+                            )}
+                            {pendingCount > 0 && (
+                                <button
+                                    onClick={() => void uploadAll()}
+                                    className="text-xs bg-teal-600 hover:bg-teal-700 text-white px-4 py-1.5 rounded-lg font-medium transition-colors"
+                                >
+                                    Nahrať všetky ({pendingCount})
+                                </button>
+                            )}
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        {queue.map((item) => (
+                            <div
+                                key={item.id}
+                                className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${
+                                    item.done
+                                        ? 'bg-green-50 border-green-200'
+                                        : item.error
+                                        ? 'bg-red-50 border-red-200'
+                                        : 'bg-white border-gray-200'
+                                }`}
+                            >
+                                <span className="text-lg shrink-0">
+                                    {item.done ? '✅' : item.error ? '❌' : item.uploading ? '⏳' : '📄'}
+                                </span>
+
+                                <div className="min-w-0 flex-1">
+                                    <p className="text-sm font-medium text-gray-900 truncate">{item.file.name}</p>
+                                    {item.error && <p className="text-xs text-red-600 mt-0.5">{item.error}</p>}
+                                </div>
+
+                                {!item.done && (
+                                    <div className="shrink-0">
+                                        <label className="text-xs text-gray-500 mr-1">Týždeň od:</label>
+                                        <input
+                                            type="date"
+                                            value={item.weekStart}
+                                            onChange={(e) => {
+                                                const d = new Date(e.target.value);
+                                                // snap to Monday
+                                                const monday = getMondayOfWeek(d);
+                                                setQueue((prev) =>
+                                                    prev.map((q) =>
+                                                        q.id === item.id ? { ...q, weekStart: monday } : q
+                                                    )
+                                                );
+                                            }}
+                                            disabled={item.uploading}
+                                            className="text-sm border border-gray-300 rounded-lg px-2 py-1 focus:outline-none focus:ring-2 focus:ring-teal-500 disabled:opacity-50"
+                                        />
+                                    </div>
+                                )}
+
+                                {!item.done && !item.uploading && (
+                                    <button
+                                        onClick={() => void uploadFile(item)}
+                                        className="text-xs bg-teal-600 hover:bg-teal-700 text-white px-3 py-1.5 rounded-lg font-medium transition-colors shrink-0"
+                                    >
+                                        Nahrať
+                                    </button>
+                                )}
+
+                                {!item.uploading && (
+                                    <button
+                                        onClick={() => removeFromQueue(item.id)}
+                                        className="text-gray-400 hover:text-gray-700 p-1 shrink-0"
+                                        aria-label="Odstrániť"
+                                    >
+                                        ✕
+                                    </button>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {/* Uploaded weeks */}
+            <div>
+                <h2 className="text-sm font-semibold text-gray-700 mb-3">
+                    Nahrané jedálničky
+                    {loading && <span className="ml-2 text-gray-400 font-normal">Načítavam...</span>}
+                </h2>
+
+                {!loading && uploads.length === 0 && (
+                    <p className="text-sm text-gray-400">Zatiaľ žiadne nahrané jedálničky.</p>
+                )}
+
+                {Object.entries(byWeek)
+                    .sort(([a], [b]) => b.localeCompare(a))
+                    .map(([weekStart, weekUploads]) => {
+                        const weekEnd = weekUploads[0].week_end;
+                        const processedCount = weekUploads.filter((u) => u.status === 'processed').length;
+                        const totalEntries = weekUploads.reduce((s, u) => s + u.entry_count, 0);
+
+                        return (
+                            <div key={weekStart} className="mb-4 rounded-xl border border-gray-200 bg-white overflow-hidden">
+                                <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 bg-gray-50">
+                                    <span className="text-base">📅</span>
+                                    <div className="flex-1">
+                                        <span className="font-semibold text-gray-900 text-sm">
+                                            {formatWeekRange(weekStart, weekEnd)}
+                                        </span>
+                                        {totalEntries > 0 && (
+                                            <span className="ml-2 text-xs text-teal-600 font-medium">
+                                                {totalEntries} položiek
+                                            </span>
+                                        )}
+                                    </div>
+                                    <span className="text-xs text-gray-400">
+                                        {processedCount}/{weekUploads.length} spracovaných
+                                    </span>
+                                </div>
+
+                                {weekUploads.map((u) => (
+                                    <div key={u.id} className="flex items-center gap-3 px-4 py-2.5 border-b border-gray-50 last:border-0">
+                                        <span className="text-sm shrink-0">📄</span>
+                                        <div className="min-w-0 flex-1">
+                                            <p className="text-sm text-gray-800 truncate">{u.filename}</p>
+                                            <p className="text-xs text-gray-400">
+                                                {new Date(u.uploaded_at).toLocaleString('sk-SK')}
+                                                {u.entry_count > 0 && ` · ${u.entry_count} položiek`}
+                                            </p>
+                                            {u.error_message && (
+                                                <p className="text-xs text-red-500 mt-0.5">{u.error_message}</p>
+                                            )}
+                                        </div>
+                                        <span className={`text-xs px-2 py-0.5 rounded-full font-medium shrink-0 ${STATUS_COLOR[u.status]}`}>
+                                            {STATUS_LABEL[u.status]}
+                                        </span>
+                                        <button
+                                            onClick={() => void deleteUpload(u.id)}
+                                            className="text-xs text-red-500 hover:text-red-700 hover:bg-red-50 px-2 py-1 rounded-lg transition-colors shrink-0"
+                                        >
+                                            Zmazať
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        );
+                    })}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/client/pages/MenuPage.tsx
+++ b/frontend/src/pages/client/pages/MenuPage.tsx
@@ -200,7 +200,7 @@ const MenuPage = () => {
           .join("")
       : mealItems.map((item) => item.template_detail?.weight_label).filter(Boolean).join(" · ");
 
-    const isEmpty = useImport ? importEntries.length === 0 : mealItems.length === 0;
+    const isEmpty = !useImport && mealItems.length === 0;
 
     return (
       <div className="zp-menu-meal" key={mealKey}>

--- a/frontend/src/pages/client/pages/MenuPage.tsx
+++ b/frontend/src/pages/client/pages/MenuPage.tsx
@@ -22,10 +22,24 @@ interface MealPlanItem {
   template_detail: MealTemplate;
 }
 
+export interface JedalnicekEntry {
+  id: number;
+  date: string;
+  category: MealKey;
+  category_display: string;
+  menu_variant: string;
+  diet: number | null;
+  diet_name: string | null;
+  name: string;
+  weight_grams: string | null;
+}
+
 interface MealPlanResponse {
   exists: boolean;
   date: string;
   items: MealPlanItem[];
+  import_entries: JedalnicekEntry[];
+  has_import: boolean;
 }
 
 interface WeekDay {
@@ -108,12 +122,12 @@ const MenuPage = () => {
               `${API_URL}/meal-plans/by-date/?date=${weekDay.date}`,
             );
             if (!res.ok) {
-              return [weekDay.date, { exists: false, date: weekDay.date, items: [] }];
+              return [weekDay.date, { exists: false, date: weekDay.date, items: [], import_entries: [], has_import: false }];
             }
             const data = (await res.json()) as MealPlanResponse;
             return [weekDay.date, data];
           } catch {
-            return [weekDay.date, { exists: false, date: weekDay.date, items: [] }];
+            return [weekDay.date, { exists: false, date: weekDay.date, items: [], import_entries: [], has_import: false }];
           }
         }),
       );
@@ -150,6 +164,20 @@ const MenuPage = () => {
     return grouped;
   }, [plan]);
 
+  const groupedImportEntries = useMemo(() => {
+    const grouped: Record<MealKey, JedalnicekEntry[]> = {
+      breakfast: [],
+      lunch: [],
+      snack: [],
+    };
+    (plan?.import_entries || []).forEach((entry) => {
+      if (entry.category in grouped) {
+        grouped[entry.category].push(entry);
+      }
+    });
+    return grouped;
+  }, [plan]);
+
   const letterClass = (letter: string) => {
     if (letter === "B") return "b";
     if (letter === "V") return "v";
@@ -157,12 +185,22 @@ const MenuPage = () => {
   };
 
   const mealColumns = (Object.keys(MEAL_META) as MealKey[]).map((mealKey) => {
+    const importEntries = groupedImportEntries[mealKey];
     const mealItems = groupedItems[mealKey];
+    const useImport = plan?.has_import && importEntries.length > 0;
     const Icon = MEAL_META[mealKey].icon;
-    const weightLabel = mealItems
-      .map((item) => item.template_detail?.weight_label)
-      .filter(Boolean)
-      .join(" · ");
+
+    // Weight label: from import (per-diet gramáže) or from templates
+    const weightLabel = useImport
+      ? importEntries
+          .filter((e) => !e.menu_variant || e.menu_variant === "A")
+          .filter((e) => e.weight_grams)
+          .map((e) => `${e.weight_grams}g`)
+          .slice(0, 1)
+          .join("")
+      : mealItems.map((item) => item.template_detail?.weight_label).filter(Boolean).join(" · ");
+
+    const isEmpty = useImport ? importEntries.length === 0 : mealItems.length === 0;
 
     return (
       <div className="zp-menu-meal" key={mealKey}>
@@ -171,10 +209,38 @@ const MenuPage = () => {
           <span className="name">{MEAL_META[mealKey].label}</span>
           <span className="gram">{weightLabel}</span>
         </div>
-        {mealItems.length === 0 ? (
+        {isEmpty ? (
           <div className="zp-empty" style={{ padding: "12px 16px", fontSize: 13 }}>
             Nie je k dispozícii
           </div>
+        ) : useImport ? (
+          // Render from import entries — group by variant
+          Object.entries(
+            importEntries.reduce<Record<string, JedalnicekEntry[]>>((acc, e) => {
+              const key = e.menu_variant || "_";
+              if (!acc[key]) acc[key] = [];
+              acc[key].push(e);
+              return acc;
+            }, {})
+          ).map(([variant, entries]) => (
+            <div className="zp-menu-item" key={variant}>
+              {variant !== "_" && (
+                <span className={`letter ${letterClass(variant)}`}>{variant}</span>
+              )}
+              <div className="body">
+                {/* Show first entry's name (diets may differ but name is same) */}
+                <div className="ttl">{entries[0].name}</div>
+                {entries.some((e) => e.weight_grams) && (
+                  <div className="desc">
+                    {entries
+                      .filter((e) => e.weight_grams)
+                      .map((e) => `${e.diet_name ?? "Štandard"}: ${e.weight_grams}g`)
+                      .join(" · ")}
+                  </div>
+                )}
+              </div>
+            </div>
+          ))
         ) : (
           mealItems.map((item) => {
             const variant = item.menu_variant || item.template_detail?.menu_variant || "A";


### PR DESCRIPTION
## Summary

- **Edupage (school orders):** `School` + `EdupageUpload` models, `/admin/edupage` page with drag-and-drop bulk upload, per-file school selector, and per-date status grid showing which schools have been uploaded (X/Y)
- **Jedálniček import:** `JedalnicekUpload` + `JedalnicekEntry` models, `/admin/jedalnicek-import` page with drag-and-drop, Monday week-start picker, and upload history grouped by week
- `DailyMealPlanViewSet.by_date` now returns `import_entries` + `has_import` flag alongside existing manual plan data
- `MenuPage` uses import entries when available, showing per-diet gramáže instead of template weight labels

CSV/Excel parser is intentionally not included — format details TBD. Files are stored with `status=pending` until parser lands. `MealTemplate` and `PortionType` are kept intact for now.

## Test plan

- [ ] Admin can add schools at `/admin/edupage` → Školy tab
- [ ] Admin can drag-and-drop multiple files, assign school per file, upload all
- [ ] Per-date grid shows correct X/Y badge and green/grey school tiles
- [ ] Admin can delete an uploaded file
- [ ] Admin can drag-and-drop weekly files at `/admin/jedalnicek-import`
- [ ] Week-start date picker snaps to Monday
- [ ] Upload history groups by week with entry count (0 until parser)
- [ ] `GET /api/meal-plans/by-date/?date=X` returns `import_entries: []` and `has_import: false` (parser pending)
- [ ] Client MenuPage still renders correctly from manual plan when no import exists
- [ ] All hooks pass: black, isort, flake8, mypy, tsc

🤖 Generated with [Claude Code](https://claude.com/claude-code)