### PR TITLE
fix: Prometheus metrics under Gunicorn

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,7 +26,7 @@ RUN pip install --upgrade pip && \
 COPY . /app/
 
 # Make scripts executable
-RUN chmod +x /app/manage.py /app/wait-for-redis.sh
+RUN chmod +x /app/manage.py /app/wait-for-redis.sh /app/start-backend.sh
 
 # Create a dedicated non-root user for runtime processes.
 RUN groupadd --system appuser && useradd --system --gid appuser --create-home appuser
@@ -44,7 +44,7 @@ USER appuser
 EXPOSE 8000
 
 # Run deployment bootstrap and start server.
-CMD ["sh", "-c", "python manage.py deploy_bootstrap && gunicorn -c gunicorn.conf.py app.wsgi:application"]
+CMD ["/app/start-backend.sh"]
 
 # Healthcheck for the main app
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=20s \

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -73,3 +73,16 @@ ca_certs = None
 do_handshake_on_connect = False
 suppress_ragged_eof = True
 ciphers = None
+
+
+def child_exit(server, worker):
+    """Clean live-gauge files when a Prometheus multiprocess worker exits."""
+    if not (
+        os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+        or os.environ.get("prometheus_multiproc_dir")
+    ):
+        return
+
+    from prometheus_client import multiprocess
+
+    multiprocess.mark_process_dead(worker.pid)

--- a/backend/start-backend.sh
+++ b/backend/start-backend.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+python manage.py deploy_bootstrap
+
+PROMETHEUS_MULTIPROC_DIR="${PROMETHEUS_MULTIPROC_DIR:-/tmp/prometheus-multiproc}"
+
+case "$PROMETHEUS_MULTIPROC_DIR" in
+  ""|"/")
+    echo "Refusing unsafe PROMETHEUS_MULTIPROC_DIR: '$PROMETHEUS_MULTIPROC_DIR'" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
+find "$PROMETHEUS_MULTIPROC_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+export PROMETHEUS_MULTIPROC_DIR
+
+exec gunicorn -c gunicorn.conf.py app.wsgi:application

--- a/compose/observability.yml
+++ b/compose/observability.yml
@@ -2,9 +2,16 @@ services:
   alloy:
     image: grafana/alloy:v1.6.1
     command: run --disable-reporting --storage.path=/var/lib/alloy /etc/alloy/config.alloy
+    privileged: true
     volumes:
       - ../observability/alloy/config.alloy:/etc/alloy/config.alloy:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /dev/disk:/dev/disk:ro
+      - /dev/kmsg:/dev/kmsg:ro
       - alloy_data:/var/lib/alloy
     environment:
       GRAFANA_LOKI_URL: ${GRAFANA_LOKI_URL:?Set GRAFANA_LOKI_URL}

--- a/observability/README.md
+++ b/observability/README.md
@@ -9,11 +9,39 @@ Alloy stack itself is run.
 | Signal   | Path                                                            | Backend               |
 |----------|------------------------------------------------------------------|------------------------|
 | Errors   | `sentry_sdk` in `backend/app/settings/{prod,staging}.py`         | Sentry (`SENTRY_DSN`)  |
-| Metrics  | `/metrics/` (django_prometheus) → Alloy `prometheus.scrape` → `prometheus.remote_write` | Grafana Cloud Prometheus/Mimir |
+| Metrics  | Django `/metrics/` + Alloy cAdvisor exporter → `prometheus.remote_write` | Grafana Cloud Prometheus/Mimir |
 | Logs     | Docker container stdout → Alloy `loki.source.docker`             | Grafana Cloud Loki     |
 
 Custom business metric: `auth_login_attempts_total{result="success"|"failure"}`
 (`backend/api/metrics.py`, incremented in `EmailTokenObtainPairView.post`).
+
+## Django metrics under Gunicorn
+
+Production and staging run Django behind Gunicorn with multiple sync workers.
+The backend image starts through `backend/start-backend.sh`, which:
+
+1. runs `python manage.py deploy_bootstrap` without Prometheus multiprocess mode,
+2. prepares a fresh `PROMETHEUS_MULTIPROC_DIR`,
+3. exports that variable only for Gunicorn and its workers.
+
+`backend/gunicorn.conf.py` also calls
+`prometheus_client.multiprocess.mark_process_dead(...)` when a worker exits, so
+live-gauge files do not accumulate for dead workers.
+
+This makes Django HTTP/DB/cache counters and histograms aggregate across all
+Gunicorn workers instead of whichever worker happened to serve `/metrics/`.
+Do not build alerts from Django `process_*` metrics such as
+`process_cpu_seconds_total` in this setup: the Prometheus Python client does
+not expose process collectors through multiprocess aggregation. Use the
+cAdvisor container metrics from Alloy for real CPU/memory/restart/OOM alerting.
+
+The Alloy container runs with cAdvisor enabled through
+`prometheus.exporter.cadvisor`. Docker deployments need the host mounts in
+`compose/observability.yml` plus `privileged: true`; without those, cAdvisor may
+only see the Alloy container itself. The relabel config keeps only containers
+whose Docker name contains `zdravy-projekt` before remote-writing to Grafana
+Cloud, which limits cardinality/cost while still covering backend, celery,
+frontend, Postgres, Redis, and the observability container.
 
 ## One-time production setup
 
@@ -91,6 +119,10 @@ rows:
 - **Exceptions & Infra Health** — unhandled exceptions by type/view (last
   1h), and whether the `django`/`alloy` scrape targets are up (catches "Alloy
   can't reach the backend" before you notice missing dashboards).
+- **Traffic Diagnostics** — HTTP/HTTPS split and view-vs-middleware latency,
+  using Django metrics that are safe under Gunicorn multiprocess aggregation.
+- **Container Runtime** — backend CPU/memory from cAdvisor, backend OOM events,
+  and backend uptime based on `container_start_time_seconds`.
 
 ## Alerts to create in Grafana Cloud (Alerting → Alert rules)
 
@@ -102,12 +134,14 @@ same Prometheus data source as the dashboard. Suggested starting set:
 
 | Alert                     | Expression                                                                                                   | For   | Severity |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------|-------|----------|
-| High 5xx error rate       | `100 * sum(rate(django_http_responses_total_by_status{status=~"5.."}[5m])) / sum(rate(django_http_responses_total_by_status[5m])) > 5` | 5m    | critical |
+| High 5xx error rate       | `100 * sum(rate(django_http_responses_total_by_status_view_method_total{status=~"5..",view!~"health_check|prometheus-django-metrics"}[5m])) / sum(rate(django_http_responses_total_by_status_view_method_total{view!~"health_check|prometheus-django-metrics"}[5m])) > 5` | 5m    | critical |
 | Elevated 5xx error rate   | same expression `> 1`                                                                                          | 10m   | warning  |
-| High p95 latency          | `histogram_quantile(0.95, sum by (le) (rate(django_http_requests_latency_seconds_by_view_method_bucket[5m]))) > 3` | 5m    | warning  |
+| High p95 latency          | `histogram_quantile(0.95, sum by (le) (rate(django_http_requests_latency_seconds_by_view_method_bucket{view!~"health_check|prometheus-django-metrics"}[5m]))) > 3` | 5m    | warning  |
 | Backend scrape down       | `up{job="django"} == 0`                                                                                        | 2m    | critical |
 | Alloy itself down         | `up{job="alloy"} == 0`                                                                                         | 5m    | warning  |
 | DB connection errors      | `increase(django_db_new_connection_errors_total[5m]) > 0`                                                       | 1m    | critical |
+| Backend OOM killed        | `sum(increase(container_oom_events_total{job="cadvisor",name=~".*backend.*"}[5m])) > 0`                         | 0m    | critical |
+| Backend recently restarted| `time() - max(container_start_time_seconds{job="cadvisor",name=~".*backend.*",image!=""}) < 600`                | 0m    | warning  |
 | Possible brute-force login| `sum(increase(auth_login_attempts_total{result="failure"}[10m])) > 30`                                          | 0m    | warning  |
 | Login failure rate spike  | `100 * sum(increase(auth_login_attempts_total{result="failure"}[15m])) / sum(increase(auth_login_attempts_total[15m])) > 50` | 5m    | warning  |
 | Cache hit rate collapse   | `100 * sum(rate(django_cache_hits_total[10m])) / sum(rate(django_cache_get_total[10m])) < 50`                   | 10m   | warning  |
@@ -118,13 +152,18 @@ alerting (Settings → Alerts on the Sentry project) for error-spike/new-issue
 notifications — worth turning on there too since Prometheus alerts above
 only see HTTP-level symptoms, not exception details.
 
+Avoid alerts on `process_cpu_seconds_total`, `process_resident_memory_bytes`,
+or other Django `process_*` series while Gunicorn multiprocess mode is enabled;
+they are not reliable app-level signals in this topology. The restart alert
+will also fire after intentional deploys because a fresh container start is the
+same signal as an unexpected replacement; mute it during planned releases.
+
 ## Known gaps / optional next steps
 
-- **Host/container resource metrics** (CPU, memory, disk per container) are
-  not collected — `compose/observability.yml` only scrapes the Django
-  `/metrics/` endpoint, no `cadvisor`/`node_exporter`. Add them to that
-  compose file and a `prometheus.scrape` block in `config.alloy` if you want
-  infra-level dashboards/alerts (e.g. "container getting OOM-killed").
+- **Host-level node metrics** (disk pressure, host CPU, host OOM killer totals)
+  are still not collected. cAdvisor covers Docker/container CPU, memory,
+  restarts, and `container_oom_events_total`; add `node_exporter` later if you
+  want host-level alerts such as filesystem pressure or kernel-wide OOM kills.
 - **Celery** has no Prometheus metrics wired (no `django_prometheus` Celery
   signal hooks, no `celery-exporter`). Worker health today is only visible
   via Sentry (task exceptions) and container logs in Loki.

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -90,6 +90,38 @@ prometheus.scrape "django" {
 	forward_to   = [prometheus.remote_write.grafana.receiver]
 }
 
+prometheus.exporter.cadvisor "docker" {
+	docker_host      = "unix:///var/run/docker.sock"
+	storage_duration = "5m"
+}
+
+prometheus.scrape "cadvisor" {
+	targets         = prometheus.exporter.cadvisor.docker.targets
+	forward_to      = [prometheus.relabel.cadvisor.receiver]
+	scrape_interval = "30s"
+}
+
+prometheus.relabel "cadvisor" {
+	forward_to = [prometheus.remote_write.grafana.receiver]
+
+	rule {
+		target_label = "job"
+		replacement  = "cadvisor"
+	}
+
+	rule {
+		target_label = "environment"
+		replacement  = sys.env("ALLOY_ENVIRONMENT")
+	}
+
+	// Keep this app's containers only to limit Grafana Cloud cardinality/cost.
+	rule {
+		source_labels = ["name"]
+		regex         = ".+zdravy-projekt.+"
+		action        = "keep"
+	}
+}
+
 prometheus.remote_write "grafana" {
 	endpoint {
 		url = sys.env("GRAFANA_PROM_URL")

--- a/observability/grafana/dashboards/backend-overview.json
+++ b/observability/grafana/dashboards/backend-overview.json
@@ -1760,7 +1760,7 @@
     {
       "id": 401,
       "type": "row",
-      "title": "Process & Runtime",
+      "title": "Traffic Diagnostics",
       "gridPos": {
         "x": 0,
         "y": 45,
@@ -1769,307 +1769,6 @@
       },
       "collapsed": false,
       "panels": []
-    },
-    {
-      "id": 30,
-      "type": "timeseries",
-      "title": "CPU usage (%)",
-      "description": "Rate of CPU time consumed by the Django process. Sustained high values indicate a CPU-bound workload.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 46,
-        "w": 12,
-        "h": 8
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A",
-          "expr": "rate(process_cpu_seconds_total{job=\"django\",environment=~\"$environment\"}[$__rate_interval]) * 100",
-          "legendFormat": "CPU %",
-          "instant": false,
-          "range": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percent",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "value": 0,
-                "color": "green"
-              },
-              {
-                "value": 80,
-                "color": "red"
-              }
-            ]
-          },
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "annotations": {
-          "clustering": -1,
-          "multiLane": false
-        },
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "enableFacetedFilter": false,
-          "overflow": "ellipsis",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      }
-    },
-    {
-      "id": 31,
-      "type": "timeseries",
-      "title": "Process memory",
-      "description": "RSS = actual physical RAM used. Virtual includes shared libs. High RSS growth over time may indicate a memory leak.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 46,
-        "w": 12,
-        "h": 8
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A",
-          "expr": "process_resident_memory_bytes{job=\"django\",environment=~\"$environment\"}",
-          "legendFormat": "RSS",
-          "instant": false,
-          "range": true
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "B",
-          "expr": "process_virtual_memory_bytes{job=\"django\",environment=~\"$environment\"}",
-          "legendFormat": "Virtual",
-          "instant": false,
-          "range": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "value": 0,
-                "color": "green"
-              },
-              {
-                "value": 80,
-                "color": "red"
-              }
-            ]
-          },
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "annotations": {
-          "clustering": -1,
-          "multiLane": false
-        },
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "enableFacetedFilter": false,
-          "overflow": "ellipsis",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      }
-    },
-    {
-      "id": 32,
-      "type": "gauge",
-      "title": "File descriptor utilization",
-      "description": "Open FDs as % of the process limit. Above 80% risks EMFILE errors.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 54,
-        "w": 6,
-        "h": 6
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A",
-          "expr": "100 * process_open_fds{job=\"django\",environment=~\"$environment\"} / process_max_fds{job=\"django\",environment=~\"$environment\"}",
-          "legendFormat": "FD usage %",
-          "instant": true,
-          "range": false
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percent",
-          "min": 0,
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "value": 0,
-                "color": "green"
-              },
-              {
-                "value": 70,
-                "color": "yellow"
-              },
-              {
-                "value": 85,
-                "color": "red"
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "barShape": "flat",
-        "barWidthFactor": 0.5,
-        "effects": {
-          "barGlow": false,
-          "centerGlow": false,
-          "gradient": false
-        },
-        "endpointMarker": "point",
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "segmentCount": 1,
-        "segmentSpacing": 0.3,
-        "shape": "gauge",
-        "showThresholdLabels": false,
-        "showThresholdMarkers": false,
-        "sizing": "auto",
-        "sparkline": false,
-        "textMode": "auto"
-      }
     },
     {
       "id": 33,
@@ -2081,10 +1780,10 @@
         "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
-        "x": 6,
-        "y": 54,
-        "w": 9,
-        "h": 6
+        "x": 0,
+        "y": 46,
+        "w": 12,
+        "h": 7
       },
       "targets": [
         {
@@ -2185,10 +1884,10 @@
         "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
-        "x": 15,
-        "y": 54,
-        "w": 9,
-        "h": 6
+        "x": 12,
+        "y": 46,
+        "w": 12,
+        "h": 7
       },
       "targets": [
         {
@@ -2291,12 +1990,357 @@
       }
     },
     {
+      "id": 402,
+      "type": "row",
+      "title": "Container Runtime",
+      "gridPos": {
+        "x": 0,
+        "y": 54,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 35,
+      "type": "timeseries",
+      "title": "Backend container CPU",
+      "description": "CPU consumed by backend containers from cAdvisor. 100% = one CPU core.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 55,
+        "w": 8,
+        "h": 7
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"cadvisor\",environment=~\"$environment\",name=~\".*backend.*\",image!=\"\"}[$__rate_interval])) * 100",
+          "legendFormat": "backend CPU %",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": 0,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "enableFacetedFilter": false,
+          "overflow": "ellipsis",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 36,
+      "type": "timeseries",
+      "title": "Backend container memory",
+      "description": "Backend working set memory from cAdvisor.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 55,
+        "w": 8,
+        "h": 7
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A",
+          "expr": "sum(container_memory_working_set_bytes{job=\"cadvisor\",environment=~\"$environment\",name=~\".*backend.*\",image!=\"\"})",
+          "legendFormat": "working set",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": 0,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "enableFacetedFilter": false,
+          "overflow": "ellipsis",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 37,
+      "type": "stat",
+      "title": "Backend OOM events (1h)",
+      "description": "Out-of-memory kills reported by cAdvisor for backend containers in the last hour.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 55,
+        "w": 4,
+        "h": 7
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A",
+          "expr": "sum(increase(container_oom_events_total{job=\"cadvisor\",environment=~\"$environment\",name=~\".*backend.*\",image!=\"\"}[1h]))",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": 0,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      }
+    },
+    {
+      "id": 38,
+      "type": "stat",
+      "title": "Backend uptime",
+      "description": "Seconds since the newest backend container start. Drops after deploys, restarts, and OOM replacements.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 55,
+        "w": 4,
+        "h": 7
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A",
+          "expr": "time() - max(container_start_time_seconds{job=\"cadvisor\",environment=~\"$environment\",name=~\".*backend.*\",image!=\"\"})",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 600,
+                "color": "yellow"
+              },
+              {
+                "value": 1800,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      }
+    },
+    {
       "id": 501,
       "type": "row",
       "title": "Exceptions & Infra Health",
       "gridPos": {
         "x": 0,
-        "y": 60,
+        "y": 63,
         "w": 24,
         "h": 1
       },
@@ -2314,7 +2358,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 61,
+        "y": 64,
         "w": 8,
         "h": 8
       },
@@ -2394,7 +2438,7 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 61,
+        "y": 64,
         "w": 8,
         "h": 8
       },
@@ -2474,7 +2518,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 61,
+        "y": 64,
         "w": 4,
         "h": 4
       },
@@ -2536,7 +2580,7 @@
       },
       "gridPos": {
         "x": 20,
-        "y": 61,
+        "y": 64,
         "w": 4,
         "h": 4
       },


### PR DESCRIPTION
## Summary
- run Django deploy bootstrap before enabling Prometheus multiprocess mode, then start Gunicorn with a clean multiprocess directory
- add Gunicorn worker-exit cleanup for Prometheus live gauge files
- add Alloy cAdvisor scraping for container CPU, memory, restart, and OOM signals
- update the backend Grafana dashboard to use container runtime panels instead of unreliable Django process metrics

## Validation
- sh -n backend/start-backend.sh
- python3 -m py_compile backend/gunicorn.conf.py
- python3 -m json.tool observability/grafana/dashboards/backend-overview.json
- git diff --check
- docker compose -f compose/observability.yml config
- docker run grafana/alloy:v1.6.1 fmt --test /etc/alloy/config.alloy
- Alloy run smoke test with cAdvisor enabled and /dev/kmsg mounted
- docker build -t zdravy-prometheus-fix:test backend
- docker run image smoke check for /app/start-backend.sh and gunicorn.conf.py

Note: local pre-commit mypy hook was skipped because the local mypy executable is not installed; black, isort, and flake8 hooks passed.