### PR TITLE
fix: resolve CodeQL alert findings

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   backend-lint:
     name: Backend Lint
@@ -181,5 +184,4 @@ jobs:
           tags: zdravy-projekt-frontend:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 concurrency:
   group: staging-images
   cancel-in-progress: true

--- a/backend/api/serializers_menu.py
+++ b/backend/api/serializers_menu.py
@@ -13,6 +13,11 @@ from .models import (
     PortionType,
 )
 
+INVALID_WEIGHT_LABEL_MESSAGE = (
+    "Nepodarilo sa rozpoznať gramáž. "
+    "Použite formát s 'g' hodnotami, napr.: 200g + 25g + 50g"
+)
+
 
 def parse_composition_grams(composition: str) -> Decimal:
     """
@@ -29,10 +34,7 @@ def parse_composition_grams(composition: str) -> Decimal:
     # (avoid false matches)
     matches = re.findall(r"(\d+(?:[.,]\d+)?)\s*g(?![a-z/])", composition, re.IGNORECASE)
     if not matches:
-        raise ValueError(
-            "Nepodarilo sa rozpoznať gramáž. "
-            "Použite formát s 'g' hodnotami, napr.: 200g + 25g + 50g"
-        )
+        raise ValueError(INVALID_WEIGHT_LABEL_MESSAGE)
     total = sum((Decimal(m.replace(",", ".")) for m in matches), Decimal(0))
     return total.quantize(Decimal("0.01"))
 
@@ -77,7 +79,7 @@ class MealTemplateSerializer(serializers.ModelSerializer):
         try:
             parse_composition_grams(value)
         except ValueError as exc:
-            raise serializers.ValidationError(str(exc))
+            raise serializers.ValidationError(INVALID_WEIGHT_LABEL_MESSAGE) from exc
         return value
 
     def _set_base_weight(self, validated_data: dict) -> dict:

--- a/backend/api/views/auth_views.py
+++ b/backend/api/views/auth_views.py
@@ -27,6 +27,7 @@ _CLIENT_REFRESH_LIFETIME = timedelta(days=30)
 
 _COOKIE_NAME = settings.REFRESH_TOKEN_COOKIE_NAME
 _COOKIE_PATH = settings.REFRESH_TOKEN_COOKIE_PATH
+PASSWORD_RESET_CONFIRM_ERROR = "Neplatný alebo expirovaný odkaz na obnovu hesla."
 
 
 def _set_refresh_cookie(response: Response, refresh_str: str, max_age: int) -> None:
@@ -302,8 +303,9 @@ class PasswordResetConfirmView(APIView):
         try:
             confirm_password_reset(token=token, new_password=new_password)
         except ValueError as exc:
+            logger.info("Password reset confirmation failed: %s", exc)
             return Response(
-                {"detail": str(exc)},
+                {"detail": PASSWORD_RESET_CONFIRM_ERROR},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/backend/api/views/edupage_views.py
+++ b/backend/api/views/edupage_views.py
@@ -14,6 +14,11 @@ from ..models import DailyOrder, EdupageUpload, UserProfile
 
 logger = logging.getLogger(__name__)
 
+EDUPAGE_SCRAPE_ERROR = (
+    "Edupage scraping failed. Check the configured URL and try again."
+)
+EDUPAGE_TEST_URL_ERROR = "URL could not be reached or parsed."
+
 
 class EdupageUploadSerializer(serializers.ModelSerializer):
     operation_name = serializers.CharField(
@@ -170,14 +175,14 @@ class AdminEdupageUploadViewSet(viewsets.ReadOnlyModelViewSet):
 
             try:
                 result = scraper.scrape(profile.mealsguest_url, target_date)
-            except Exception as exc:
+            except Exception:
                 logger.exception("Scrape failed for operation %s", profile.pk)
                 results.append(
                     {
                         "operation_id": profile.pk,
                         "name": str(profile),
                         "status": "error",
-                        "error": str(exc),
+                        "error": EDUPAGE_SCRAPE_ERROR,
                     }
                 )
                 continue
@@ -229,9 +234,9 @@ class AdminEdupageUploadViewSet(viewsets.ReadOnlyModelViewSet):
 
         try:
             result = EdupageScraper().scrape(url, datetime.date.today())
-        except Exception as exc:
-            logger.warning("test_url failed for %s: %s", url, exc)
-            return Response({"ok": False, "error": str(exc)})
+        except Exception:
+            logger.warning("test_url failed for %s", url, exc_info=True)
+            return Response({"ok": False, "error": EDUPAGE_TEST_URL_ERROR})
 
         total = sum(
             meal.get("menuCounts", {}).get("A", 0)


### PR DESCRIPTION
## Summary
- add explicit read-only workflow permissions to PR and staging workflows
- stop returning raw exception text from Edupage scrape/test-url endpoints
- replace raw exception propagation in meal-template and password-reset validation responses with controlled public messages

## Alerts addressed
- CodeQL `actions/missing-workflow-permissions`: alerts #20-25
- CodeQL `py/stack-trace-exposure`: alerts #8, #12, #26, #27

## Verification
- `python3` YAML parse for `.github/workflows/pr.yml` and `.github/workflows/staging.yml`
- `black --check api/views/edupage_views.py api/serializers_menu.py api/views/auth_views.py`
- `flake8 api/views/edupage_views.py api/serializers_menu.py api/views/auth_views.py`
- `mypy api --ignore-missing-imports`
- `pytest tests/test_password_reset.py api/tests/integration/test_auth_api.py api/tests/integration/test_admin_api.py -q --no-cov`
- `pytest tests/test_password_reset.py api/tests/integration/test_auth_api.py -q --no-cov`

## Notes
- Dependabot alerts could not be fetched with the current GitHub API access: GitHub returned HTTP 403 and reported Dependabot alerts are disabled / require `admin:repo_hook`. No Dependabot-specific dependency changes are included in this PR.