### PR TITLE
fix: set explicit allValue for dashboard variable

### DIFF
--- a/observability/grafana/dashboards/backend-overview.json
+++ b/observability/grafana/dashboards/backend-overview.json
@@ -89,7 +89,8 @@
           "text": "All",
           "value": "$__all"
         },
-        "label": "Environment"
+        "label": "Environment",
+        "allValue": ".*"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- The `environment` template variable in `observability/grafana/dashboards/backend-overview.json` had `includeAll: true` but no `allValue`. Without it, Grafana's "All" selection ORs together whatever option values it fetched at variable-refresh time — since the `environment` label didn't exist in Prometheus until the backend scraping fixes landed (PRs #338-341), "All" resolved to an empty/unmatched regex and every panel came back empty.
- Sets `allValue: ".*"` so "All" always matches regardless of what values have been fetched.

## Test plan
- [x] Verified live: after the scraping fixes, `/metrics/` now returns real `django_db_*`/`auth_login_attempts_total` samples once exercised by real requests — confirming the underlying data pipeline works, this was purely a dashboard variable config issue.