### PR TITLE
chore(ci): manage Grafana alert Terraform checks

### DIFF
--- a/.github/workflows/grafana-alerts.yml
+++ b/.github/workflows/grafana-alerts.yml
@@ -22,6 +22,7 @@ concurrency:
 
 env:
   TF_DIR: observability/terraform/grafana-alerts
+  TF_IMAGE: hashicorp/terraform:1.10.5
   TF_IN_AUTOMATION: "true"
   TF_INPUT: "false"
   TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL }}
@@ -38,25 +39,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
-
       - name: Check Terraform formatting
-        working-directory: ${{ env.TF_DIR }}
-        run: terraform fmt -check -recursive
+        run: docker run --rm -v "$PWD/${TF_DIR}:/work" -w /work "$TF_IMAGE" fmt -check -recursive
 
       - name: Initialize Terraform
-        working-directory: ${{ env.TF_DIR }}
-        run: terraform init -backend=false
+        run: docker run --rm -v "$PWD/${TF_DIR}:/work" -w /work "$TF_IMAGE" init -backend=false
 
       - name: Validate Terraform
-        working-directory: ${{ env.TF_DIR }}
-        run: terraform validate
+        run: docker run --rm -v "$PWD/${TF_DIR}:/work" -w /work "$TF_IMAGE" validate
 
       - name: Plan Grafana alert changes
         if: ${{ env.TF_VAR_grafana_url != '' && env.TF_VAR_grafana_auth != '' && env.TF_VAR_prometheus_datasource_uid != '' }}
-        working-directory: ${{ env.TF_DIR }}
-        run: terraform plan -no-color
+        run: |
+          docker run --rm \
+            -v "$PWD/${TF_DIR}:/work" \
+            -w /work \
+            -e TF_IN_AUTOMATION \
+            -e TF_INPUT \
+            -e TF_VAR_grafana_url \
+            -e TF_VAR_grafana_auth \
+            -e TF_VAR_prometheus_datasource_uid \
+            -e TF_VAR_environment \
+            "$TF_IMAGE" plan -no-color
 
       - name: Explain skipped plan
         if: ${{ env.TF_VAR_grafana_url == '' || env.TF_VAR_grafana_auth == '' || env.TF_VAR_prometheus_datasource_uid == '' }}

--- a/.github/workflows/grafana-alerts.yml
+++ b/.github/workflows/grafana-alerts.yml
@@ -2,12 +2,12 @@ name: Grafana Alerts Terraform
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [main]
     paths:
       - ".github/workflows/grafana-alerts.yml"
       - "observability/terraform/grafana-alerts/**"
   push:
-    branches: [develop]
+    branches: [main]
     paths:
       - ".github/workflows/grafana-alerts.yml"
       - "observability/terraform/grafana-alerts/**"

--- a/.github/workflows/grafana-alerts.yml
+++ b/.github/workflows/grafana-alerts.yml
@@ -1,0 +1,65 @@
+name: Grafana Alerts Terraform
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - ".github/workflows/grafana-alerts.yml"
+      - "observability/terraform/grafana-alerts/**"
+  push:
+    branches: [develop]
+    paths:
+      - ".github/workflows/grafana-alerts.yml"
+      - "observability/terraform/grafana-alerts/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: grafana-alerts-terraform-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TF_DIR: observability/terraform/grafana-alerts
+  TF_IN_AUTOMATION: "true"
+  TF_INPUT: "false"
+  TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL }}
+  TF_VAR_grafana_auth: ${{ secrets.GRAFANA_AUTH }}
+  TF_VAR_prometheus_datasource_uid: ${{ secrets.GRAFANA_PROMETHEUS_DS_UID }}
+  TF_VAR_environment: ${{ vars.GRAFANA_ENVIRONMENT || 'production' }}
+
+jobs:
+  validate-and-plan:
+    name: Validate Grafana alerts
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Check Terraform formatting
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform fmt -check -recursive
+
+      - name: Initialize Terraform
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform init -backend=false
+
+      - name: Validate Terraform
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform validate
+
+      - name: Plan Grafana alert changes
+        if: ${{ env.TF_VAR_grafana_url != '' && env.TF_VAR_grafana_auth != '' && env.TF_VAR_prometheus_datasource_uid != '' }}
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform plan -no-color
+
+      - name: Explain skipped plan
+        if: ${{ env.TF_VAR_grafana_url == '' || env.TF_VAR_grafana_auth == '' || env.TF_VAR_prometheus_datasource_uid == '' }}
+        run: |
+          echo "Skipping terraform plan because Grafana secrets are not configured."
+          echo "Required secrets: GRAFANA_URL, GRAFANA_AUTH, GRAFANA_PROMETHEUS_DS_UID."

--- a/.github/workflows/grafana-alerts.yml
+++ b/.github/workflows/grafana-alerts.yml
@@ -42,11 +42,14 @@ jobs:
       - name: Check Terraform formatting
         run: docker run --rm -v "$PWD/${TF_DIR}:/work" -w /work "$TF_IMAGE" fmt -check -recursive
 
-      - name: Initialize Terraform
-        run: docker run --rm -v "$PWD/${TF_DIR}:/work" -w /work "$TF_IMAGE" init -backend=false
-
       - name: Validate Terraform
-        run: docker run --rm -v "$PWD/${TF_DIR}:/work" -w /work "$TF_IMAGE" validate
+        run: |
+          docker run --rm \
+            -v "$PWD/${TF_DIR}:/work" \
+            -w /work \
+            -e TF_DATA_DIR=/tmp/terraform-data \
+            --entrypoint sh \
+            "$TF_IMAGE" -c "terraform init -backend=false -lockfile=readonly && terraform validate"
 
       - name: Plan Grafana alert changes
         if: ${{ env.TF_VAR_grafana_url != '' && env.TF_VAR_grafana_auth != '' && env.TF_VAR_prometheus_datasource_uid != '' }}
@@ -60,7 +63,9 @@ jobs:
             -e TF_VAR_grafana_auth \
             -e TF_VAR_prometheus_datasource_uid \
             -e TF_VAR_environment \
-            "$TF_IMAGE" plan -no-color
+            -e TF_DATA_DIR=/tmp/terraform-data \
+            --entrypoint sh \
+            "$TF_IMAGE" -c "terraform init -backend=false -lockfile=readonly && terraform plan -no-color"
 
       - name: Explain skipped plan
         if: ${{ env.TF_VAR_grafana_url == '' || env.TF_VAR_grafana_auth == '' || env.TF_VAR_prometheus_datasource_uid == '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,16 @@ env/*
 *.env.staging
 *.env.prod
 
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+*.tfvars
+*.tfvars.json
+crash.log
+crash.*.log
+
 # Certificates
 certbot/
 

--- a/observability/README.md
+++ b/observability/README.md
@@ -124,13 +124,21 @@ rows:
 - **Container Runtime** — backend CPU/memory from cAdvisor, backend OOM events,
   and backend uptime based on `container_start_time_seconds`.
 
-## Alerts to create in Grafana Cloud (Alerting → Alert rules)
+## Grafana Cloud alerting
 
-There's no infra-as-code alert provisioning in this repo (Grafana Cloud
-alerting is normally managed via its UI or Terraform, and this repo has
-neither a Terraform setup nor an API key configured) — create these by hand
-under the Grafana Cloud stack's **Alerting** section, evaluating against the
-same Prometheus data source as the dashboard. Suggested starting set:
+Grafana alert rules live in Terraform under
+`observability/terraform/grafana-alerts`. They evaluate against the same
+Prometheus/Mimir data source as the dashboard. To let GitHub Actions validate
+and plan changes, create these repository secrets:
+
+- `GRAFANA_URL`
+- `GRAFANA_AUTH`
+- `GRAFANA_PROMETHEUS_DS_UID`
+
+Optionally set repository variable `GRAFANA_ENVIRONMENT` if the target
+environment label is not `production`.
+
+The Terraform rule group currently manages this starting set:
 
 | Alert                     | Expression                                                                                                   | For   | Severity |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------|-------|----------|
@@ -146,11 +154,14 @@ same Prometheus data source as the dashboard. Suggested starting set:
 | Login failure rate spike  | `100 * sum(increase(auth_login_attempts_total{result="failure"}[15m])) / sum(increase(auth_login_attempts_total[15m])) > 50` | 5m    | warning  |
 | Cache hit rate collapse   | `100 * sum(rate(django_cache_hits_total[10m])) / sum(rate(django_cache_get_total[10m])) < 50`                   | 10m   | warning  |
 
-Route them to whatever contact point you set up (email/Slack/etc. under
-Grafana Cloud → Alerting → Contact points). Sentry has its own, separate
-alerting (Settings → Alerts on the Sentry project) for error-spike/new-issue
-notifications — worth turning on there too since Prometheus alerts above
-only see HTTP-level symptoms, not exception details.
+Notification contact points and notification policies are still managed in the
+Grafana UI. Terraform deliberately does not touch the notification policy tree
+yet, because Grafana treats it as one shared resource and an incomplete import
+can overwrite existing routing.
+
+Sentry has its own, separate alerting (Settings → Alerts on the Sentry project)
+for error-spike/new-issue notifications — worth turning on there too since
+Prometheus alerts above only see HTTP-level symptoms, not exception details.
 
 Avoid alerts on `process_cpu_seconds_total`, `process_resident_memory_bytes`,
 or other Django `process_*` series while Gunicorn multiprocess mode is enabled;

--- a/observability/terraform/grafana-alerts/.terraform.lock.hcl
+++ b/observability/terraform/grafana-alerts/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "4.40.1"
+  constraints = ">= 2.9.0, < 5.0.0"
+  hashes = [
+    "h1:dJ1LcdZ9UqQ7l+kw+O8rxZKtECCP31KA9djwRSDrfLU=",
+    "zh:189ab344beedaf6879c44134a0b1387b0df6e0f9ca0f76fefbb5de57db38e4e1",
+    "zh:1d07898548f280b25088b83d0a5d4b654d7ea6f2eff09e9d25d39d544a08b2d0",
+    "zh:26117ceaae116629e629b36732c59c8ce5d6d5a95b3a68f66475fe595f5df593",
+    "zh:2e595a65f1f9ab584e6348a651097e1cb4ab476f392a0cff17f78e669a0dd8b0",
+    "zh:36132f71520a9200c22fa8abcaa0b7abe32084a09e7e62cb8fe8aab8d10b7e1d",
+    "zh:405d143fcd77badf8a57bd51956ea3ac83d65f81c5c47226f06583fa0311d0cc",
+    "zh:409cf836c0bbbbe403f3446bdd73727c44d080b2d1c17ff3944f46fa8a496c48",
+    "zh:63ed93fb2032f50d0e4fd1c72dd49871628752d0ab61e0faf2c389a570c22f7c",
+    "zh:78bd344b32f6438111fb8ab11d99a66b243688d820d74cfe710c815769756b34",
+    "zh:7a569e8654b802f2d8972ad616e1aae2de988638c6ff0aa17b74f554c4828e42",
+    "zh:7bb1c82a4210b9bbc966c9bb145bf3b1f665445d0867a352a619ca0b39131091",
+    "zh:7cf7485817c4ba75249915be9a8652742dfe614b4630c2bf7d2c2b8181a85650",
+    "zh:806c7d1ce5b4c3abf056acefeb881e3c64178f2b165abea039def3137a627ae0",
+    "zh:94fc6893e400615a0b431581d2a3e40d5c89b6f2c66e1d96ad3f95de9c42499b",
+    "zh:9be1ec75a94eef9e07b2d514be8fd8ca979eddf1ce4f0844799638833ae467f8",
+    "zh:bd8447933e3677c87693399925e38db110eee6077a8f0dde5bf96f64a52d757c",
+    "zh:e2ef366a50bf6cf8e079217c7e26ebf4e12fb7f4f9efcb559ecdbe2b2babaef3",
+    "zh:e64e326a0a96ffa474df94617cae51105e222160bf8deae7019281d732003990",
+    "zh:f7e6b7f6baff1974bcdd86ed7e4a577ca88d420c355fd2c2aa134a6c781bd8d6",
+  ]
+}

--- a/observability/terraform/grafana-alerts/README.md
+++ b/observability/terraform/grafana-alerts/README.md
@@ -29,6 +29,11 @@ Optional GitHub repository variable:
 
 - `GRAFANA_ENVIRONMENT` (defaults to `production`)
 
+GitHub Actions validates and plans these alerts for PRs into `main`, pushes to
+`main`, and manual `workflow_dispatch` runs. It intentionally does not run for
+every `develop` PR because the configured secrets target the production Grafana
+stack by default.
+
 ## Local commands
 
 ```bash

--- a/observability/terraform/grafana-alerts/README.md
+++ b/observability/terraform/grafana-alerts/README.md
@@ -1,0 +1,74 @@
+# Grafana Alerts Terraform
+
+This directory manages the Zdravy Projekt backend alert rules in Grafana Cloud.
+The alerts use the same Prometheus/Mimir data source as
+`observability/grafana/dashboards/backend-overview.json`.
+
+## Values you need from Grafana
+
+1. `GRAFANA_URL`
+   - Your Grafana Cloud stack URL, for example `https://example.grafana.net`.
+2. `GRAFANA_AUTH`
+   - A Grafana service-account token.
+   - Create it in Grafana Cloud under **Administration -> Users and access ->
+     Service accounts**.
+   - Use an Admin token first while wiring this up, then narrow permissions
+     later if needed.
+3. `GRAFANA_PROMETHEUS_DS_UID`
+   - The UID of the Prometheus/Mimir data source used by the dashboard.
+   - Find it in **Connections -> Data sources -> Prometheus/Mimir -> Settings**.
+   - It also appears in the data-source edit URL.
+
+Store these as GitHub repository secrets, not in this repo:
+
+- `GRAFANA_URL`
+- `GRAFANA_AUTH`
+- `GRAFANA_PROMETHEUS_DS_UID`
+
+Optional GitHub repository variable:
+
+- `GRAFANA_ENVIRONMENT` (defaults to `production`)
+
+## Local commands
+
+```bash
+cd observability/terraform/grafana-alerts
+
+export TF_VAR_grafana_url="https://example.grafana.net"
+export TF_VAR_grafana_auth="<service-account-token>"
+export TF_VAR_prometheus_datasource_uid="<prometheus-datasource-uid>"
+export TF_VAR_environment="production"
+
+terraform init
+terraform fmt -check -recursive
+terraform validate
+terraform plan
+```
+
+Apply intentionally remains a manual step until this repo has a remote
+Terraform state backend. Running apply from ephemeral GitHub Actions state would
+make future plans unreliable.
+
+```bash
+terraform apply
+```
+
+## Alerts
+
+The rule group creates these alerts:
+
+- High 5xx error rate
+- Elevated 5xx error rate
+- High p95 latency
+- Backend scrape down
+- Alloy scrape down
+- DB connection errors
+- Backend OOM killed
+- Backend recently restarted
+- Possible brute-force login
+- Login failure rate spike
+- Cache hit rate collapse
+
+Notification contact points and notification policies are not managed here yet.
+Those are intentionally left in the Grafana UI for now so this first Terraform
+step cannot overwrite the existing notification tree.

--- a/observability/terraform/grafana-alerts/main.tf
+++ b/observability/terraform/grafana-alerts/main.tf
@@ -1,0 +1,258 @@
+locals {
+  excluded_django_views = "health_check|prometheus-django-metrics"
+
+  django_5xx_rate_percent = "100 * sum(rate(django_http_responses_total_by_status_view_method_total{environment=\"${var.environment}\",status=~\"5..\",view!~\"${local.excluded_django_views}\"}[5m])) / clamp_min(sum(rate(django_http_responses_total_by_status_view_method_total{environment=\"${var.environment}\",view!~\"${local.excluded_django_views}\"}[5m])), 0.001)"
+
+  alert_rules = {
+    high_5xx_error_rate = {
+      name            = "High 5xx error rate"
+      expr            = local.django_5xx_rate_percent
+      math_expression = "$B > ${var.high_5xx_error_rate_percent}"
+      for             = "5m"
+      severity        = "critical"
+      summary         = "Backend 5xx error rate is above ${var.high_5xx_error_rate_percent}%"
+      description     = "Django is returning too many 5xx responses in ${var.environment}. Check Sentry, backend logs, DB health, and the busiest endpoints panel."
+    }
+
+    elevated_5xx_error_rate = {
+      name            = "Elevated 5xx error rate"
+      expr            = local.django_5xx_rate_percent
+      math_expression = "$B > ${var.elevated_5xx_error_rate_percent}"
+      for             = "10m"
+      severity        = "warning"
+      summary         = "Backend 5xx error rate is above ${var.elevated_5xx_error_rate_percent}%"
+      description     = "Django is returning more 5xx responses than expected in ${var.environment}. Check whether this is a deploy, integration, or database issue."
+    }
+
+    high_p95_latency = {
+      name            = "High p95 latency"
+      expr            = "histogram_quantile(0.95, sum by (le) (rate(django_http_requests_latency_seconds_by_view_method_bucket{environment=\"${var.environment}\",view!~\"${local.excluded_django_views}\"}[5m])))"
+      math_expression = "$B > ${var.high_p95_latency_seconds}"
+      for             = "5m"
+      severity        = "warning"
+      summary         = "Backend p95 latency is above ${var.high_p95_latency_seconds}s"
+      description     = "Request latency is high in ${var.environment}. Check slowest endpoints, DB p95 latency, and container CPU/memory."
+    }
+
+    backend_scrape_down = {
+      name            = "Backend scrape down"
+      expr            = "min(up{environment=\"${var.environment}\",job=\"django\"})"
+      math_expression = "$B < 1"
+      for             = "2m"
+      no_data_state   = "Alerting"
+      severity        = "critical"
+      summary         = "Alloy cannot scrape the Django backend"
+      description     = "The django scrape target is down in ${var.environment}. Check the Alloy stack, ALLOY_METRICS_TARGET, container networking, and backend health."
+    }
+
+    alloy_scrape_down = {
+      name            = "Alloy scrape down"
+      expr            = "min(up{environment=\"${var.environment}\",job=\"alloy\"})"
+      math_expression = "$B < 1"
+      for             = "5m"
+      no_data_state   = "Alerting"
+      severity        = "warning"
+      summary         = "Alloy self-scrape is down"
+      description     = "Alloy is not reporting its own scrape health in ${var.environment}. Metrics and logs may stop arriving in Grafana Cloud."
+    }
+
+    db_connection_errors = {
+      name            = "DB connection errors"
+      expr            = "sum(increase(django_db_new_connection_errors_total{environment=\"${var.environment}\"}[5m]))"
+      math_expression = "$B > 0"
+      for             = "1m"
+      severity        = "critical"
+      summary         = "Django is seeing database connection errors"
+      description     = "Database connection errors appeared in ${var.environment}. Check Postgres availability, max connections, and backend logs."
+    }
+
+    backend_oom_killed = {
+      name            = "Backend OOM killed"
+      expr            = "sum(increase(container_oom_events_total{environment=\"${var.environment}\",job=\"cadvisor\",name=~\".*backend.*\"}[5m]))"
+      math_expression = "$B > 0"
+      for             = "0s"
+      severity        = "critical"
+      summary         = "Backend container had an OOM event"
+      description     = "cAdvisor reported an OOM event for a backend container in ${var.environment}. Check memory usage, container limits, and recent traffic/jobs."
+    }
+
+    backend_recently_restarted = {
+      name            = "Backend recently restarted"
+      expr            = "time() - max(container_start_time_seconds{environment=\"${var.environment}\",job=\"cadvisor\",name=~\".*backend.*\",image!=\"\"})"
+      math_expression = "$B < ${var.backend_recent_restart_seconds}"
+      for             = "0s"
+      severity        = "warning"
+      summary         = "Backend container restarted recently"
+      description     = "The backend container start time is fresh in ${var.environment}. This also fires after intentional deploys, so mute it during planned releases."
+    }
+
+    possible_bruteforce_login = {
+      name            = "Possible brute-force login"
+      expr            = "sum(increase(auth_login_attempts_total{environment=\"${var.environment}\",result=\"failure\"}[10m]))"
+      math_expression = "$B > ${var.login_failure_count_threshold}"
+      for             = "0s"
+      severity        = "warning"
+      summary         = "Failed login attempts are elevated"
+      description     = "There were more than ${var.login_failure_count_threshold} failed login attempts in 10 minutes in ${var.environment}."
+    }
+
+    login_failure_rate_spike = {
+      name            = "Login failure rate spike"
+      expr            = "100 * sum(increase(auth_login_attempts_total{environment=\"${var.environment}\",result=\"failure\"}[15m])) / clamp_min(sum(increase(auth_login_attempts_total{environment=\"${var.environment}\"}[15m])), 1)"
+      math_expression = "$B > ${var.login_failure_rate_percent}"
+      for             = "5m"
+      severity        = "warning"
+      summary         = "Login failure rate is above ${var.login_failure_rate_percent}%"
+      description     = "A high share of login attempts are failing in ${var.environment}. Check whether users are affected or someone is probing login."
+    }
+
+    cache_hit_rate_collapse = {
+      name            = "Cache hit rate collapse"
+      expr            = "100 * sum(rate(django_cache_hits_total{environment=\"${var.environment}\"}[10m])) / clamp_min(sum(rate(django_cache_get_total{environment=\"${var.environment}\"}[10m])), 0.001)"
+      math_expression = "$B < ${var.cache_hit_rate_percent}"
+      for             = "10m"
+      severity        = "warning"
+      summary         = "Cache hit rate is below ${var.cache_hit_rate_percent}%"
+      description     = "Cache hit rate dropped in ${var.environment}. Check Redis availability and whether a deploy or batch job invalidated many keys."
+    }
+  }
+}
+
+resource "grafana_folder" "zdravy_project" {
+  title = var.folder_title
+}
+
+resource "grafana_rule_group" "backend" {
+  name             = var.alert_group_name
+  folder_uid       = grafana_folder.zdravy_project.uid
+  interval_seconds = 60
+  org_id           = 1
+
+  dynamic "rule" {
+    for_each = local.alert_rules
+
+    content {
+      name      = rule.value.name
+      condition = "C"
+      for       = rule.value.for
+
+      no_data_state  = lookup(rule.value, "no_data_state", "OK")
+      exec_err_state = "Error"
+      is_paused      = false
+
+      labels = {
+        environment = var.environment
+        managed_by  = "terraform"
+        service     = "backend"
+        severity    = rule.value.severity
+      }
+
+      annotations = {
+        summary     = rule.value.summary
+        description = rule.value.description
+      }
+
+      data {
+        ref_id         = "A"
+        datasource_uid = var.prometheus_datasource_uid
+        relative_time_range {
+          from = 600
+          to   = 0
+        }
+        model = jsonencode({
+          datasource = {
+            type = "prometheus"
+            uid  = var.prometheus_datasource_uid
+          }
+          editorMode    = "code"
+          expr          = rule.value.expr
+          instant       = true
+          intervalMs    = 1000
+          legendFormat  = "__auto"
+          maxDataPoints = 43200
+          range         = false
+          refId         = "A"
+        })
+      }
+
+      data {
+        ref_id         = "B"
+        datasource_uid = "__expr__"
+        relative_time_range {
+          from = 600
+          to   = 0
+        }
+        model = jsonencode({
+          conditions = [
+            {
+              evaluator = {
+                params = []
+                type   = "gt"
+              }
+              operator = {
+                type = "and"
+              }
+              query = {
+                params = ["B"]
+              }
+              reducer = {
+                params = []
+                type   = "last"
+              }
+              type = "query"
+            }
+          ]
+          datasource = {
+            type = "__expr__"
+            uid  = "__expr__"
+          }
+          expression    = "A"
+          intervalMs    = 1000
+          maxDataPoints = 43200
+          reducer       = "last"
+          refId         = "B"
+          type          = "reduce"
+        })
+      }
+
+      data {
+        ref_id         = "C"
+        datasource_uid = "__expr__"
+        relative_time_range {
+          from = 600
+          to   = 0
+        }
+        model = jsonencode({
+          conditions = [
+            {
+              evaluator = {
+                params = [0]
+                type   = "gt"
+              }
+              operator = {
+                type = "and"
+              }
+              query = {
+                params = ["C"]
+              }
+              reducer = {
+                params = []
+                type   = "last"
+              }
+              type = "query"
+            }
+          ]
+          datasource = {
+            type = "__expr__"
+            uid  = "__expr__"
+          }
+          expression    = rule.value.math_expression
+          intervalMs    = 1000
+          maxDataPoints = 43200
+          refId         = "C"
+          type          = "math"
+        })
+      }
+    }
+  }
+}

--- a/observability/terraform/grafana-alerts/outputs.tf
+++ b/observability/terraform/grafana-alerts/outputs.tf
@@ -1,0 +1,9 @@
+output "grafana_folder_uid" {
+  description = "UID of the Grafana folder containing Terraform-managed alerts."
+  value       = grafana_folder.zdravy_project.uid
+}
+
+output "grafana_alert_group_name" {
+  description = "Grafana alert rule group name."
+  value       = grafana_rule_group.backend.name
+}

--- a/observability/terraform/grafana-alerts/providers.tf
+++ b/observability/terraform/grafana-alerts/providers.tf
@@ -1,0 +1,4 @@
+provider "grafana" {
+  url  = var.grafana_url
+  auth = var.grafana_auth
+}

--- a/observability/terraform/grafana-alerts/variables.tf
+++ b/observability/terraform/grafana-alerts/variables.tf
@@ -1,0 +1,75 @@
+variable "grafana_url" {
+  description = "Grafana Cloud stack URL, for example https://example.grafana.net."
+  type        = string
+}
+
+variable "grafana_auth" {
+  description = "Grafana service-account token with permissions to manage alerting resources."
+  type        = string
+  sensitive   = true
+}
+
+variable "prometheus_datasource_uid" {
+  description = "UID of the Grafana Cloud Prometheus/Mimir data source used by the backend dashboard."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment label value used by Alloy when remote-writing metrics."
+  type        = string
+  default     = "production"
+}
+
+variable "folder_title" {
+  description = "Grafana folder where Terraform-managed alert rules are stored."
+  type        = string
+  default     = "Zdravy Projekt"
+}
+
+variable "alert_group_name" {
+  description = "Grafana alert rule group name."
+  type        = string
+  default     = "Zdravy Projekt Backend"
+}
+
+variable "high_5xx_error_rate_percent" {
+  description = "Critical 5xx error-rate threshold over the last 5 minutes."
+  type        = number
+  default     = 5
+}
+
+variable "elevated_5xx_error_rate_percent" {
+  description = "Warning 5xx error-rate threshold over the last 10 minutes."
+  type        = number
+  default     = 1
+}
+
+variable "high_p95_latency_seconds" {
+  description = "Warning threshold for backend p95 latency."
+  type        = number
+  default     = 3
+}
+
+variable "backend_recent_restart_seconds" {
+  description = "How long after a backend container start to alert about a recent restart."
+  type        = number
+  default     = 600
+}
+
+variable "login_failure_count_threshold" {
+  description = "Warning threshold for failed login attempts over 10 minutes."
+  type        = number
+  default     = 30
+}
+
+variable "login_failure_rate_percent" {
+  description = "Warning threshold for failed login percentage over 15 minutes."
+  type        = number
+  default     = 50
+}
+
+variable "cache_hit_rate_percent" {
+  description = "Warning threshold for cache hit rate over 10 minutes."
+  type        = number
+  default     = 50
+}

--- a/observability/terraform/grafana-alerts/versions.tf
+++ b/observability/terraform/grafana-alerts/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = ">= 2.9.0, < 5.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform config for Grafana Cloud backend alert rules
- add GitHub Actions workflow for Terraform fmt/init/validate and optional plan when Grafana secrets are configured
- document required Grafana secrets and keep notification routing in the Grafana UI for now

## Tests
- docker run --rm -v "/home/tomas-magula/Documents/Projects/ZB/zdravy-projekt-grafana-alerts/observability/terraform/grafana-alerts:/work" -w /work hashicorp/terraform:1.10.5 init -backend=false -input=false
- docker run --rm -v "/home/tomas-magula/Documents/Projects/ZB/zdravy-projekt-grafana-alerts/observability/terraform/grafana-alerts:/work" -w /work hashicorp/terraform:1.10.5 fmt -check -recursive
- docker run --rm -v "/home/tomas-magula/Documents/Projects/ZB/zdravy-projekt-grafana-alerts/observability/terraform/grafana-alerts:/work" -w /work hashicorp/terraform:1.10.5 validate
- docker run --rm -v "/home/tomas-magula/Documents/Projects/ZB/zdravy-projekt-grafana-alerts/observability/terraform/grafana-alerts:/work" -w /work -e TF_VAR_grafana_url=https://example.grafana.net -e TF_VAR_grafana_auth=dummy-token -e TF_VAR_prometheus_datasource_uid=prometheus hashicorp/terraform:1.10.5 plan -refresh=false -no-color
- docker run --rm -v "/home/tomas-magula/Documents/Projects/ZB/zdravy-projekt-grafana-alerts:/repo" -w /repo rhysd/actionlint:latest .github/workflows/grafana-alerts.yml