### PR TITLE
feat: admin dashboard

### DIFF
--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -89,9 +89,9 @@ interface MealColors {
 }
 
 const BREAKFAST_COLORS: MealColors = {
-  header1: "bg-amber-600", header2: "bg-amber-500", cellBg: "bg-amber-50/50",
+  header1: "bg-amber-700", header2: "bg-amber-600", cellBg: "bg-amber-50/50",
   rowBorder: "border-l-4 border-amber-400",
-  cardHeader: "bg-amber-600", cardStdBg: "bg-amber-50", cardDietBg: "bg-amber-100/60",
+  cardHeader: "bg-amber-700", cardStdBg: "bg-amber-50", cardDietBg: "bg-amber-100/60",
   cardStdText: "text-amber-900", cardDietText: "text-amber-700",
 };
 
@@ -407,14 +407,16 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
   const GramCells = ({
     col_grams,
     extraCellClass = "",
-    positiveClass = "text-gray-900 font-medium",
+    positiveClass,
     tintCells = false,
   }: {
     col_grams: string[][];
     extraCellClass?: string;
     positiveClass?: string;
     tintCells?: boolean;
-  }) => (
+  }) => {
+    const resolved = positiveClass ?? "text-gray-900 font-medium";
+    return (
     <>
       {col_groups.map((cg, gi) => {
         const grams = col_grams[gi] || [];
@@ -422,7 +424,7 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
         return cg.components.map((_, ci) => (
           <td key={`${gi}-${ci}`} className={`px-2 py-1.5 text-right tabular-nums text-xs ${tint} ${extraCellClass}`}>
             {grams[ci] ? (
-              <span className={parseFloat(grams[ci]) > 0 ? positiveClass : "text-gray-300"}>
+              <span className={parseFloat(grams[ci]) > 0 ? resolved : "text-gray-300"}>
                 {parseFloat(grams[ci]) > 0 ? Math.round(parseFloat(grams[ci])) : "—"}
               </span>
             ) : (
@@ -432,7 +434,8 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
         ));
       })}
     </>
-  );
+    );
+  };
 
   const SummaryRow = ({
     label,
@@ -440,12 +443,14 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
     col_grams,
     rowClassName,
     cellClassName,
+    positiveClass,
   }: {
     label: string;
     count: number;
     col_grams: string[][];
     rowClassName: string;
     cellClassName: string;
+    positiveClass?: string;
   }) => (
     <tr className={rowClassName}>
       <td className={`px-4 py-2 sticky left-0 z-10 ${cellClassName}`}>
@@ -454,7 +459,7 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
       <td className={`px-3 py-2 text-center font-semibold ${cellClassName}`}>
         {count > 0 ? count : "—"}
       </td>
-      <GramCells col_grams={col_grams} extraCellClass={cellClassName} />
+      <GramCells col_grams={col_grams} extraCellClass={cellClassName} positiveClass={positiveClass} />
     </tr>
   );
 
@@ -553,9 +558,9 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
                         key={si}
                         className={`border-b border-gray-100 hover:bg-gray-50 transition ${
                           sr.type === "diet" ? "bg-yellow-50" : ""
-                        } ${mealColors.rowBorder}`}
+                        }`}
                       >
-                        <td className={`px-4 py-1.5 text-gray-700 sticky left-0 z-10 ${sr.type === "diet" ? "bg-yellow-50 pl-8 text-xs italic text-yellow-700" : "bg-white"}`}>
+                        <td className={`px-4 py-1.5 text-gray-700 sticky left-0 z-10 ${mealColors.rowBorder} ${sr.type === "diet" ? "bg-yellow-50 pl-8 text-xs italic text-yellow-700" : "bg-white"}`}>
                           {sr.type === "diet" ? `↳ ${sr.label}` : sr.label}
                         </td>
                         <td className={`px-3 py-1.5 text-center font-semibold ${sr.type === "diet" ? "text-yellow-700 text-xs" : "text-gray-900"}`}>
@@ -586,6 +591,7 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
                     col_grams={row.standard_col_grams}
                     rowClassName="border-b border-emerald-100 bg-emerald-50/80"
                     cellClassName="bg-emerald-50/80 text-emerald-900"
+                    positiveClass="text-emerald-900 font-medium"
                   />
                   {row.diet_summary_rows.map((diet) => (
                     <SummaryRow
@@ -595,6 +601,7 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
                       col_grams={diet.col_grams}
                       rowClassName="border-b border-amber-100 bg-amber-50/80"
                       cellClassName="bg-amber-50/80 text-amber-900"
+                      positiveClass="text-amber-900 font-medium"
                     />
                   ))}
                 </React.Fragment>

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -74,6 +74,67 @@ interface GramageDashboard {
   count_summary: CountSection[];
 }
 
+// ── Meal color palette ────────────────────────────────────────────────────────
+
+interface MealColors {
+  header1: string;   // primary header bg
+  header2: string;   // secondary header bg (component row)
+  cellBg: string;    // data cell tint
+  rowBorder: string; // tbody row left border
+  cardHeader: string;
+  cardStdBg: string;
+  cardDietBg: string;
+  cardStdText: string;
+  cardDietText: string;
+}
+
+const BREAKFAST_COLORS: MealColors = {
+  header1: "bg-amber-600", header2: "bg-amber-500", cellBg: "bg-amber-50/50",
+  rowBorder: "border-l-4 border-amber-400",
+  cardHeader: "bg-amber-600", cardStdBg: "bg-amber-50", cardDietBg: "bg-amber-100/60",
+  cardStdText: "text-amber-900", cardDietText: "text-amber-700",
+};
+
+const LUNCH_COLORS: Record<string, MealColors> = {
+  A: {
+    header1: "bg-sky-700", header2: "bg-sky-600", cellBg: "bg-sky-50/50",
+    rowBorder: "border-l-4 border-sky-400",
+    cardHeader: "bg-sky-700", cardStdBg: "bg-sky-50", cardDietBg: "bg-sky-100/60",
+    cardStdText: "text-sky-900", cardDietText: "text-sky-700",
+  },
+  B: {
+    header1: "bg-indigo-700", header2: "bg-indigo-600", cellBg: "bg-indigo-50/50",
+    rowBorder: "border-l-4 border-indigo-400",
+    cardHeader: "bg-indigo-700", cardStdBg: "bg-indigo-50", cardDietBg: "bg-indigo-100/60",
+    cardStdText: "text-indigo-900", cardDietText: "text-indigo-700",
+  },
+  C: {
+    header1: "bg-violet-700", header2: "bg-violet-600", cellBg: "bg-violet-50/50",
+    rowBorder: "border-l-4 border-violet-400",
+    cardHeader: "bg-violet-700", cardStdBg: "bg-violet-50", cardDietBg: "bg-violet-100/60",
+    cardStdText: "text-violet-900", cardDietText: "text-violet-700",
+  },
+  V: {
+    header1: "bg-purple-700", header2: "bg-purple-600", cellBg: "bg-purple-50/50",
+    rowBorder: "border-l-4 border-purple-400",
+    cardHeader: "bg-purple-700", cardStdBg: "bg-purple-50", cardDietBg: "bg-purple-100/60",
+    cardStdText: "text-purple-900", cardDietText: "text-purple-700",
+  },
+};
+
+const SNACK_COLORS: MealColors = {
+  header1: "bg-emerald-700", header2: "bg-emerald-600", cellBg: "bg-emerald-50/50",
+  rowBorder: "border-l-4 border-emerald-400",
+  cardHeader: "bg-emerald-700", cardStdBg: "bg-emerald-50", cardDietBg: "bg-emerald-100/60",
+  cardStdText: "text-emerald-900", cardDietText: "text-emerald-700",
+};
+
+function getMealColors(meal: string, variant: string): MealColors {
+  if (meal === "breakfast") return BREAKFAST_COLORS;
+  if (meal === "lunch") return LUNCH_COLORS[variant] ?? LUNCH_COLORS.A;
+  return SNACK_COLORS;
+}
+
 // ── Date helpers ──────────────────────────────────────────────────────────────
 
 function toDateString(d: Date): string {
@@ -227,7 +288,65 @@ const AdminDashboard: React.FC = () => {
         </div>
       )}
 
-      {!loading && data && hasData && <GramageTable data={data} />}
+      {!loading && data && hasData && (
+        <>
+          <CountSummarySection sections={data.count_summary} />
+          <GramageTable data={data} />
+        </>
+      )}
+    </div>
+  );
+};
+
+// ── CountSummarySection ───────────────────────────────────────────────────────
+
+const CountSummarySection: React.FC<{ sections: CountSection[] }> = ({ sections }) => {
+  if (sections.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-lg font-bold text-gray-800">Súhrn počtov porcií</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {sections.map((section) => {
+          const colors = getMealColors(section.meal, section.variant);
+          const totalStd = section.standard.reduce((s, r) => s + r.count, 0);
+          const totalDiets = section.diets.reduce((s, r) => s + r.count, 0);
+          return (
+            <div key={`${section.meal}_${section.variant}`} className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+              <div className={`${colors.cardHeader} text-white px-4 py-3`}>
+                <div className="font-bold text-sm">{section.label}</div>
+                <div className="text-xs opacity-80 mt-0.5">Celkom: {totalStd + totalDiets} porcií</div>
+              </div>
+              <div className="divide-y divide-gray-100">
+                {section.standard.map((row) => (
+                  <div key={row.name} className={`flex items-center justify-between px-4 py-2 ${colors.cardStdBg}`}>
+                    <span className={`text-sm font-medium ${colors.cardStdText}`}>{row.name}</span>
+                    <span className={`text-sm font-bold tabular-nums ${colors.cardStdText}`}>{row.count}</span>
+                  </div>
+                ))}
+                {section.standard.length > 1 && (
+                  <div className={`flex items-center justify-between px-4 py-2 border-t border-gray-200 ${colors.cardStdBg}`}>
+                    <span className={`text-xs font-bold uppercase tracking-wide opacity-70 ${colors.cardStdText}`}>Spolu štandard</span>
+                    <span className={`text-sm font-bold tabular-nums ${colors.cardStdText}`}>{totalStd}</span>
+                  </div>
+                )}
+                {section.diets.map((row) => (
+                  <div key={row.label} className={`flex items-center justify-between px-4 py-2 pl-7 ${colors.cardDietBg}`}>
+                    <span className={`text-xs italic ${colors.cardDietText}`}>↳ {row.label}</span>
+                    <span className={`text-xs font-semibold tabular-nums ${colors.cardDietText}`}>{row.count}</span>
+                  </div>
+                ))}
+                {section.diets.length > 0 && (
+                  <div className={`flex items-center justify-between px-4 py-2 border-t border-gray-200 ${colors.cardDietBg}`}>
+                    <span className={`text-xs font-bold uppercase tracking-wide opacity-70 ${colors.cardDietText}`}>Spolu diéty</span>
+                    <span className={`text-xs font-bold tabular-nums ${colors.cardDietText}`}>{totalDiets}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 };
@@ -238,7 +357,6 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
   const { col_groups, rows, totals } = data;
   const [expandedClients, setExpandedClients] = useState<number[]>([]);
 
-  // Total component count across all col_groups
   const totalComponents = col_groups.reduce((s, cg) => s + cg.components.length, 0);
 
   const toggleClient = (clientId: number) => {
@@ -249,7 +367,12 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
     );
   };
 
-  // Aggregate sub_rows from all clients into per-variant gram totals
+  // Precomputed per-col-group colors
+  const colGroupColors = useMemo(
+    () => col_groups.map((cg) => getMealColors(cg.meal, cg.variant)),
+    [col_groups],
+  );
+
   const aggregatedRows = useMemo(() => {
     type NumRow = { type: "standard" | "diet"; label: string; count: number; col_grams: number[][] };
     const map = new Map<string, NumRow>();
@@ -281,13 +404,23 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
     };
   }, [rows, col_groups]);
 
-  // Helper: render gramage cells for a sub_row
-  const GramCells = ({ col_grams, className = "", positiveClass = "text-gray-900 font-medium" }: { col_grams: string[][]; className?: string; positiveClass?: string }) => (
+  const GramCells = ({
+    col_grams,
+    extraCellClass = "",
+    positiveClass = "text-gray-900 font-medium",
+    tintCells = false,
+  }: {
+    col_grams: string[][];
+    extraCellClass?: string;
+    positiveClass?: string;
+    tintCells?: boolean;
+  }) => (
     <>
       {col_groups.map((cg, gi) => {
         const grams = col_grams[gi] || [];
+        const tint = tintCells ? colGroupColors[gi].cellBg : "";
         return cg.components.map((_, ci) => (
-          <td key={`${gi}-${ci}`} className={`px-2 py-1.5 text-right tabular-nums text-xs ${className}`}>
+          <td key={`${gi}-${ci}`} className={`px-2 py-1.5 text-right tabular-nums text-xs ${tint} ${extraCellClass}`}>
             {grams[ci] ? (
               <span className={parseFloat(grams[ci]) > 0 ? positiveClass : "text-gray-300"}>
                 {parseFloat(grams[ci]) > 0 ? Math.round(parseFloat(grams[ci])) : "—"}
@@ -321,11 +454,10 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
       <td className={`px-3 py-2 text-center font-semibold ${cellClassName}`}>
         {count > 0 ? count : "—"}
       </td>
-      <GramCells col_grams={col_grams} className={cellClassName} />
+      <GramCells col_grams={col_grams} extraCellClass={cellClassName} />
     </tr>
   );
 
-  // Totals row cells
   const TotalCells = () => (
     <>
       {col_groups.map((cg, gi) =>
@@ -343,19 +475,19 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
       <div className="overflow-x-auto">
         <table className="w-full text-sm border-collapse">
           <thead>
-            {/* Row 1: meal group headers */}
-            <tr className="bg-blue-800 text-white">
-              <th className="px-4 py-3 text-left font-semibold sticky left-0 bg-blue-800 z-10 min-w-[180px]" rowSpan={2}>
-                Klient / Riadok
+            {/* Row 1: meal group headers — each col_group gets its meal color */}
+            <tr className="text-white">
+              <th className="px-4 py-3 text-left font-semibold sticky left-0 bg-slate-700 z-10 min-w-[180px]" rowSpan={2}>
+                Prevádzka / Riadok
               </th>
-              <th className="px-3 py-3 font-semibold text-center min-w-[50px]" rowSpan={2}>
+              <th className="px-3 py-3 font-semibold text-center min-w-[50px] bg-slate-700" rowSpan={2}>
                 Počet
               </th>
-              {col_groups.map((cg) => (
+              {col_groups.map((cg, gi) => (
                 <th
                   key={cg.key}
                   colSpan={cg.components.length}
-                  className="px-3 py-2 text-center font-semibold border-l border-blue-600"
+                  className={`px-3 py-2 text-center font-semibold border-l border-white/20 ${colGroupColors[gi].header1}`}
                 >
                   {cg.label}
                   <div className="text-[10px] font-normal opacity-75 truncate max-w-[200px] mx-auto">
@@ -365,10 +497,13 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
               ))}
             </tr>
             {/* Row 2: component labels */}
-            <tr className="bg-blue-700 text-white text-xs">
-              {col_groups.map((cg) =>
+            <tr className="text-white text-xs">
+              {col_groups.map((cg, gi) =>
                 cg.components.map((comp, ci) => (
-                  <th key={`${cg.key}-${ci}`} className={`px-2 py-1.5 text-center font-medium ${ci === 0 ? "border-l border-blue-600" : ""}`}>
+                  <th
+                    key={`${cg.key}-${ci}`}
+                    className={`px-2 py-1.5 text-center font-medium ${colGroupColors[gi].header2} ${ci === 0 ? "border-l border-white/20" : ""}`}
+                  >
                     {comp.label}
                     <span className="block text-[10px] opacity-60">{comp.base_grams}g</span>
                   </th>
@@ -411,22 +546,25 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
                     </td>
                   </tr>
 
-                  {isExpanded && row.sub_rows.map((sr, si) => (
-                    <tr
-                      key={si}
-                      className={`border-b border-gray-100 hover:bg-gray-50 transition ${
-                        sr.type === "diet" ? "bg-yellow-50" : ""
-                      }`}
-                    >
-                      <td className={`px-4 py-1.5 text-gray-700 sticky left-0 z-10 ${sr.type === "diet" ? "bg-yellow-50 pl-8 text-xs italic text-yellow-700" : "bg-white"}`}>
-                        {sr.type === "diet" ? `↳ ${sr.label}` : sr.label}
-                      </td>
-                      <td className={`px-3 py-1.5 text-center font-semibold ${sr.type === "diet" ? "text-yellow-700 text-xs" : "text-gray-900"}`}>
-                        {sr.count}
-                      </td>
-                      <GramCells col_grams={sr.col_grams} />
-                    </tr>
-                  ))}
+                  {isExpanded && row.sub_rows.map((sr, si) => {
+                    const mealColors = getMealColors(sr.meal, sr.variant ?? "");
+                    return (
+                      <tr
+                        key={si}
+                        className={`border-b border-gray-100 hover:bg-gray-50 transition ${
+                          sr.type === "diet" ? "bg-yellow-50" : ""
+                        } ${mealColors.rowBorder}`}
+                      >
+                        <td className={`px-4 py-1.5 text-gray-700 sticky left-0 z-10 ${sr.type === "diet" ? "bg-yellow-50 pl-8 text-xs italic text-yellow-700" : "bg-white"}`}>
+                          {sr.type === "diet" ? `↳ ${sr.label}` : sr.label}
+                        </td>
+                        <td className={`px-3 py-1.5 text-center font-semibold ${sr.type === "diet" ? "text-yellow-700 text-xs" : "text-gray-900"}`}>
+                          {sr.count}
+                        </td>
+                        <GramCells col_grams={sr.col_grams} tintCells />
+                      </tr>
+                    );
+                  })}
 
                   {isExpanded && row.admin_order_note?.trim() && (
                     <tr className="border-b border-green-100 bg-green-50/40">
@@ -464,31 +602,27 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
             })}
           </tbody>
           <tfoot>
-            {/* Section header */}
             <tr className="bg-slate-600 text-white border-t-2 border-slate-700">
               <td colSpan={2 + totalComponents} className="px-4 py-2 font-bold text-xs uppercase tracking-wider sticky left-0 bg-slate-600 z-10">
                 Súhrn porcií
               </td>
             </tr>
-            {/* Standard variant rows */}
             {aggregatedRows.standard.map((row) => (
               <tr key={row.label} className="border-b border-gray-100 bg-white">
                 <td className="px-4 py-2 sticky left-0 z-10 bg-white text-sm text-gray-700">{row.label}</td>
                 <td className="px-3 py-2 text-center text-sm tabular-nums font-semibold text-gray-900">{row.count > 0 ? row.count : "—"}</td>
-                <GramCells col_grams={row.col_grams} />
+                <GramCells col_grams={row.col_grams} tintCells />
               </tr>
             ))}
-            {/* Diet variant rows */}
             {aggregatedRows.diets.map((row) => (
               <tr key={row.label} className="border-b border-amber-50 bg-amber-50/40">
                 <td className="px-4 py-2 pl-10 sticky left-0 z-10 bg-amber-50/40 text-xs italic text-amber-700">↳ {row.label}</td>
                 <td className="px-3 py-2 text-center text-xs tabular-nums font-semibold text-amber-700">{row.count > 0 ? row.count : "—"}</td>
-                <GramCells col_grams={row.col_grams} className="bg-amber-50/40" positiveClass="text-amber-800 font-medium" />
+                <GramCells col_grams={row.col_grams} extraCellClass="bg-amber-50/40" positiveClass="text-amber-800 font-medium" />
               </tr>
             ))}
-            {/* Grand total */}
-            <tr className="bg-blue-800 text-white border-t-2 border-blue-900">
-              <td colSpan={2} className="px-4 py-2.5 font-bold sticky left-0 bg-blue-800 z-10">
+            <tr className="bg-slate-700 text-white border-t-2 border-slate-800">
+              <td colSpan={2} className="px-4 py-2.5 font-bold sticky left-0 bg-slate-700 z-10">
                 CELKOM (g)
               </td>
               <TotalCells />

--- a/frontend/src/pages/admin/ClientDetail.tsx
+++ b/frontend/src/pages/admin/ClientDetail.tsx
@@ -248,8 +248,6 @@ const ClientDetail: React.FC = () => {
     setSaving(true);
     try {
       const payload = {
-        first_name: user.first_name,
-        last_name: user.last_name,
         email: user.email,
         is_staff: user.is_staff,
         settings: {
@@ -326,9 +324,7 @@ const ClientDetail: React.FC = () => {
             </div>
             <div>
               <h2 className="text-3xl font-bold text-gray-900">
-                {user.first_name || user.last_name
-                  ? `${user.first_name} ${user.last_name}`.trim()
-                  : user.email}
+                {user.profile?.company_name || user.email}
               </h2>
               <p className="text-gray-500">{user.email}</p>
               {isApiClient && (

--- a/frontend/src/pages/admin/ClientDetail.tsx
+++ b/frontend/src/pages/admin/ClientDetail.tsx
@@ -26,8 +26,6 @@ interface UserProfile {
 interface AdminUser {
   id: number;
   email: string;
-  first_name: string;
-  last_name: string;
   is_active: boolean;
   is_staff: boolean;
   settings: UserSettings | null;

--- a/frontend/src/pages/admin/ClientList.tsx
+++ b/frontend/src/pages/admin/ClientList.tsx
@@ -7,7 +7,7 @@ import { logger } from '../../lib/logger';
 interface AdUser {
   id: number;
   email: string;
-  company_name?: string;
+  profile?: { company_name: string };
   is_active: boolean;
   is_staff: boolean;
 }
@@ -129,7 +129,7 @@ const ClientList: React.FC = () => {
     setEditTarget(user);
     setEditForm({
       email: user.email,
-      company_name: user.company_name || "",
+      company_name: user.profile?.company_name || "",
       ico: "",
       dic: "",
     });
@@ -200,7 +200,7 @@ const ClientList: React.FC = () => {
   const filteredUsers = users.filter(
     (u) =>
       u.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      (u.company_name ?? "").toLowerCase().includes(searchTerm.toLowerCase()),
+      (u.profile?.company_name ?? "").toLowerCase().includes(searchTerm.toLowerCase()),
   );
 
   return (
@@ -256,7 +256,7 @@ const ClientList: React.FC = () => {
                           </div>
                           <div>
                             <div className="font-semibold text-gray-900">
-                              {user.company_name || user.email}
+                              {user.profile?.company_name || user.email}
                             </div>
                             <div className="text-xs text-gray-400">{user.email}</div>
                           </div>

--- a/frontend/src/pages/admin/ClientList.tsx
+++ b/frontend/src/pages/admin/ClientList.tsx
@@ -7,16 +7,13 @@ import { logger } from '../../lib/logger';
 interface AdUser {
   id: number;
   email: string;
-  first_name: string;
-  last_name: string;
+  company_name?: string;
   is_active: boolean;
   is_staff: boolean;
 }
 
 interface ClientCreateForm {
   email: string;
-  first_name: string;
-  last_name: string;
   company_name: string;
   ico: string;
   dic: string;
@@ -26,8 +23,6 @@ interface ClientCreateForm {
 
 interface ClientEditForm {
   email: string;
-  first_name: string;
-  last_name: string;
   company_name: string;
   ico: string;
   dic: string;
@@ -35,8 +30,6 @@ interface ClientEditForm {
 
 const EMPTY_CLIENT_FORM: ClientCreateForm = {
   email: "",
-  first_name: "",
-  last_name: "",
   company_name: "",
   ico: "",
   dic: "",
@@ -79,7 +72,7 @@ const ClientList: React.FC = () => {
   // Edit modal
   const editRequestRef = useRef<number | null>(null);
   const [editTarget, setEditTarget] = useState<AdUser | null>(null);
-  const [editForm, setEditForm] = useState<ClientEditForm>({ email: "", first_name: "", last_name: "", company_name: "", ico: "", dic: "" });
+  const [editForm, setEditForm] = useState<ClientEditForm>({ email: "", company_name: "", ico: "", dic: "" });
   const [saving, setSaving] = useState(false);
 
   // Delete modal
@@ -136,9 +129,7 @@ const ClientList: React.FC = () => {
     setEditTarget(user);
     setEditForm({
       email: user.email,
-      first_name: user.first_name,
-      last_name: user.last_name,
-      company_name: "",
+      company_name: user.company_name || "",
       ico: "",
       dic: "",
     });
@@ -150,8 +141,6 @@ const ClientList: React.FC = () => {
       if (editRequestRef.current !== user.id) return;
       setEditForm({
         email: data.email,
-        first_name: data.first_name,
-        last_name: data.last_name,
         company_name: data.company_name || "",
         ico: data.profile?.ico || "",
         dic: data.profile?.dic || "",
@@ -211,7 +200,7 @@ const ClientList: React.FC = () => {
   const filteredUsers = users.filter(
     (u) =>
       u.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      (u.first_name + " " + u.last_name).toLowerCase().includes(searchTerm.toLowerCase()),
+      (u.company_name ?? "").toLowerCase().includes(searchTerm.toLowerCase()),
   );
 
   return (
@@ -267,9 +256,7 @@ const ClientList: React.FC = () => {
                           </div>
                           <div>
                             <div className="font-semibold text-gray-900">
-                              {user.first_name || user.last_name
-                                ? `${user.first_name} ${user.last_name}`.trim()
-                                : user.email}
+                              {user.company_name || user.email}
                             </div>
                             <div className="text-xs text-gray-400">{user.email}</div>
                           </div>
@@ -321,25 +308,15 @@ const ClientList: React.FC = () => {
               <button type="button" aria-label="Zavrieť" onClick={() => setShowCreate(false)} className="text-gray-400 hover:text-gray-600 text-2xl leading-none">×</button>
             </div>
             <form onSubmit={handleCreate} className="p-6 space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Meno</label>
-                  <input
-                    type="text"
-                    value={clientForm.first_name}
-                    onChange={(e) => setClientForm((f) => ({ ...f, first_name: e.target.value }))}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Priezvisko</label>
-                  <input
-                    type="text"
-                    value={clientForm.last_name}
-                    onChange={(e) => setClientForm((f) => ({ ...f, last_name: e.target.value }))}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
-                  />
-                </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Názov prevádzky <span className="text-red-500">*</span></label>
+                <input
+                  type="text"
+                  required
+                  value={clientForm.company_name}
+                  onChange={(e) => setClientForm((f) => ({ ...f, company_name: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
+                />
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Email <span className="text-red-500">*</span></label>
@@ -348,15 +325,6 @@ const ClientList: React.FC = () => {
                   required
                   value={clientForm.email}
                   onChange={(e) => setClientForm((f) => ({ ...f, email: e.target.value }))}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Názov spoločnosti</label>
-                <input
-                  type="text"
-                  value={clientForm.company_name}
-                  onChange={(e) => setClientForm((f) => ({ ...f, company_name: e.target.value }))}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
                 />
               </div>
@@ -437,25 +405,15 @@ const ClientList: React.FC = () => {
               <button type="button" aria-label="Zavrieť" onClick={() => setEditTarget(null)} className="text-gray-400 hover:text-gray-600 text-2xl leading-none">×</button>
             </div>
             <form onSubmit={handleEdit} className="p-6 space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Meno</label>
-                  <input
-                    type="text"
-                    value={editForm.first_name}
-                    onChange={(e) => setEditForm((f) => ({ ...f, first_name: e.target.value }))}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Priezvisko</label>
-                  <input
-                    type="text"
-                    value={editForm.last_name}
-                    onChange={(e) => setEditForm((f) => ({ ...f, last_name: e.target.value }))}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
-                  />
-                </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Názov prevádzky <span className="text-red-500">*</span></label>
+                <input
+                  type="text"
+                  required
+                  value={editForm.company_name}
+                  onChange={(e) => setEditForm((f) => ({ ...f, company_name: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
+                />
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Email <span className="text-red-500">*</span></label>
@@ -464,15 +422,6 @@ const ClientList: React.FC = () => {
                   required
                   value={editForm.email}
                   onChange={(e) => setEditForm((f) => ({ ...f, email: e.target.value }))}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Názov spoločnosti</label>
-                <input
-                  type="text"
-                  value={editForm.company_name}
-                  onChange={(e) => setEditForm((f) => ({ ...f, company_name: e.target.value }))}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none text-sm"
                 />
               </div>


### PR DESCRIPTION
## Summary

- **Prevádzky namiesto mien**: V `ClientList` a `ClientDetail` sú odstránené polia Meno / Priezvisko a nahradené povinným poľom **Názov prevádzky** (`company_name`). Tabuľka klientov aj detailová hlavička zobrazuje názov prevádzky.
- **Farebná gramážová tabuľka**: Stĺpce a riadky dashboardu sú teraz farebne odlíšené podľa druhu jedla:
  - Raňajky → **amber/oranžová**
  - Obed Menu A → **sky/modrá**
  - Obed Menu B → **indigo/fialová**
  - Obed Menu C → **violet**
  - Obed Menu V → **purple**
  - Olovrant → **emerald/zelená**
  Farebné sú hlavičkové riadky aj svetlý tint dátových buniek a ľavý border riadkov.
- **Súhrnné karty počtov**: Nad gramážovou tabuľkou pribudla sekcia `Súhrn počtov porcií` – farebné karty pre každý úsek jedálneho lístka zobrazujú počet porcií zvlášť per menu (Raňajky, Obed Menu A, Obed Menu B, Olovrant) vrátane diét a súčtov.

## Test plan

- [ ] Otvoriť admin → Správa klientov: vo formulároch vidieť len „Názov prevádzky" (nie Meno/Priezvisko)
- [ ] Vytvoriť nového klienta a overiť, že sa company_name uloží a zobrazí v tabuľke
- [ ] Otvoriť admin dashboard pre deň s dátami: karty súhrnu zobrazené nad tabuľkou
- [ ] Overiť, že hlavičky stĺpcov sú farebne odlíšené (amber raňajky, sky/indigo obed, emerald olovrant)
- [ ] TypeScript build bez chýb ✅ (overené)

🤖 Generated with [Claude Code](https://claude.com/claude-code)