### PR TITLE
fix: exempt /metrics/ from HTTPS redirect

### DIFF
--- a/backend/app/settings/prod.py
+++ b/backend/app/settings/prod.py
@@ -41,6 +41,11 @@ CORS_ALLOW_CREDENTIALS = True
 
 # Security settings
 SECURE_SSL_REDIRECT = True
+# Alloy scrapes /metrics/ over plain HTTP on the internal Docker network (no
+# TLS listener there, and it can't send X-Forwarded-Proto like the LB does),
+# so exempt only this path from the HTTPS redirect. Everything else still
+# enforces SECURE_SSL_REDIRECT.
+SECURE_REDIRECT_EXEMPT = [r"^metrics/?$"]
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 SECURE_BROWSER_XSS_FILTER = True


### PR DESCRIPTION
## Summary
- `SECURE_SSL_REDIRECT` was forcing a 301 to https on every request, including Alloy's scrape of `/metrics/` over plain HTTP on the internal Docker network. Verified live: every scrape got redirected to `https://backend/metrics/`, which has no listener (TLS terminates at the edge, not on this container) — so metrics have never actually reached Prometheus even after the alias/ALLOWED_HOSTS fixes.
- Tried adding `X-Forwarded-Proto: https` via Alloy's `prometheus.scrape` config first; confirmed (by actually running `alloy run` with a synthetic config) that `http_headers` isn't a real argument in this Alloy version (`unrecognized attribute name`). Prometheus scrape configs don't generally support arbitrary custom headers.
- Fixed on the Django side instead: `SECURE_REDIRECT_EXEMPT = [r"^metrics/?$"]`, scoped to only this path — nothing else loses HTTPS enforcement.

## Test plan
- [x] `flake8` on the changed file
- [x] Loaded `app.settings.prod` locally with dummy env vars, confirmed `SECURE_REDIRECT_EXEMPT` is set correctly