### PR TITLE
fix: EduPage facility reconciliation and modal focus

### DIFF
--- a/.claude/skills/compare-real/SKILL.md
+++ b/.claude/skills/compare-real/SKILL.md
@@ -86,7 +86,8 @@ The command auto-resolves the workbook by date, then emits a JSON report on **st
 and a one-line summary on **stderr**. It runs two tiers:
 
 1. **Tier 1 — counts, PER MEAL TYPE.** App per-facility counts vs the `Hárok1` count
-   lines, compared **like-for-like by meal type** (`lunch`, `snack`, `breakfast`). This
+   lines, compared **like-for-like by meal type** (`breakfast`, `lunch`, `snack`;
+   `snack` = olovrant). This
    matters: a facility that only orders obed must **not** be faulted against the app's
    lunch+olovrant grand total. Which Hárok1 column is lunch and which is olovrant is
    derived from the app's own `col_groups` (matched by dish name), because the dishes
@@ -121,8 +122,13 @@ maps them; pass it with `--alias-map`. Matching is ASCII-folded/punctuation-stri
 A facility still landing in both `app_only` and `real_only` is an unresolved mapping —
 **resolve the spelling and add it to `facility_aliases.json`, don't invent a match.** Add
 only confident pairings; leave ambiguous ones out and list them as unresolved in the
-report (e.g. `SZŠ FAN` — no clear real counterpart; `Zdravé Bruško ↔ deutsche schule`
-was confirmed via count match).
+report (e.g. `SZŠ FAN` — no clear real counterpart). `Zdravé Brúsko` is no longer
+an alias for `deutsche schule`; the app should label the split row as `Deutsche schule`
+directly.
+
+`Deutsche schule` has a special service rule: even if EduPage contains breakfast/snack
+rows for it, the app should ignore those meals. Expected reconciliation is
+`breakfast=0`, `snack=0`, and lunch compared normally.
 
 ## How to run — week comparison (no daily `real/` workbook)
 

--- a/.claude/skills/compare-real/SKILL.md
+++ b/.claude/skills/compare-real/SKILL.md
@@ -103,8 +103,8 @@ and a one-line summary on **stderr**. It runs two tiers:
    has a blank spacer, so positional reads are wrong. Each facility's grams are the sum
    of its whole **block** (KLASIK header row + diet sub-rows, until the next facility,
    detected by the address line beneath a header). Residual Tier-2 diffs after this are
-   count-driven (they track a Tier-1 count gap) or olovrant billed separately (real=0),
-   not column/aggregation bugs.
+   usually count-driven (they track a Tier-1 count gap), missing menu-column matches, or
+   unresolved facility mapping — not column/aggregation bugs.
 
 Flags: `--alias-map <path>` (facility name dictionary, below), `--workbook <path>`
 (override auto-resolve), `--count-tolerance N` (default 0), `--gram-tolerance N`

--- a/.claude/skills/compare-real/facility_aliases.json
+++ b/.claude/skills/compare-real/facility_aliases.json
@@ -14,7 +14,6 @@
   "MŠ Libellus": "libellus",
   "MŠ Rozmanitá": ["rozmanita skolka", "rozmanita skola"],
   "MŠ Prameň": "pramienok",
-  "MŠ Zdravé Bruško": "deutsche schule",
   "ZŠ Ivanka pri Dunaji": "ivanka",
   "Škôlka MS – Les": "skolicka les",
   "Škôlka MS – Lúka": "skolicka luka"

--- a/backend/api/edupage_scraper.py
+++ b/backend/api/edupage_scraper.py
@@ -168,18 +168,24 @@ def _has_diet_signal(key: str) -> bool:
     return any(fragment in key for fragment in _NAZOV_KEYWORD_MAP)
 
 
-def build_prevadzka_matches(prevadzky) -> dict[str, str]:
-    """{prefix: názov prevádzky} pre `match_prevadzka`.
+def build_prevadzka_matches(prevadzky) -> dict[str, list[str]]:
+    """{prefix: [názvy prevádzok]} pre `match_prevadzka`.
 
     Jedna prevádzka môže prispieť viacerými prefixami (`edupage_match` oddelený
-    čiarkami), preto sa mapa nedá postaviť ako `{p.edupage_match: p.nazov}` a jej
+    bodkočiarkami), preto sa mapa nedá postaviť ako `{p.edupage_match: p.nazov}` a jej
     veľkosť sa nesmie porovnávať s počtom prevádzok — na to je
     `prevadzky_without_match`.
+
+    Hodnota je zoznam, lebo jeden prefix môže patriť viacerým prevádzkam: EduPage
+    Zdravého Brúska zlučuje MŠ Malokarpatské a MŠ Heyrovského do jednej skratky
+    (`mšMal,Hey`) pri desiate a olovrante. Rozpad na tie dve škôlky v dátach nie je,
+    tak sa počet zapíše NAPLNO obom — dočasne, kým klient menu nerozdelí (viď
+    feedback.md). Nadhodnocuje to fakturáciu oboch, ale je to vedomé.
     """
-    matches: dict[str, str] = {}
+    matches: dict[str, list[str]] = {}
     for prevadzka in prevadzky:
         for prefix in prevadzka.edupage_prefixes():
-            matches[prefix] = prevadzka.nazov
+            matches.setdefault(prefix, []).append(prevadzka.nazov)
     return matches
 
 
@@ -189,25 +195,49 @@ def prevadzky_without_match(prevadzky) -> list[str]:
 
 
 def match_prevadzka(
-    matches: dict[str, str], payer_name: str, menu_nazov: str
-) -> str | None:
+    matches: dict[str, list[str]],
+    payer_name: str,
+    menu_nazov: str,
+    menu_skratka: str = "",
+) -> list[str]:
     """Priraď EduPage riadok prevádzke podľa `edupage_match` prefixu.
 
-    Prevádzka je zakódovaná ako PREFIX payer labelu (`J1 1.st. klasik`, `B - Les`)
-    alebo názvu menu (`Palisády nM`). Skúšame oboje. Match je `startswith`, nie
-    substring — inak by krátky `edupage_match` (napr. `Les`) chytil aj nesúvisiaci
-    label, kde sa ten reťazec vyskytne v strede. Dlhšie prefixy majú prednosť, aby
-    `J1` neprebilo špecifickejší match.
+    Prevádzka je zakódovaná ako PREFIX payer labelu (`J1 1.st. klasik`, `B - Les`),
+    názvu menu (`Palisády nM`) alebo skratky menu (`dsbA`, `zšlaNM`). Skúšame všetky
+    tri. Skratka je jediný spoľahlivý nosič tam, kde EduPage zastrešuje viac
+    samostatných subjektov: Zdravé Brúsko vedie päť škôl a ich payer labely (`MŠ
+    Klasik`, `MŠ Vege`) ani názvy menu (`Klasik`) školu neurčujú — skratka áno.
+
+    Match je `startswith`, nie substring — inak by krátky `edupage_match` (napr. `Les`)
+    chytil aj nesúvisiaci label, kde sa ten reťazec vyskytne v strede. Dlhšie prefixy
+    majú prednosť, aby `J1` neprebilo špecifickejší match; vyhráva teda JEDEN prefix,
+    a viac prevádzok vráti len vtedy, keď si ten istý prefix zdieľajú (`mšMal,Hey`).
+
+    Vracia zoznam — prázdny znamená „nepriradené", nie „nič sa nedeje": volajúci to
+    musí nahlásiť ako neúplný scrape, inak by porcie ticho zmizli.
+
+    Skratka má PREDNOSŤ pred payer labelom, lebo je to jediný spoľahlivý nosič: v
+    skratke je prefix celok a suffix porcia (`dsbNMNE` = Deutsche schule + NoMilk/
+    NoEgg). Payer label pomenúva len skupinu a vie si so skratkou protirečiť —
+    riadok `payer='MŠ Mal. NoMilk'` so skratkou `dsbNMNE` je porcia Deutsche schule,
+    nie Malokarpatského, hoci payer začína na `mšMal`. Keby vyhral payer, porcia by
+    sa fakturovala nesprávnej škole.
     """
-    payer_key = _normalise_key(payer_name)
-    menu_key = _normalise_key(menu_nazov)
-    for prefix in sorted(matches, key=len, reverse=True):
-        prefix_key = _normalise_key(prefix)
-        if not prefix_key:
+    kandidati = (
+        _normalise_key(menu_skratka),
+        _normalise_key(payer_name),
+        _normalise_key(menu_nazov),
+    )
+    for key in kandidati:
+        if not key:
             continue
-        if payer_key.startswith(prefix_key) or menu_key.startswith(prefix_key):
-            return matches[prefix]
-    return None
+        for prefix in sorted(matches, key=len, reverse=True):
+            prefix_key = _normalise_key(prefix)
+            if not prefix_key:
+                continue
+            if key.startswith(prefix_key):
+                return list(matches[prefix])
+    return []
 
 
 # ------------------------------------------------------------------
@@ -252,7 +282,7 @@ class EdupageScraper:
         self,
         mealsguest_url: str,
         target_date: date,
-        prevadzka_matches: dict[str, str] | None = None,
+        prevadzka_matches: dict[str, list[str]] | None = None,
     ) -> ScrapeResult:
         url = self._inject_date(mealsguest_url, target_date)
         html = self._fetch(url)
@@ -563,7 +593,7 @@ class EdupageScraper:
         html: str,
         target_date: date,
         config: PrevadzkaConfig | None = None,
-        prevadzka_matches: dict[str, str] | None = None,
+        prevadzka_matches: dict[str, list[str]] | None = None,
     ) -> ScrapeResult:
         prehlad_raw = self._extract_block(html, "prehlad")
         nazov_menu_raw = self._extract_block(html, "nazovMenu")
@@ -680,33 +710,36 @@ class EdupageScraper:
                     effective_menu = "A" if effective_diet else (menu_variant or "A")
 
                     if matches:
-                        bucket = match_prevadzka(matches, match_name, nazov)
-                        if bucket is None:
+                        buckets = match_prevadzka(matches, match_name, nazov, skratka)
+                        if not buckets:
                             # Radšej nahlás neúplný scrape, než ticho zahodiť porcie.
                             unmatched.append(
                                 f"{letter}:{skratka}/{payer_info.get('name', payer_id)}"
                             )
                             continue
                     else:
-                        bucket = ""
+                        buckets = [""]
 
-                    if flag_label is not None:
-                        attention_buckets.setdefault(bucket, set()).add(flag_label)
+                    # Zdieľaná skratka (`mšMal,Hey`) padne viacerým prevádzkam naraz —
+                    # celý počet každej z nich, nie delený. Viď `build_prevadzka_matches`.
+                    for bucket in buckets:
+                        if flag_label is not None:
+                            attention_buckets.setdefault(bucket, set()).add(flag_label)
 
-                    counts_by_meal = counts.setdefault(bucket, {})
-                    meal_counts = counts_by_meal.setdefault(meal_key, {})
-                    portion_counts = meal_counts.setdefault(
-                        portion_name, {"menuCounts": {}, "diets": {}}
-                    )
-                    menu_counts = portion_counts["menuCounts"]
-                    diet_counts = portion_counts["diets"]
-                    menu_counts[effective_menu] = (
-                        menu_counts.get(effective_menu, 0) + total
-                    )
-                    if effective_diet:
-                        diet_counts[effective_diet] = (
-                            diet_counts.get(effective_diet, 0) + total
+                        counts_by_meal = counts.setdefault(bucket, {})
+                        meal_counts = counts_by_meal.setdefault(meal_key, {})
+                        portion_counts = meal_counts.setdefault(
+                            portion_name, {"menuCounts": {}, "diets": {}}
                         )
+                        menu_counts = portion_counts["menuCounts"]
+                        diet_counts = portion_counts["diets"]
+                        menu_counts[effective_menu] = (
+                            menu_counts.get(effective_menu, 0) + total
+                        )
+                        if effective_diet:
+                            diet_counts[effective_diet] = (
+                                diet_counts.get(effective_diet, 0) + total
+                            )
 
         def _clean(counts_by_meal: dict) -> dict[str, Any]:
             return {

--- a/backend/api/management/commands/reconcile_real.py
+++ b/backend/api/management/commands/reconcile_real.py
@@ -169,10 +169,10 @@ def _resolve_workbook(date_str: str) -> Path:
 # ── Tier 1: counts from the Hárok1 sheet ───────────────────────────────────────
 # Meal-type buckets are compared like-for-like: a facility that only bills OBED
 # must not be faulted against the app's lunch+olovrant grand total.
-MEAL_TYPES = ("lunch", "snack", "breakfast")
+MEAL_TYPES = ("breakfast", "lunch", "snack")
 
 
-# Maps app meal-plan categories to the vyúčtovanie meal-type buckets. Soup and
+# Maps app meal-plan categories to reconciliation meal-type buckets. Soup and
 # main_course share one headcount (a "lunch"), so only main_course is counted.
 _APP_MEAL_TO_TYPE = {
     "main_course": "lunch",
@@ -636,14 +636,9 @@ class Command(BaseCommand):
             row, app_buckets = app_counts[key]
             real_buckets = real_counts[key]
             client = str(row.get("client", ""))
-            # Only compare meal types that either side actually billed/ordered.
             for meal_type in MEAL_TYPES:
-                app_val = app_buckets.get(meal_type)
-                real_val = real_buckets.get(meal_type)
-                if app_val is None and real_val is None:
-                    continue
-                app_val = app_val or Decimal("0")
-                real_val = real_val or Decimal("0")
+                app_val = app_buckets.get(meal_type) or Decimal("0")
+                real_val = real_buckets.get(meal_type) or Decimal("0")
                 diff = app_val - real_val
                 count_findings.append(
                     {

--- a/backend/api/management/commands/seed_prevadzky_edupage.py
+++ b/backend/api/management/commands/seed_prevadzky_edupage.py
@@ -48,11 +48,12 @@ SPLITS: dict[str, list[tuple[str, str]]] = {
     # Hárok1 vedie školu ako pod-riadok škôlky (`DOBRODRUŽSTVO Škola` za blokom
     # `dobrodružstvo`), ale sú to dve prevádzky jedného celku. EduPage ich rozlišuje
     # spoľahlivo: škôlkové skupiny majú prefix `MŠ`, školské sa volajú `1.st`, `2.st`
-    # a `Dospelý` — spoločný prefix nemajú, preto sú vymenované. Overené proti živým
-    # dátam (17.7.2026): všetkých 14 skupín sadne, 0 nezaradených.
+    # a `Dospelý` — spoločný prefix nemajú, preto sú vymenované (oddeľovač je
+    # bodkočiarka, viď `Prevadzka.edupage_prefixes`). Overené proti živým dátam
+    # (17.7.2026): všetkých 14 skupín sadne, 0 nezaradených.
     "dobrodružstvo": [
         ("MŠ Dobrodružstvo", "MŠ"),
-        ("ZŠ Dobrodružstvo", "1.st, 2.st, Dospelý"),
+        ("ZŠ Dobrodružstvo", "1.st; 2.st; Dospelý"),
     ],
 }
 

--- a/backend/api/management/commands/seed_zdrave_brusko.py
+++ b/backend/api/management/commands/seed_zdrave_brusko.py
@@ -1,0 +1,133 @@
+"""Rozdeľ EduPage `zdravebrusko` na päť samostatných celkov.
+
+`zdravebrusko.edupage.org` nie je škola — je to len EduPage, do ktorého objednáva päť
+navzájom nesúvisiacich subjektov. Každý z nich fakturuje sám za seba, takže to nie je
+jeden celok s piatimi prevádzkami: spoločný EduPage nie je príznak celku. Preto tu
+vzniká päť celkov a jeden login (`profil.prevadzky` M2M) siahajúci naprieč nimi.
+
+Mapovanie prefixov je odčítané z EduPage konfigu „Menu – Názov" a overené proti
+`prevadzky.md` rosteru (Hárok1):
+
+    dsb    → Deutsche schule                (Bárdošova 33)
+    sšv    → SŠ VETERINÁRNA                 (Pod brehmi 6)
+    zšla   → ZŠ Malokarpatská               (Malokarpatské námestie 2, Lamač)
+    mšHey  → MŠ Heyrovského 4
+    mšMal  → MŠ Malokarpatké námestie 6
+
+`mšMal` a `zšla` sú dve rôzne školy na dvoch adresách (námestie 6 vs. 2) — nie je to
+tá istá inštitúcia a nesmú sa zlúčiť. Prefixy sú case-sensitive a `match_prevadzka`
+ich berie ako prefix, nie substring, takže `mšMal` nechytí `mšHey`.
+
+    python manage.py seed_zdrave_brusko
+    python manage.py seed_zdrave_brusko --dry-run
+"""
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from api.models import Celok, DailyOrder, Prevadzka, UserProfile
+
+EMAIL = "zdravebrusko@edupage.local"
+MEALSGUEST_URL = "https://zdravebrusko.edupage.org/menu/mealsGuest?id=LFpbpn1"
+
+# Celok, ktorý tu pôvodne zastrešoval všetkých päť škôl. Nie je to reálny subjekt,
+# len artefakt toho, že seed mapoval jeden EduPage login na jeden celok.
+STARY_CELOK = "MŠ Zdravé Bruško"
+
+# (názov celku, adresa prevádzky, edupage_match)
+SKOLY: list[tuple[str, str, str]] = [
+    ("Deutsche schule", "Bárdošova 33, Bratislava", "dsb"),
+    ("SŠ VETERINÁRNA", "Pod brehmi 6, Bratislava", "sšv"),
+    ("ZŠ Malokarpatská", "Malokarpatské námestie 2, Lamač", "zšla"),
+    # Desiata a olovrant majú jedinú spoločnú skratku `mšMal,Hey` — EduPage tie dve
+    # škôlky pri týchto chodoch nerozlišuje. Deklarujú ju obe, takže počet padne
+    # naplno každej z nich (viď feedback.md: dočasné, nadhodnocuje fakturáciu oboch).
+    # Pri obede sú rozlíšené (`mšHey. NM/NG` vs `mšMal. NM/NG`).
+    ("MŠ Heyrovského 4", "Heyrovského 4, Bratislava", "mšHey; mšMal,Hey"),
+    (
+        "MŠ Malokarpatké námestie 6",
+        "Malokarpatské námestie 6, Bratislava",
+        "mšMal; mšMal,Hey",
+    ),
+]
+
+
+class Command(BaseCommand):
+    help = "Rozdelí EduPage zdravebrusko na päť samostatných celkov."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+
+        user = User.objects.filter(username=EMAIL).first()
+        if user is None:
+            self.stderr.write(f"✗ login neexistuje: {EMAIL}")
+            return
+        profil = UserProfile.objects.filter(user=user).first()
+        if profil is None:
+            self.stderr.write(f"✗ profil neexistuje pre {EMAIL}")
+            return
+
+        prevadzky: list[Prevadzka] = []
+        for sort_order, (nazov, adresa, match) in enumerate(SKOLY, start=1):
+            celok, celok_created = Celok.objects.get_or_create(
+                nazov=nazov,
+                defaults={"billing_name": nazov, "zdroj_objednavok": "edupage"},
+            )
+            if not celok_created and celok.zdroj_objednavok != "edupage":
+                # Roster ich vedie ako `app`, lebo si dosiaľ objednávali priamo.
+                celok.zdroj_objednavok = "edupage"
+                celok.save(update_fields=["zdroj_objednavok"])
+
+            prevadzka, _ = Prevadzka.objects.update_or_create(
+                celok=celok,
+                nazov=nazov,
+                defaults={
+                    "adresa": adresa,
+                    "edupage_match": match,
+                    "sort_order": sort_order,
+                    "is_active": True,
+                },
+            )
+            prevadzky.append(prevadzka)
+            verb = "vytvorený" if celok_created else "aktualizovaný"
+            self.stdout.write(f"  {nazov} ({match}) — celok {verb}")
+
+            # Prevádzky, ktoré celku ostali z čias, keď si objednával v appke, by
+            # scrape zhodil: bez `edupage_match` nemá viac-prevádzkový celok čo
+            # priradiť. Deaktivujeme, nemažeme — visí na nich história.
+            for stara in Prevadzka.objects.filter(celok=celok).exclude(pk=prevadzka.pk):
+                self.stdout.write(f"    retirujem prevádzku '{stara.nazov}'")
+                if not dry_run:
+                    stara.is_active = False
+                    stara.save(update_fields=["is_active"])
+
+        # Login plní všetkých päť škôl naraz. `celok` mu necháme prázdny: ukázať
+        # ním na jednu z piatich by klamalo — nepatrí ani pod jednu.
+        if not dry_run:
+            profil.mealsguest_url = MEALSGUEST_URL
+            profil.is_edupage = True
+            profil.celok = None
+            profil.save(update_fields=["mealsguest_url", "is_edupage", "celok"])
+            profil.prevadzky.set(prevadzky)
+        self.stdout.write(
+            f"  login {EMAIL} → {len(prevadzky)} prevádzok naprieč celkami"
+        )
+
+        # Starý zberný celok padá až teraz, keď už profil neukazuje naň (FK je PROTECT).
+        stary = Celok.objects.filter(nazov=STARY_CELOK).first()
+        if stary is not None:
+            objednavky = DailyOrder.objects.filter(prevadzka__celok=stary).count()
+            self.stdout.write(
+                f"  mažem zberný celok '{STARY_CELOK}' ({objednavky} objednávok)"
+            )
+            if not dry_run:
+                stary.delete()
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("\n--dry-run: rollback"))
+            transaction.set_rollback(True)

--- a/backend/api/management/commands/seed_zdrave_brusko.py
+++ b/backend/api/management/commands/seed_zdrave_brusko.py
@@ -25,6 +25,7 @@ ich berie ako prefix, nie substring, takže `mšMal` nechytí `mšHey`.
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from django.utils import timezone
 
 from api.models import Celok, DailyOrder, Prevadzka, UserProfile
 
@@ -118,15 +119,32 @@ class Command(BaseCommand):
             f"  login {EMAIL} → {len(prevadzky)} prevádzok naprieč celkami"
         )
 
-        # Starý zberný celok padá až teraz, keď už profil neukazuje naň (FK je PROTECT).
+        # Starý zberný celok nechávame kvôli histórii. Od dneška vyššie sú jeho
+        # objednávky duplicitné: nové samostatné celky ich prescrapujú za seba.
         stary = Celok.objects.filter(nazov=STARY_CELOK).first()
         if stary is not None:
-            objednavky = DailyOrder.objects.filter(prevadzka__celok=stary).count()
-            self.stdout.write(
-                f"  mažem zberný celok '{STARY_CELOK}' ({objednavky} objednávok)"
+            dnes = timezone.localdate()
+            duplicitne = DailyOrder.objects.filter(
+                prevadzka__celok=stary, date__gte=dnes
             )
-            if not dry_run:
-                stary.delete()
+            pocet = duplicitne.count()
+            if pocet:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  '{STARY_CELOK}': mažem {pocet} objednávok od {dnes} "
+                        "(duplikáty, nové celky ich prescrapujú)"
+                    )
+                )
+                if not dry_run:
+                    duplicitne.delete()
+
+            for stara in Prevadzka.objects.filter(celok=stary):
+                self.stdout.write(
+                    f"  '{STARY_CELOK}': retirujem historickú prevádzku '{stara.nazov}'"
+                )
+                if not dry_run:
+                    stara.is_active = False
+                    stara.save(update_fields=["is_active"])
 
         if dry_run:
             self.stdout.write(self.style.WARNING("\n--dry-run: rollback"))

--- a/backend/api/migrations/0047_edupage_match_semicolon_separator.py
+++ b/backend/api/migrations/0047_edupage_match_semicolon_separator.py
@@ -1,0 +1,40 @@
+"""Prepni oddeľovač viacerých `edupage_match` prefixov z čiarky na bodkočiarku.
+
+Čiarka oddeľovač byť nemôže: EduPage skratky ju samy obsahujú (`mšMal,Hey` je JEDNA
+skratka zdieľaná dvoma škôlkami Zdravého Brúska), takže čiarkový oddeľovač by ju
+rozsekol na dva neplatné prefixy a riadok by ostal nezaradený.
+
+Migrujeme len presne známe legacy hodnoty, ktoré používali čiarku ako oddeľovač.
+Neštiepime všetky čiarky plošne: `mšMal,Hey` je legitímny jeden prefix s čiarkou.
+"""
+
+from django.db import migrations
+
+LEGACY_TO_SEMICOLON = {
+    "1.st, 2.st, Dospelý": "1.st; 2.st; Dospelý",
+}
+SEMICOLON_TO_LEGACY = {value: key for key, value in LEGACY_TO_SEMICOLON.items()}
+
+
+def na_bodkociarku(apps, schema_editor):
+    Prevadzka = apps.get_model("api", "Prevadzka")
+    for prevadzka in Prevadzka.objects.filter(
+        edupage_match__in=LEGACY_TO_SEMICOLON.keys()
+    ):
+        prevadzka.edupage_match = LEGACY_TO_SEMICOLON[prevadzka.edupage_match]
+        prevadzka.save(update_fields=["edupage_match"])
+
+
+def na_ciarku(apps, schema_editor):
+    Prevadzka = apps.get_model("api", "Prevadzka")
+    for prevadzka in Prevadzka.objects.filter(
+        edupage_match__in=SEMICOLON_TO_LEGACY.keys()
+    ):
+        prevadzka.edupage_match = SEMICOLON_TO_LEGACY[prevadzka.edupage_match]
+        prevadzka.save(update_fields=["edupage_match"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [("api", "0046_prevadzka_edupage_match_multi")]
+
+    operations = [migrations.RunPython(na_bodkociarku, na_ciarku)]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -246,12 +246,17 @@ class UserProfile(models.Model):
 
         Prázdny M2M znamená „celý celok", nie „nič" — inak by každý nový login
         stratil prístup, kým mu ho niekto ručne nenaklikal.
+
+        Vyplnený M2M platí aj bez celku a smie siahať naprieč celkami: jeden EduPage
+        môže zastrešovať viac samostatných subjektov (Zdravé Brúsko vedie pod jedným
+        loginom päť škôl, ktoré fakturujú každá zvlášť). Spoločný EduPage teda nie je
+        príznak celku, preto sa tu na celok neviažeme.
         """
-        if self.celok_id is None:
-            return Prevadzka.objects.none()
         vybrane = self.prevadzky.filter(is_active=True)
         if vybrane.exists():
             return vybrane
+        if self.celok_id is None:
+            return Prevadzka.objects.none()
         return self.celok.prevadzky.filter(is_active=True)
 
 
@@ -315,8 +320,10 @@ class Prevadzka(models.Model):
         help_text=(
             "Prefix payer labelu / menu skratky, podľa ktorého sa EduPage riadky "
             "priradia tejto prevádzke (napr. 'J1', 'Palisády', 'B - Les'). "
-            "Viac prefixov oddeľ čiarkou — škola nemá spoločný prefix, jej skupiny "
-            "sa volajú '1.st', '2.st' aj 'Dospelý' ('1.st, 2.st, Dospelý')."
+            "Viac prefixov oddeľ BODKOČIARKOU — škola nemá spoločný prefix, jej "
+            "skupiny sa volajú '1.st', '2.st' aj 'Dospelý' ('1.st; 2.st; Dospelý'). "
+            "Čiarka oddeľovač byť nemôže: sama sa vyskytuje v skratkách menu "
+            "('mšMal,Hey' je jedna skratka pre dve škôlky)."
         ),
     )
 
@@ -326,8 +333,12 @@ class Prevadzka(models.Model):
         Jeden prefix nestačí všade: MŠ skupiny zdieľajú prefix `MŠ`, ale školské sa
         volajú `1.st.`, `2.st.` aj `Dospelý` — bez viacerých prefixov by školské
         riadky ostali nezaradené a scrape by celý celok zahodil ako neúplný.
+
+        Oddeľovač je bodkočiarka, nie čiarka: EduPage skratky čiarku bežne obsahujú
+        (`mšMal,Hey` je JEDNA skratka zdieľaná dvoma škôlkami), takže čiarkový
+        oddeľovač by ju rozsekol na dva neplatné prefixy.
         """
-        return [part.strip() for part in self.edupage_match.split(",") if part.strip()]
+        return [part.strip() for part in self.edupage_match.split(";") if part.strip()]
 
     sort_order = models.PositiveSmallIntegerField(default=0)
     is_active = models.BooleanField(default=True)

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -410,6 +410,7 @@ def scrape_edupage_orders_task(
         )
         from api.models import DailyOrder, GlobalSettings, UserProfile
         from api.services import _next_workday
+        from api.utils import filter_order_data_for_prevadzka
 
         valid_meal_types = {"breakfast", "lunch", "olovrant"}
         if isinstance(meal_types, str):
@@ -475,11 +476,7 @@ def scrape_edupage_orders_task(
         scraped = errors = skipped = 0
 
         for profile in profiles:
-            prevadzky = (
-                list(profile.celok.prevadzky.filter(is_active=True))
-                if profile.celok_id
-                else []
-            )
+            prevadzky = list(profile.dostupne_prevadzky())
             if not prevadzky:
                 logger.warning(
                     "scrape_edupage_orders_task: %s nemá žiadnu prevádzku — preskakujem",
@@ -552,6 +549,9 @@ def scrape_edupage_orders_task(
 
                     nested_order_data = nest_order_data_by_category(
                         data_by_nazov.get(nazov, {}), nazov
+                    )
+                    nested_order_data = filter_order_data_for_prevadzka(
+                        nested_order_data, nazov
                     )
                     imported_data = _filter_order_data_by_meals(
                         nested_order_data, requested_meals

--- a/backend/api/tests/test_edupage_config.py
+++ b/backend/api/tests/test_edupage_config.py
@@ -320,14 +320,14 @@ class TestPayerHookInParse(unittest.TestCase):
 
     def test_supplier_prefix_stripped_lets_clean_match_win(self):
         cfg = _cfg(OlovrantMode.EDUPAGE, payer_hook=skolickams_payer_hook)
-        res = self._parse({"Les": "Les", "Lúka": "Lúka"}, cfg)
+        res = self._parse({"Les": ["Les"], "Lúka": ["Lúka"]}, cfg)
         by = res.order_data_by_prevadzka
         self.assertEqual(by["Les"]["lunch"]["Škôlka"]["menuCounts"]["A"], 6)
         self.assertEqual(by["Lúka"]["lunch"]["Škôlka"]["menuCounts"]["A"], 4)
 
     def test_bm_becomes_no_milk_diet(self):
         cfg = _cfg(OlovrantMode.EDUPAGE, payer_hook=skolickams_payer_hook)
-        res = self._parse({"Les": "Les", "Lúka": "Lúka"}, cfg)
+        res = self._parse({"Les": ["Les"], "Lúka": ["Lúka"]}, cfg)
         luka = res.order_data_by_prevadzka["Lúka"]["lunch"]["Škôlka"]
         self.assertEqual(luka["diets"]["NO MILK"], 4)
         les = res.order_data_by_prevadzka["Les"]["lunch"]["Škôlka"]
@@ -335,33 +335,71 @@ class TestPayerHookInParse(unittest.TestCase):
 
     def test_without_hook_supplier_prefix_breaks_clean_match(self):
         # bez hooku `B - Les` prefixovo nesadne na čisté `Les` → unmatched
-        res = self._parse({"Les": "Les", "Lúka": "Lúka"}, config=None)
+        res = self._parse({"Les": ["Les"], "Lúka": ["Lúka"]}, config=None)
         self.assertTrue(res.unmatched_prevadzka)
 
 
 class TestMatchPrevadzka(unittest.TestCase):
-    MATCHES = {"J1": "Jolly 1", "J2": "Jolly 2", "Palisády": "Palisády"}
+    MATCHES = {"J1": ["Jolly 1"], "J2": ["Jolly 2"], "Palisády": ["Palisády"]}
 
     def test_matches_payer_label_prefix(self):
         self.assertEqual(
-            match_prevadzka(self.MATCHES, "J1 1.st. klasik", "klasik A"), "Jolly 1"
+            match_prevadzka(self.MATCHES, "J1 1.st. klasik", "klasik A"), ["Jolly 1"]
         )
 
     def test_matches_menu_nazov(self):
         self.assertEqual(
-            match_prevadzka(self.MATCHES, "Klasik - MŠ", "Palisády nM"), "Palisády"
+            match_prevadzka(self.MATCHES, "Klasik - MŠ", "Palisády nM"), ["Palisády"]
         )
 
     def test_diacritics_and_spaces_ignored(self):
-        self.assertEqual(match_prevadzka({"B - Les": "Les"}, "B-Les sd", ""), "Les")
+        self.assertEqual(match_prevadzka({"B - Les": ["Les"]}, "B-Les sd", ""), ["Les"])
 
-    def test_no_match_returns_none(self):
-        self.assertIsNone(match_prevadzka(self.MATCHES, "J9 klasik", "menu A"))
+    def test_no_match_returns_empty(self):
+        self.assertEqual(match_prevadzka(self.MATCHES, "J9 klasik", "menu A"), [])
 
     def test_longer_prefix_wins(self):
-        matches = {"J1": "Jolly 1", "J1 2.st": "Jolly 1 druhy stupen"}
+        matches = {"J1": ["Jolly 1"], "J1 2.st": ["Jolly 1 druhy stupen"]}
         self.assertEqual(
-            match_prevadzka(matches, "J1 2.st klasik", ""), "Jolly 1 druhy stupen"
+            match_prevadzka(matches, "J1 2.st klasik", ""), ["Jolly 1 druhy stupen"]
+        )
+
+    def test_matches_menu_skratka(self):
+        """Skratka nesie celok v prefixe (`dsbA` = Deutsche schule + Klasik).
+
+        Pri Zdravom Brúsku je to jediný rozlišovač: payer label je pre všetky školy
+        `MŠ ...` a názov menu je `Klasik`.
+        """
+        matches = {"dsb": ["Deutsche schule"], "sšv": ["SŠ VETERINÁRNA"]}
+        self.assertEqual(
+            match_prevadzka(matches, "MŠ Klasik", "Klasik", "dsbA"), ["Deutsche schule"]
+        )
+        self.assertEqual(
+            match_prevadzka(matches, "MŠ Klasik", "Klasik", "sšvA"), ["SŠ VETERINÁRNA"]
+        )
+
+    def test_skratka_beats_conflicting_payer(self):
+        """Payer label si so skratkou vie protirečiť — vyhrať musí skratka.
+
+        `MŠ Mal. NoMilk` so skratkou `dsbNMNE` je porcia Deutsche schule; keby vyhral
+        payer, fakturovala by sa Malokarpatskému.
+        """
+        matches = {"dsb": ["Deutsche schule"], "mšMal": ["MŠ Malokarpatké námestie 6"]}
+        self.assertEqual(
+            match_prevadzka(matches, "MŠ Mal. NoMilk", "NoMilk/NoEgg", "dsbNMNE"),
+            ["Deutsche schule"],
+        )
+
+    def test_shared_skratka_hits_both_prevadzky(self):
+        """`mšMal,Hey` je jedna skratka pre dve škôlky — počet padne naplno obom."""
+        matches = {
+            "mšMal": ["MŠ Malokarpatké námestie 6"],
+            "mšHey": ["MŠ Heyrovského 4"],
+            "mšMal,Hey": ["MŠ Heyrovského 4", "MŠ Malokarpatké námestie 6"],
+        }
+        self.assertEqual(
+            match_prevadzka(matches, "MŠ Diéta", "Diéta Lamač", "mšMal,Hey"),
+            ["MŠ Heyrovského 4", "MŠ Malokarpatké námestie 6"],
         )
 
 
@@ -373,25 +411,25 @@ class _FakePrevadzka:
         self.edupage_match = edupage_match
 
     def edupage_prefixes(self):
-        return [p.strip() for p in self.edupage_match.split(",") if p.strip()]
+        return [p.strip() for p in self.edupage_match.split(";") if p.strip()]
 
 
 class TestBuildPrevadzkaMatches(unittest.TestCase):
-    """Dobrodružstvo: škola nemá spoločný prefix → `edupage_match` s čiarkami."""
+    """Dobrodružstvo: škola nemá spoločný prefix → `edupage_match` s bodkočiarkami."""
 
     DOBRODRUZSTVO = [
         _FakePrevadzka("MŠ Dobrodružstvo", "MŠ"),
-        _FakePrevadzka("ZŠ Dobrodružstvo", "1.st, 2.st, Dospelý"),
+        _FakePrevadzka("ZŠ Dobrodružstvo", "1.st; 2.st; Dospelý"),
     ]
 
     def test_each_prefix_maps_to_its_prevadzka(self):
         self.assertEqual(
             build_prevadzka_matches(self.DOBRODRUZSTVO),
             {
-                "MŠ": "MŠ Dobrodružstvo",
-                "1.st": "ZŠ Dobrodružstvo",
-                "2.st": "ZŠ Dobrodružstvo",
-                "Dospelý": "ZŠ Dobrodružstvo",
+                "MŠ": ["MŠ Dobrodružstvo"],
+                "1.st": ["ZŠ Dobrodružstvo"],
+                "2.st": ["ZŠ Dobrodružstvo"],
+                "Dospelý": ["ZŠ Dobrodružstvo"],
             },
         )
 
@@ -416,17 +454,17 @@ class TestBuildPrevadzkaMatches(unittest.TestCase):
         ]
         for nazov in skolka:
             self.assertEqual(
-                match_prevadzka(matches, nazov, ""), "MŠ Dobrodružstvo", nazov
+                match_prevadzka(matches, nazov, ""), ["MŠ Dobrodružstvo"], nazov
             )
         for nazov in skola:
             self.assertEqual(
-                match_prevadzka(matches, nazov, ""), "ZŠ Dobrodružstvo", nazov
+                match_prevadzka(matches, nazov, ""), ["ZŠ Dobrodružstvo"], nazov
             )
 
     def test_single_prefix_still_works(self):
         self.assertEqual(
             build_prevadzka_matches([_FakePrevadzka("Jolly 1", "J1")]),
-            {"J1": "Jolly 1"},
+            {"J1": ["Jolly 1"]},
         )
 
     def test_prevadzka_without_match_is_reported(self):
@@ -471,17 +509,17 @@ class TestParseSplit(unittest.TestCase):
         return EdupageScraper()._parse(html, TARGET, prevadzka_matches=matches)
 
     def test_counts_split_between_prevadzky(self):
-        res = self._parse([("1", 5), ("2", 3)], {"J1": "Jolly 1", "J2": "Jolly 2"})
+        res = self._parse([("1", 5), ("2", 3)], {"J1": ["Jolly 1"], "J2": ["Jolly 2"]})
         by = res.order_data_by_prevadzka
         self.assertEqual(by["Jolly 1"]["lunch"]["ZŠ 1.stupeň"]["menuCounts"]["A"], 5)
         self.assertEqual(by["Jolly 2"]["lunch"]["ZŠ 1.stupeň"]["menuCounts"]["A"], 3)
 
     def test_merged_order_data_is_the_sum(self):
-        res = self._parse([("1", 5), ("2", 3)], {"J1": "Jolly 1", "J2": "Jolly 2"})
+        res = self._parse([("1", 5), ("2", 3)], {"J1": ["Jolly 1"], "J2": ["Jolly 2"]})
         self.assertEqual(res.order_data["lunch"]["ZŠ 1.stupeň"]["menuCounts"]["A"], 8)
 
     def test_unmatched_row_is_reported_not_silently_dropped(self):
-        res = self._parse([("1", 5), ("9", 4)], {"J1": "Jolly 1"})
+        res = self._parse([("1", 5), ("9", 4)], {"J1": ["Jolly 1"]})
         self.assertEqual(res.order_data["lunch"]["ZŠ 1.stupeň"]["menuCounts"]["A"], 5)
         self.assertTrue(res.unmatched_prevadzka)
         self.assertTrue(res.warnings, "nezaradený riadok musí byť scrape failure")
@@ -497,11 +535,12 @@ class TestMatchPrevadzkaPrefixOnly(unittest.TestCase):
 
     def test_substring_in_middle_does_not_match(self):
         # "Les" sa vyskytuje v strede, nie ako prefix → nesmie matchnúť.
-        self.assertIsNone(
-            match_prevadzka({"Les": "Školička Les"}, "Bez Lesných plodov", "")
+        self.assertEqual(
+            match_prevadzka({"Les": ["Školička Les"]}, "Bez Lesných plodov", ""), []
         )
 
     def test_prefix_matches(self):
         self.assertEqual(
-            match_prevadzka({"Les": "Školička Les"}, "Les učiteľ", ""), "Školička Les"
+            match_prevadzka({"Les": ["Školička Les"]}, "Les učiteľ", ""),
+            ["Školička Les"],
         )

--- a/backend/api/tests/test_harok1_facility_commands.py
+++ b/backend/api/tests/test_harok1_facility_commands.py
@@ -1,11 +1,13 @@
+import datetime
 from pathlib import Path
 
 import pytest
 from django.contrib.auth.models import User
 from django.core.management import call_command
+from django.utils import timezone
 from openpyxl import Workbook
 
-from api.models import Celok, Prevadzka, UserProfile
+from api.models import Celok, DailyOrder, Prevadzka, UserProfile
 
 
 def _workbook(path: Path, rows: list[list[object]]) -> Path:
@@ -151,3 +153,47 @@ def test_rename_harok1_does_not_rewrite_unrelated_profile_subset(tmp_path, monke
     target_prevadzka.refresh_from_db()
     assert profile.company_name == "Iný login"
     assert target_prevadzka.nazov == "MŠ Zdravé Bruško"
+
+
+@pytest.mark.django_db
+def test_seed_zdrave_brusko_preserves_old_history_and_removes_future_duplicates():
+    stary = Celok.objects.create(nazov="MŠ Zdravé Bruško", zdroj_objednavok="edupage")
+    stara_prevadzka = Prevadzka.objects.create(celok=stary, nazov="MŠ Zdravé Bruško")
+    user = User.objects.create_user(
+        username="zdravebrusko@edupage.local",
+        email="zdravebrusko@edupage.local",
+    )
+    UserProfile.objects.create(
+        user=user,
+        company_name="MŠ Zdravé Bruško",
+        celok=stary,
+        is_edupage=True,
+    )
+    dnes = timezone.localdate()
+    historicka = DailyOrder.objects.create(
+        user=user,
+        prevadzka=stara_prevadzka,
+        date=dnes - datetime.timedelta(days=1),
+        data={"lunch": {"Škôlka": {"menuCounts": {"A": 1}, "diets": {}}}},
+    )
+    duplicitna = DailyOrder.objects.create(
+        user=user,
+        prevadzka=stara_prevadzka,
+        date=dnes,
+        data={"lunch": {"Škôlka": {"menuCounts": {"A": 2}, "diets": {}}}},
+    )
+
+    call_command("seed_zdrave_brusko")
+
+    assert Celok.objects.filter(pk=stary.pk).exists()
+    stara_prevadzka.refresh_from_db()
+    assert stara_prevadzka.is_active is False
+    assert DailyOrder.objects.filter(pk=historicka.pk).exists()
+    assert not DailyOrder.objects.filter(pk=duplicitna.pk).exists()
+    assert set(user.profile.prevadzky.values_list("nazov", flat=True)) == {
+        "Deutsche schule",
+        "SŠ VETERINÁRNA",
+        "ZŠ Malokarpatská",
+        "MŠ Heyrovského 4",
+        "MŠ Malokarpatké námestie 6",
+    }

--- a/backend/api/tests/test_utils.py
+++ b/backend/api/tests/test_utils.py
@@ -1,0 +1,88 @@
+import datetime
+
+import pytest
+from django.contrib.auth.models import User
+
+from api.models import Celok, DailyOrder, Prevadzka, UserProfile
+from api.utils import filter_order_data_for_prevadzka, order_row_label
+
+
+def _user_with_profile(email: str, company_name: str, celok=None):
+    user = User.objects.create_user(username=email, email=email)
+    profile = UserProfile.objects.create(user=user, company_name=company_name)
+    profile.celok = celok
+    profile.save(update_fields=["celok"])
+    return user, profile
+
+
+@pytest.mark.django_db
+class TestOrderRowLabel:
+    def test_single_prevadzka_same_celok_keeps_login_label(self):
+        celok = Celok.objects.create(nazov="MŠ Felix Karlovská")
+        prevadzka = Prevadzka.objects.create(celok=celok, nazov="MŠ Felix Karlovská")
+        user, _ = _user_with_profile(
+            "felix@example.com", "MŠ Felix Karlovská", celok=celok
+        )
+        order = DailyOrder.objects.create(
+            user=user,
+            prevadzka=prevadzka,
+            date=datetime.date(2026, 7, 17),
+            data={},
+        )
+
+        assert order_row_label(order) == "MŠ Felix Karlovská"
+
+    def test_cross_celok_edupage_login_uses_actual_celok_label(self):
+        celok = Celok.objects.create(nazov="Deutsche schule")
+        prevadzka = Prevadzka.objects.create(celok=celok, nazov="Deutsche schule")
+        user, profile = _user_with_profile(
+            "zdravebrusko@edupage.local", "MŠ Zdravé Bruško", celok=None
+        )
+        profile.prevadzky.add(prevadzka)
+        order = DailyOrder.objects.create(
+            user=user,
+            prevadzka=prevadzka,
+            date=datetime.date(2026, 7, 17),
+            data={},
+        )
+
+        assert order_row_label(order) == "Deutsche schule"
+
+    def test_cross_celok_with_multiple_prevadzky_in_celok_includes_prevadzka(self):
+        celok = Celok.objects.create(nazov="Jolly Homeschool")
+        jolly_1 = Prevadzka.objects.create(celok=celok, nazov="Jolly 1")
+        Prevadzka.objects.create(celok=celok, nazov="Jolly 2")
+        user, profile = _user_with_profile(
+            "shared@example.com", "Spoločný EduPage", celok=None
+        )
+        profile.prevadzky.add(jolly_1)
+        order = DailyOrder.objects.create(
+            user=user,
+            prevadzka=jolly_1,
+            date=datetime.date(2026, 7, 17),
+            data={},
+        )
+
+        assert order_row_label(order) == "Jolly Homeschool – Jolly 1"
+
+
+class TestFilterOrderDataForPrevadzka:
+    def test_deutsche_schule_serves_lunch_only(self):
+        data = {
+            "breakfast": {"Deutsche schule": {"Škôlka": {"menuCounts": {"A": 5}}}},
+            "lunch": {"Deutsche schule": {"Škôlka": {"menuCounts": {"A": 56}}}},
+            "olovrant": {"Deutsche schule": {"Škôlka": {"menuCounts": {"A": 57}}}},
+        }
+
+        assert filter_order_data_for_prevadzka(data, "Deutsche schule") == {
+            "lunch": {"Deutsche schule": {"Škôlka": {"menuCounts": {"A": 56}}}}
+        }
+
+    def test_other_prevadzka_is_unchanged(self):
+        data = {
+            "breakfast": {"MŠ Felix Karlovská": {}},
+            "lunch": {"MŠ Felix Karlovská": {}},
+            "olovrant": {"MŠ Felix Karlovská": {}},
+        }
+
+        assert filter_order_data_for_prevadzka(data, "MŠ Felix Karlovská") == data

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -1,11 +1,22 @@
 """Shared utility functions for report processing."""
 
 import datetime
+import unicodedata
 from typing import Any, Dict
 
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from .order_data import OrderData
+
+NON_SERVED_ORDER_MEALS_BY_PREVADZKA = {
+    "deutsche schule": {"breakfast", "olovrant"},
+}
+
+
+def _meal_rule_key(value: object) -> str:
+    normalized = unicodedata.normalize("NFKD", str(value or "").casefold())
+    ascii_value = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return " ".join(ascii_value.replace(".", " ").replace("-", " ").split())
 
 
 def parse_date_param(date_str: str, param: str = "date") -> datetime.date:
@@ -38,9 +49,27 @@ def order_row_label(order) -> str:
     # Iterujeme cez .all(), nie .filter().count(): pri prefetchnutom
     # `prevadzka__celok__prevadzky` to nespustí dotaz na každý riadok reportu.
     aktivne = sum(1 for p in celok.prevadzky.all() if p.is_active)
+
+    profile = getattr(order.user, "profile", None)
+    profile_celok_id = getattr(profile, "celok_id", None) if profile else None
+    if profile_celok_id != celok.id:
+        if aktivne > 1:
+            return f"{celok.nazov} – {prevadzka.nazov}"
+        return celok.nazov or prevadzka.nazov
+
     if aktivne > 1:
         return f"{celok.nazov} – {prevadzka.nazov}"
     return user_operation_name(order.user)
+
+
+def filter_order_data_for_prevadzka(
+    order_data: Dict[str, Any], prevadzka_nazov: str
+) -> Dict[str, Any]:
+    """Apply prevádzka-specific meal availability rules to imported order data."""
+    blocked = NON_SERVED_ORDER_MEALS_BY_PREVADZKA.get(_meal_rule_key(prevadzka_nazov))
+    if not blocked:
+        return order_data
+    return {meal: data for meal, data in order_data.items() if meal not in blocked}
 
 
 def build_user_meal_row(order_data: Dict[str, Any], meal_key: str) -> Dict[str, Any]:

--- a/backend/api/views/edupage_views.py
+++ b/backend/api/views/edupage_views.py
@@ -16,6 +16,7 @@ from ..edupage_scraper import (
     prevadzky_without_match,
 )
 from ..models import DailyOrder, EdupageUpload, UserProfile
+from ..utils import filter_order_data_for_prevadzka
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ class AdminEdupageUploadViewSet(viewsets.ReadOnlyModelViewSet):
         scraper = EdupageScraper()
 
         for profile in qs.select_related("user", "celok").prefetch_related(
-            "celok__prevadzky"
+            "celok__prevadzky", "prevadzky"
         ):
             if not profile.mealsguest_url:
                 results.append(
@@ -180,11 +181,7 @@ class AdminEdupageUploadViewSet(viewsets.ReadOnlyModelViewSet):
                 )
                 continue
 
-            prevadzky = (
-                list(profile.celok.prevadzky.filter(is_active=True))
-                if profile.celok_id
-                else []
-            )
+            prevadzky = list(profile.dostupne_prevadzky())
             if not prevadzky:
                 results.append(
                     {
@@ -266,6 +263,7 @@ class AdminEdupageUploadViewSet(viewsets.ReadOnlyModelViewSet):
                     order_data = nest_order_data_by_category(
                         data_by_nazov.get(nazov, {}), nazov
                     )
+                    order_data = filter_order_data_for_prevadzka(order_data, nazov)
                     order, created = DailyOrder.objects.update_or_create(
                         prevadzka=prevadzka,
                         date=target_date,

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -26,7 +26,7 @@ services:
     build:
       context: ../backend
       dockerfile: Dockerfile
-    command: sh -c "python manage.py migrate && python manage.py init_roles && python manage.py init_reference_data && python manage.py ensure_global_settings && python manage.py real_initial_seed_prevadzky && python manage.py sync_periodic_tasks --fix && python manage.py scrape_edupage_orders && python manage.py runserver 0.0.0.0:8000"
+    command: sh -c "python manage.py migrate && python manage.py init_roles && python manage.py init_reference_data && python manage.py ensure_global_settings && python manage.py real_initial_seed_prevadzky && python manage.py seed_prevadzky_edupage && python manage.py seed_zdrave_brusko && python manage.py sync_periodic_tasks --fix && python manage.py scrape_edupage_orders && python manage.py runserver 0.0.0.0:8000"
     volumes:
       - ../backend:/app
     ports:

--- a/feedback.md
+++ b/feedback.md
@@ -148,3 +148,39 @@ Reconcile na 15.7 zlyhal len preto, že v dev DB nebol **meal plán** pre daný 
 medzitým vyresetovaná), nie kvôli formátu. Kľúčové obedy (kde sa olovrant fakturuje
 samostatne, teda total = obed) sedia presne: Zdravé Bruško (Deutsche schule) 69/69,
 Felix 10/10, Filipa Nériho 21/21.
+
+---
+
+## ❗ Zdravé Brúsko — MŠ Malokarpatské a MŠ Heyrovského zdieľajú stĺpec (desiata + olovrant)
+
+`zdravebrusko.edupage.org` nie je škola, je to spoločný EduPage piatich **samostatných
+subjektov**, ktoré fakturujú každý zvlášť (spoločný EduPage nie je príznak celku).
+Rozdelenie ide cez skratku menu (`nazovMenu`), nie cez payer label — payer je jediný
+(`Škôlka`) a nerozlišuje nič.
+
+Overené naživo proti EduPage (17.7.2026):
+
+| Chod | Písmená menu → škola |
+|------|----------------------|
+| Desiata | `A`=dsbA · `B`=sšvA · **`C`=mšMal,Hey** |
+| Obed | `A`–`F`,`J`=dsb · `G`–`I`=sšv · `K`,`L`,`R`=zšla · `M`–`O`=mšMal · `P`,`Q`=mšHey |
+| Olovrant | `A`=dsbA · `B`=sšvA · **`C`=mšMal,Hey** |
+
+**Špeciálne pravidlo:** `Deutsche schule` síce v EduPage vie niesť skratky pri desiate
+alebo olovrante, ale reálne sa pre ňu tieto chody nevydávajú ani nefakturujú. Pri
+importe sa preto pre `Deutsche schule` ponecháva iba obed; raňajky/desiata a olovrant
+sa ignorujú.
+
+**❗ Otvorené — treba rozhodnutie klienta:** menu `C` (`mšMal,Hey`) zlučuje **MŠ
+Malokarpatské námestie 6** a **MŠ Heyrovského 4** do jedného stĺpca pri **desiate a
+olovrante**. Z dát sa nedá zistiť, koľko z toho počtu patrí ktorej škôlke — a keďže
+fakturujú samostatne, nedá sa to ani odhadnúť. Pri obede sú rozlíšené (`M`/`N`/`O` vs
+`P`/`Q`), problém je len desiata + olovrant.
+
+**Dočasné riešenie:** desiatu a olovrant z menu `C` zapisujeme **naplno obom** škôlkam
+(nie delené na polovicu). Znamená to, že súčet porcií cez celý EduPage bude o tento
+počet vyšší než realita a **fakturácia oboch škôlok je nadhodnotená**, kým klient
+nerozdelí `C` na dve menu v EduPage konfigu. Toto je vedomý dočasný stav, nie chyba.
+
+**Poznámka:** veterinárna sa tohto netýka — `sšv*` má vlastné skratky vo všetkých
+troch chodoch.

--- a/frontend/src/pages/admin/ClientList.test.tsx
+++ b/frontend/src/pages/admin/ClientList.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ClientList from "./ClientList";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("../../context/auth", () => ({
+  useAuth: () => ({ apiFetch: mockApiFetch }),
+}));
+
+vi.mock("../../context/ToastContext", () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const operation = {
+  id: 1,
+  email: "palysady@example.com",
+  profile: {
+    company_name: "Palisády",
+    billing_name: "Palisády s.r.o.",
+  },
+  is_active: true,
+  is_staff: false,
+};
+
+const operationDetail = {
+  ...operation,
+  profile: {
+    ...operation.profile,
+    ico: "12345678",
+    dic: "2020123456",
+    is_edupage: false,
+    api_identifier: "",
+    mealsguest_url: "",
+  },
+};
+
+const response = (payload: unknown, ok = true) => ({
+  ok,
+  status: ok ? 200 : 400,
+  json: () => Promise.resolve(payload),
+});
+
+describe("ClientList", () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url.endsWith("/admin/users/1/")) {
+        return Promise.resolve(response(operationDetail));
+      }
+      if (url.endsWith("/admin/users/")) {
+        return Promise.resolve(response([operation]));
+      }
+      return Promise.resolve(response({}));
+    });
+  });
+
+  it("keeps focus in the edit operation input while typing", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ClientList />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("Palisády");
+    await user.click(screen.getByRole("button", { name: "Upraviť" }));
+
+    const operationNameInput = screen.getByLabelText(/názov prevádzky/i) as HTMLInputElement;
+
+    await waitFor(() => {
+      expect(operationNameInput).toHaveValue("Palisády");
+    });
+
+    await user.clear(operationNameInput);
+    await user.type(operationNameInput, "Krásňanko");
+
+    expect(operationNameInput).toHaveValue("Krásňanko");
+    expect(operationNameInput).toHaveFocus();
+    expect(operationNameInput).toBe(document.activeElement);
+  });
+});

--- a/frontend/src/pages/admin/ClientList.tsx
+++ b/frontend/src/pages/admin/ClientList.tsx
@@ -36,6 +36,91 @@ const EMPTY_OPERATION_FORM: OperationForm = {
   mealsguest_url: "",
 };
 
+interface OperationFieldsProps {
+  form: OperationForm;
+  setForm: React.Dispatch<React.SetStateAction<OperationForm>>;
+  source: "create" | "edit";
+  testingUrl: "create" | "edit" | null;
+  urlTestResult: { ok: boolean; message: string } | null;
+  onClearUrlTestResult: () => void;
+  onTestMealsguestUrl: (url: string, source: "create" | "edit") => void;
+}
+
+const OperationFields: React.FC<OperationFieldsProps> = ({
+  form,
+  setForm,
+  source,
+  testingUrl,
+  urlTestResult,
+  onClearUrlTestResult,
+  onTestMealsguestUrl,
+}) => (
+  <>
+    <Field label="Názov prevádzky" req hint="(interný)">
+      <Input required value={form.company_name} onChange={(e) => setForm((f) => ({ ...f, company_name: e.target.value }))} />
+    </Field>
+    <Field label="Názov spoločnosti" hint="(fakturácia)">
+      <Input value={form.billing_name} onChange={(e) => setForm((f) => ({ ...f, billing_name: e.target.value }))} />
+    </Field>
+    <Field label="Email" req>
+      <Input type="email" required value={form.email} onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} />
+    </Field>
+    <div className="zpa-grid-2">
+      <Field label="IČO">
+        <Input value={form.ico} onChange={(e) => setForm((f) => ({ ...f, ico: e.target.value }))} />
+      </Field>
+      <Field label="DIČ">
+        <Input value={form.dic} onChange={(e) => setForm((f) => ({ ...f, dic: e.target.value }))} />
+      </Field>
+    </div>
+    <Checkbox
+      on={form.is_edupage}
+      onChange={(v) => {
+        setForm((f) => ({ ...f, is_edupage: v, ...(!v && { api_identifier: "", mealsguest_url: "" }) }));
+        onClearUrlTestResult();
+      }}
+    >
+      Edupage prevádzka
+    </Checkbox>
+    {form.is_edupage && (
+      <>
+        <Field label="Edupage identifikátor">
+          <Input
+            placeholder="Identifikátor pre párovanie v Edupage súboroch"
+            value={form.api_identifier}
+            onChange={(e) => setForm((f) => ({ ...f, api_identifier: e.target.value }))}
+          />
+        </Field>
+        <Field label="MealsGuest URL">
+          <div style={{ display: "flex", gap: 8 }}>
+            <Input
+              placeholder="https://skola.edupage.org/menu/mealsGuest?id=TOKEN"
+              value={form.mealsguest_url}
+              onChange={(e) => {
+                setForm((f) => ({ ...f, mealsguest_url: e.target.value }));
+                onClearUrlTestResult();
+              }}
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={testingUrl === source}
+              onClick={() => onTestMealsguestUrl(form.mealsguest_url, source)}
+            >
+              {testingUrl === source ? "Testujem…" : "Test"}
+            </Button>
+          </div>
+          {urlTestResult && (
+            <p style={{ marginTop: 6, fontSize: 12, color: urlTestResult.ok ? "var(--green-600)" : "var(--coral-600)" }}>
+              {urlTestResult.message}
+            </p>
+          )}
+        </Field>
+      </>
+    )}
+  </>
+);
+
 const ClientList: React.FC = () => {
   const { apiFetch } = useAuth();
   const { success, error: toastError } = useToast();
@@ -214,61 +299,6 @@ const ClientList: React.FC = () => {
       (u.profile?.billing_name ?? "").toLowerCase().includes(searchTerm.toLowerCase()),
   );
 
-  // Shared operation form body (create + edit)
-  const OperationFields: React.FC<{
-    form: OperationForm;
-    setForm: React.Dispatch<React.SetStateAction<OperationForm>>;
-    source: "create" | "edit";
-  }> = ({ form, setForm, source }) => (
-    <>
-      <Field label="Názov prevádzky" req hint="(interný)">
-        <Input required value={form.company_name} onChange={(e) => setForm((f) => ({ ...f, company_name: e.target.value }))} />
-      </Field>
-      <Field label="Názov spoločnosti" hint="(fakturácia)">
-        <Input value={form.billing_name} onChange={(e) => setForm((f) => ({ ...f, billing_name: e.target.value }))} />
-      </Field>
-      <Field label="Email" req>
-        <Input type="email" required value={form.email} onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} />
-      </Field>
-      <div className="zpa-grid-2">
-        <Field label="IČO">
-          <Input value={form.ico} onChange={(e) => setForm((f) => ({ ...f, ico: e.target.value }))} />
-        </Field>
-        <Field label="DIČ">
-          <Input value={form.dic} onChange={(e) => setForm((f) => ({ ...f, dic: e.target.value }))} />
-        </Field>
-      </div>
-      <Checkbox
-        on={form.is_edupage}
-        onChange={(v) => { setForm((f) => ({ ...f, is_edupage: v, ...(!v && { api_identifier: "", mealsguest_url: "" }) })); setUrlTestResult(null); }}
-      >
-        Edupage prevádzka
-      </Checkbox>
-      {form.is_edupage && (
-        <>
-          <Field label="Edupage identifikátor">
-            <Input placeholder="Identifikátor pre párovanie v Edupage súboroch" value={form.api_identifier} onChange={(e) => setForm((f) => ({ ...f, api_identifier: e.target.value }))} />
-          </Field>
-          <Field label="MealsGuest URL">
-            <div style={{ display: "flex", gap: 8 }}>
-              <Input
-                placeholder="https://skola.edupage.org/menu/mealsGuest?id=TOKEN"
-                value={form.mealsguest_url}
-                onChange={(e) => { setForm((f) => ({ ...f, mealsguest_url: e.target.value })); setUrlTestResult(null); }}
-              />
-              <Button type="button" variant="secondary" disabled={testingUrl === source} onClick={() => testMealsguestUrl(form.mealsguest_url, source)}>
-                {testingUrl === source ? "Testujem…" : "Test"}
-              </Button>
-            </div>
-            {urlTestResult && (
-              <p style={{ marginTop: 6, fontSize: 12, color: urlTestResult.ok ? "var(--green-600)" : "var(--coral-600)" }}>{urlTestResult.message}</p>
-            )}
-          </Field>
-        </>
-      )}
-    </>
-  );
-
   return (
     <>
       <PageHead
@@ -353,7 +383,15 @@ const ClientList: React.FC = () => {
           }
         >
           <form id="create-op-form" onSubmit={handleCreate} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <OperationFields form={clientForm} setForm={setClientForm} source="create" />
+            <OperationFields
+              form={clientForm}
+              setForm={setClientForm}
+              source="create"
+              testingUrl={testingUrl}
+              urlTestResult={urlTestResult}
+              onClearUrlTestResult={() => setUrlTestResult(null)}
+              onTestMealsguestUrl={testMealsguestUrl}
+            />
           </form>
         </Modal>
       )}
@@ -373,7 +411,15 @@ const ClientList: React.FC = () => {
           }
         >
           <form id="edit-op-form" onSubmit={handleEdit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <OperationFields form={editForm} setForm={setEditForm} source="edit" />
+            <OperationFields
+              form={editForm}
+              setForm={setEditForm}
+              source="edit"
+              testingUrl={testingUrl}
+              urlTestResult={urlTestResult}
+              onClearUrlTestResult={() => setUrlTestResult(null)}
+              onTestMealsguestUrl={testMealsguestUrl}
+            />
           </form>
         </Modal>
       )}


### PR DESCRIPTION
## Summary
- split Zdravé Brúsko/Dobrodružstvo and Hárok1 reconciliation logic across real facilities
- preserve old Zdravé Brúsko history while deleting only current/future duplicate aggregate orders
- update compare-real guidance to use Hárok1 as count/gram authority
- extract ClientList operation fields so modal input focus is stable

## Validation
- `docker compose -f compose/dev.yml exec -T backend python -m pytest api/tests -q --no-cov -p no:cacheprovider`
- `docker compose -f compose/dev.yml exec -T backend sh -lc 'mypy --config-file mypy.ini --ignore-missing-imports api/edupage_scraper.py api/management/commands/reconcile_real.py api/management/commands/seed_zdrave_brusko.py api/management/commands/seed_facilities_from_harok1.py api/management/commands/seed_prevadzky_edupage.py api/utils.py'`
- `npm --prefix frontend test -- --run`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
