### PR TITLE
fix: use River comment syntax in Alloy config

### DIFF
--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -6,10 +6,10 @@ discovery.docker "containers" {
 discovery.relabel "docker_logs" {
 	targets = discovery.docker.containers.targets
 
-	# Only ship logs for containers that opt in via the `logging.job` compose
-	# label (backend, celery, celery-beat, frontend). Without this, Alloy tails
-	# every container on the host, including Dokploy's own infra (e.g. Traefik),
-	# which adds noise and can trip Loki's retention window with old backlog.
+	// Only ship logs for containers that opt in via the `logging.job` compose
+	// label (backend, celery, celery-beat, frontend). Without this, Alloy tails
+	// every container on the host, including Dokploy's own infra (e.g. Traefik),
+	// which adds noise and can trip Loki's retention window with old backlog.
 	rule {
 		source_labels = ["__meta_docker_container_label_logging_job"]
 		regex         = ".+"


### PR DESCRIPTION
## Summary
- PR #338 (network alias fix) merged into `main` before a follow-up fix landed on `develop`. `main`'s `observability/alloy/config.alloy` still has `#`-style comments, which the Alloy config language (River) doesn't support — Alloy fails to load the config entirely (`illegal character U+0023 '#'`).
- Switches those comments to River's `//` syntax. Verified by running `grafana/alloy:v1.6.1`'s `fmt --test` against the file (exit 0, no parse errors).

## Test plan
- [x] `docker run --rm -v .../config.alloy:/etc/alloy/config.alloy:ro --entrypoint /bin/alloy grafana/alloy:v1.6.1 fmt --test /etc/alloy/config.alloy` — exits 0