### PR TITLE
fix(frontend): repair broken client onboarding tour

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -172,6 +172,85 @@
   box-shadow: 0 0 0 4px rgba(114, 136, 75, 0.15);
 }
 
+.zp-tour-tooltip {
+  position: fixed;
+  z-index: 50;
+  width: 288px;
+  background: var(--bg-cream-warm);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--sp-4);
+}
+
+.zp-tour-arrow {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: var(--bg-cream-warm);
+  border: 1px solid var(--line-soft);
+  transform: rotate(45deg);
+}
+.zp-tour-arrow--top {
+  top: 0; left: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+  border-right: 0; border-bottom: 0;
+}
+.zp-tour-arrow--bottom {
+  bottom: 0; left: 50%;
+  transform: translate(-50%, 50%) rotate(45deg);
+  border-left: 0; border-top: 0;
+}
+.zp-tour-arrow--left {
+  left: 0; top: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+  border-top: 0; border-right: 0;
+}
+.zp-tour-arrow--right {
+  right: 0; top: 50%;
+  transform: translate(50%, -50%) rotate(45deg);
+  border-bottom: 0; border-left: 0;
+}
+
+.zp-tour-step-counter {
+  font-size: var(--fs-xs);
+  color: var(--ink-3);
+  text-align: right;
+  margin: 0 0 var(--sp-1);
+}
+.zp-tour-title {
+  font-family: var(--font-display);
+  font-size: var(--fs-base);
+  font-weight: 700;
+  color: var(--green-900);
+  margin: 0 0 var(--sp-1);
+}
+.zp-tour-body {
+  font-size: var(--fs-sm);
+  line-height: var(--lh-normal);
+  color: var(--ink-2);
+  margin: 0 0 var(--sp-4);
+}
+.zp-tour-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+}
+.zp-tour-nav {
+  display: flex;
+  gap: var(--sp-2);
+}
+.zp-tour-skip {
+  background: none;
+  border: none;
+  font-size: var(--fs-sm);
+  color: var(--ink-3);
+  cursor: pointer;
+  padding: 0;
+}
+.zp-tour-skip:hover { color: var(--green-800); }
+
 /* ===== Zdravý Projekt — Client PWA Component Classes (from client.css) ===== */
 
 * { box-sizing: border-box; }

--- a/frontend/src/pages/client/components/onboarding/TourOverlay.tsx
+++ b/frontend/src/pages/client/components/onboarding/TourOverlay.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { useOnboarding } from "../../../../context/OnboardingContext";
 import { TOUR_STEPS, TourStep } from "./tourSteps";
 import TourTooltip from "./TourTooltip";
 
-const TOOLTIP_WIDTH = 288; // w-72
-const TOOLTIP_HEIGHT = 190; // approximate
+const TOOLTIP_WIDTH = 288; // matches .zp-tour-tooltip width
+const TOOLTIP_HEIGHT_ESTIMATE = 190; // used only for the first render, before we can measure
 const OFFSET = 12; // gap between target and tooltip
 const VIEWPORT_PADDING = 8;
 
@@ -18,6 +18,7 @@ interface TooltipPos {
 function calcPosition(
   rect: DOMRect,
   preferredPlacement: TourStep["placement"],
+  tooltipHeight: number,
 ): TooltipPos {
   const vw = window.innerWidth;
   const vh = window.innerHeight;
@@ -38,13 +39,13 @@ function calcPosition(
       top = rect.bottom + OFFSET;
       left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2;
     } else if (p === "top") {
-      top = rect.top - TOOLTIP_HEIGHT - OFFSET;
+      top = rect.top - tooltipHeight - OFFSET;
       left = rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2;
     } else if (p === "right") {
-      top = rect.top + rect.height / 2 - TOOLTIP_HEIGHT / 2;
+      top = rect.top + rect.height / 2 - tooltipHeight / 2;
       left = rect.right + OFFSET;
     } else {
-      top = rect.top + rect.height / 2 - TOOLTIP_HEIGHT / 2;
+      top = rect.top + rect.height / 2 - tooltipHeight / 2;
       left = rect.left - TOOLTIP_WIDTH - OFFSET;
     }
 
@@ -55,11 +56,11 @@ function calcPosition(
     );
     top = Math.max(
       VIEWPORT_PADDING,
-      Math.min(top, vh - TOOLTIP_HEIGHT - VIEWPORT_PADDING),
+      Math.min(top, vh - tooltipHeight - VIEWPORT_PADDING),
     );
 
     const fitsVertically =
-      top >= VIEWPORT_PADDING && top + TOOLTIP_HEIGHT <= vh - VIEWPORT_PADDING;
+      top >= VIEWPORT_PADDING && top + tooltipHeight <= vh - VIEWPORT_PADDING;
     const fitsHorizontally =
       left >= VIEWPORT_PADDING &&
       left + TOOLTIP_WIDTH <= vw - VIEWPORT_PADDING;
@@ -81,8 +82,13 @@ const TourOverlay: React.FC = () => {
   const location = useLocation();
   const [tooltipPos, setTooltipPos] = useState<TooltipPos | null>(null);
   const highlightedEl = useRef<Element | null>(null);
+  const targetRectRef = useRef<DOMRect | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const hasRemeasured = useRef(false);
 
   useEffect(() => {
+    hasRemeasured.current = false;
+
     if (!isTourActive) {
       setTooltipPos(null);
       return;
@@ -102,34 +108,73 @@ const TourOverlay: React.FC = () => {
       highlightedEl.current = null;
     }
 
-    const el = document.querySelector(`[data-tour-id="${step.targetId}"]`);
-    if (!el) {
-      setTooltipPos(null);
-      return;
-    }
+    // The target element may not exist in the DOM yet — e.g. it lives inside
+    // a meal card that another effect (in OrderPage) is still in the process
+    // of expanding in response to this same step change. Poll briefly instead
+    // of giving up on the first missed lookup.
+    let attempts = 0;
+    const maxAttempts = 20; // ~2s at 100ms
+    let pollTimer: ReturnType<typeof setTimeout> | undefined;
+    let settleTimer: ReturnType<typeof setTimeout> | undefined;
 
-    // Scroll into view first, then measure
-    el.scrollIntoView({ behavior: "smooth", block: "center" });
-
-    const measure = () => {
-      const rect = el.getBoundingClientRect();
-      if (rect.width === 0 && rect.height === 0) {
-        setTooltipPos(null);
+    const tryFind = () => {
+      const el = document.querySelector(`[data-tour-id="${step.targetId}"]`);
+      if (!el) {
+        attempts += 1;
+        if (attempts < maxAttempts) {
+          pollTimer = setTimeout(tryFind, 100);
+        } else {
+          setTooltipPos(null);
+        }
         return;
       }
-      const pos = calcPosition(rect, step.placement);
-      setTooltipPos(pos);
 
-      el.classList.add("tour-highlight");
-      highlightedEl.current = el;
+      // Scroll into view first, then measure
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+
+      const measure = () => {
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) {
+          setTooltipPos(null);
+          return;
+        }
+        targetRectRef.current = rect;
+        const pos = calcPosition(rect, step.placement, TOOLTIP_HEIGHT_ESTIMATE);
+        setTooltipPos(pos);
+
+        el.classList.add("tour-highlight");
+        highlightedEl.current = el;
+      };
+
+      // Small delay to let scrollIntoView settle
+      settleTimer = setTimeout(measure, 350);
     };
 
-    // Small delay to let scrollIntoView settle
-    const timer = setTimeout(measure, 350);
+    tryFind();
     return () => {
-      clearTimeout(timer);
+      clearTimeout(pollTimer);
+      clearTimeout(settleTimer);
     };
   }, [isTourActive, currentStep, location.pathname]);
+
+  // Once the tooltip has actually rendered, re-position using its real
+  // height instead of the estimate (long step text otherwise overlaps
+  // the highlighted element or gets clipped by the viewport edge).
+  useLayoutEffect(() => {
+    if (!tooltipPos || !tooltipRef.current || !targetRectRef.current) return;
+    if (hasRemeasured.current) return;
+    hasRemeasured.current = true;
+
+    const actualHeight = tooltipRef.current.getBoundingClientRect().height;
+    if (Math.abs(actualHeight - TOOLTIP_HEIGHT_ESTIMATE) < 1) return;
+
+    const pos = calcPosition(
+      targetRectRef.current,
+      tooltipPos.arrowPlacement,
+      actualHeight,
+    );
+    setTooltipPos(pos);
+  }, [tooltipPos]);
 
   // Cleanup highlight on unmount
   useEffect(() => {
@@ -150,6 +195,7 @@ const TourOverlay: React.FC = () => {
 
       {/* Tooltip */}
       <TourTooltip
+        ref={tooltipRef}
         top={tooltipPos.top}
         left={tooltipPos.left}
         arrowPlacement={tooltipPos.arrowPlacement}

--- a/frontend/src/pages/client/components/onboarding/TourTooltip.tsx
+++ b/frontend/src/pages/client/components/onboarding/TourTooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { forwardRef } from "react";
 import { useOnboarding } from "../../../../context/OnboardingContext";
 import { TOUR_STEPS } from "./tourSteps";
 
@@ -8,68 +8,61 @@ interface Props {
   arrowPlacement: "top" | "bottom" | "left" | "right";
 }
 
-const TourTooltip: React.FC<Props> = ({ top, left, arrowPlacement }) => {
-  const { currentStep, totalSteps, nextStep, prevStep, completeTour, skipTour } =
-    useOnboarding();
-  const step = TOUR_STEPS[currentStep];
-  const isLast = currentStep === totalSteps - 1;
-  const isFirst = currentStep === 0;
+// The arrow sits on the edge of the tooltip facing the highlighted element,
+// i.e. the opposite edge from where the tooltip was placed relative to it.
+const arrowEdgeForPlacement: Record<string, string> = {
+  top: "zp-tour-arrow--bottom",
+  bottom: "zp-tour-arrow--top",
+  left: "zp-tour-arrow--right",
+  right: "zp-tour-arrow--left",
+};
 
-  const arrowClass: Record<string, string> = {
-    top: "top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 border-t-0 border-l-0",
-    bottom:
-      "bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 border-b-0 border-r-0",
-    left: "left-0 top-1/2 -translate-y-1/2 -translate-x-1/2 border-l-0 border-b-0",
-    right:
-      "right-0 top-1/2 -translate-y-1/2 translate-x-1/2 border-r-0 border-t-0",
-  };
+const TourTooltip = forwardRef<HTMLDivElement, Props>(
+  ({ top, left, arrowPlacement }, ref) => {
+    const { currentStep, totalSteps, nextStep, prevStep, completeTour, skipTour } =
+      useOnboarding();
+    const step = TOUR_STEPS[currentStep];
+    const isLast = currentStep === totalSteps - 1;
+    const isFirst = currentStep === 0;
 
-  return (
-    <div
-      className="fixed z-50 w-72 bg-white rounded-2xl shadow-2xl border border-indigo-100 p-4"
-      style={{ top, left }}
-    >
-      {/* Arrow */}
+    return (
       <div
-        className={`absolute w-3 h-3 bg-white border border-indigo-100 rotate-45 ${arrowClass[arrowPlacement]}`}
-      />
+        ref={ref}
+        className="zp-tour-tooltip"
+        style={{ top, left }}
+      >
+        <div className={`zp-tour-arrow ${arrowEdgeForPlacement[arrowPlacement]}`} />
 
-      {/* Step counter */}
-      <p className="text-xs text-slate-400 text-right mb-1">
-        Krok {currentStep + 1} z {totalSteps}
-      </p>
+        <p className="zp-tour-step-counter">
+          Krok {currentStep + 1} z {totalSteps}
+        </p>
 
-      {/* Content */}
-      <p className="text-base font-bold text-slate-900 mb-1">{step.title}</p>
-      <p className="text-sm text-slate-600 mb-4">{step.body}</p>
+        <p className="zp-tour-title">{step.title}</p>
+        <p className="zp-tour-body">{step.body}</p>
 
-      {/* Actions */}
-      <div className="flex items-center justify-between gap-2">
-        <button
-          onClick={() => skipTour()}
-          className="text-sm text-slate-400 hover:text-slate-600 transition-colors"
-        >
-          Preskočiť
-        </button>
-        <div className="flex gap-2">
-          {!isFirst && (
-            <button
-              onClick={prevStep}
-              className="px-3 py-1.5 text-sm text-indigo-600 border border-indigo-200 rounded-lg hover:bg-indigo-50 transition-colors"
-            >
-              Späť
-            </button>
-          )}
-          <button
-            onClick={isLast ? () => completeTour() : nextStep}
-            className="px-4 py-1.5 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg transition-colors"
-          >
-            {isLast ? "Dokončiť" : "Ďalej"}
+        <div className="zp-tour-actions">
+          <button onClick={() => skipTour()} className="zp-tour-skip">
+            Preskočiť
           </button>
+          <div className="zp-tour-nav">
+            {!isFirst && (
+              <button onClick={prevStep} className="zp-btn zp-btn--ghost zp-btn--sm">
+                Späť
+              </button>
+            )}
+            <button
+              onClick={isLast ? () => completeTour() : nextStep}
+              className="zp-btn zp-btn--primary zp-btn--sm"
+            >
+              {isLast ? "Dokončiť" : "Ďalej"}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  },
+);
+
+TourTooltip.displayName = "TourTooltip";
 
 export default TourTooltip;

--- a/frontend/src/pages/client/components/onboarding/tourSteps.ts
+++ b/frontend/src/pages/client/components/onboarding/tourSteps.ts
@@ -53,6 +53,13 @@ export const TOUR_STEPS: TourStep[] = [
     page: "/order",
   },
   {
+    targetId: "tour-fullday-card",
+    title: "Celodenná objednávka",
+    body: "Ak chcete naraz objednať všetky jedlá (raňajky, obed aj olovrant), zapnite túto kartu a nastavte porcie len raz. Kým je zapnutá, jednotlivé jedlá nižšie sú uzamknuté – vypnutím ju znova odomknete.",
+    placement: "bottom",
+    page: "/order",
+  },
+  {
     targetId: "tour-meal-card",
     title: "Prepínač jedla",
     body: "Každé jedlo (raňajky, obed, olovrant) môžete zapnúť alebo vypnúť prepínačom. Ak je zapnuté, zobrazí sa zadávanie porcií.",
@@ -61,8 +68,8 @@ export const TOUR_STEPS: TourStep[] = [
   },
   {
     targetId: "tour-category-row",
-    title: "Počet porcií",
-    body: "Pre každú vekovú skupinu (napr. Škôlka, ZŠ 1. stupeň) nastavte počet porcií pomocou tlačidiel + a –. Menu A/B sú varianty obeda.",
+    title: "Počet porcií a diéty",
+    body: "Pre každú vekovú skupinu (napr. Škôlka, ZŠ 1. stupeň) nastavte počet porcií pomocou tlačidiel + a –. Menu A/B sú varianty obeda. Ak dieťa potrebuje diétu, kliknite na tlačidlo „Diéty“ pri Menu A a vyberte konkrétnu diétu a počet porcií (diéty sa dajú priradiť len v rámci porcií Menu A).",
     placement: "right",
     page: "/order",
   },

--- a/frontend/src/pages/client/hooks/useOrder.ts
+++ b/frontend/src/pages/client/hooks/useOrder.ts
@@ -646,7 +646,6 @@ export const useOrder = () => {
         ? visibleDietDetails.map(d => d.name)
         : [];
 
-    // Override getAvailableDiets to intersection of enabledDiets (local preference) AND adminVisibleDiets
     const getAvailableDiets = (categoryName: string) => {
         const diets = OrderService.getAvailableDiets(categoryName, adminVisibleDiets);
         if (!diets.includes(SPECIAL_DIET_NAME)) {

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -13,6 +13,7 @@ import OrderService, { CategoryData, DailyOrder } from "../services/OrderService
 import { useToast } from "../../../context/ToastContext";
 import { OrderRequestError } from "../hooks/useOrder";
 import TourOverlay from "../components/onboarding/TourOverlay";
+import { TOUR_STEPS } from "../components/onboarding/tourSteps";
 import { useOnboarding } from "../../../context/OnboardingContext";
 import { logger } from '../../../lib/logger';
 
@@ -143,7 +144,7 @@ const OrderPage = () => {
   }, [fullDayOrder, isFullDayDeadlineOpen, toggleFullDay]);
 
   useEffect(() => {
-    if (!isTourActive || currentStep !== 7) return;
+    if (!isTourActive || TOUR_STEPS[currentStep]?.targetId !== "tour-category-row") return;
     const firstMeal = visibleMealsList[0];
     if (!firstMeal) return;
     const key = firstMeal.key as "breakfast" | "lunch" | "olovrant";
@@ -347,6 +348,7 @@ const OrderPage = () => {
       <MealCard
         title="Celodenná objednávka"
         icon={CalendarDays}
+        tourId="tour-fullday-card"
         isActive={fullDayOrder && isFullDayDeadlineOpen}
         onToggle={() => isFullDayDeadlineOpen && toggleFullDay()}
         statusMessage={


### PR DESCRIPTION
## Summary
The client onboarding tour ("sprievodca") never kept up with two subsequent UI overhauls and was reported as visually broken and missing information. This fixes:

- **Tooltip arrow pointed the wrong way** — arrow-edge mapping in `TourTooltip.tsx` was inverted, so arrows pointed away from the highlighted element instead of at it.
- **Stale design** — tooltip used the old indigo/slate Tailwind look; restyled to the app's current cream/green `zp-*` design system.
- **"Celodenná objednávka" (full-day order) was never explained** — that card had no `tourId`/tour step at all; added both.
- **Diet selection was never explained** — the step that highlights the row with the "Diéty" button never mentioned diets; body text now explains it.
- **Race condition**: the tour gave up instantly if its target element wasn't in the DOM yet (e.g. category rows only mount after a meal card opens). Now polls briefly instead of failing silently — this is what caused the diet step to never appear in practice.
- **Hardcoded step index** (`currentStep !== 7`) in `OrderPage.tsx` that silently broke once a new tour step was inserted; now resolved by step name instead of a magic number.
- Hardcoded `TOOLTIP_HEIGHT` guess replaced with a real measurement of the rendered tooltip, to avoid overlap/clipping on longer step text or small viewports.
- Removed a stale/misleading code comment in `useOrder.ts`.

## Test plan
- [x] `tsc --noEmit` and `eslint` clean
- [x] Verified end-to-end in a local dev stack (Playwright + headless Chromium) driving the full tour as a real client user across `/home` and `/order`: confirmed correct arrow direction, matching design system, the new "Celodenná objednávka" step with its own highlight, and the diet-selection step rendering with the "Diéty" button visible and highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)