### PR TITLE
fix: repo-managed backend CPU alert

### DIFF
--- a/observability/terraform/grafana-alerts/main.tf
+++ b/observability/terraform/grafana-alerts/main.tf
@@ -66,6 +66,16 @@ locals {
       description     = "Database connection errors appeared in ${var.environment}. Check Postgres availability, max connections, and backend logs."
     }
 
+    high_backend_cpu = {
+      name            = "High backend CPU"
+      expr            = "sum(rate(container_cpu_usage_seconds_total{environment=\"${var.environment}\",job=\"cadvisor\",name=~\".*backend.*\",image!=\"\"}[5m]))"
+      math_expression = "$B > ${var.high_backend_cpu_cores}"
+      for             = "10m"
+      severity        = "warning"
+      summary         = "Backend container CPU is above ${var.high_backend_cpu_cores} cores"
+      description     = "Sustained high CPU on backend containers in ${var.environment}. Check traffic, slow endpoints, DB load, and Celery jobs. Replaces the unmanaged Grafana Cloud \"Django - High CPU\" preset alert."
+    }
+
     backend_oom_killed = {
       name            = "Backend OOM killed"
       expr            = "sum(increase(container_oom_events_total{environment=\"${var.environment}\",job=\"cadvisor\",name=~\".*backend.*\"}[5m]))"

--- a/observability/terraform/grafana-alerts/variables.tf
+++ b/observability/terraform/grafana-alerts/variables.tf
@@ -50,6 +50,12 @@ variable "high_p95_latency_seconds" {
   default     = 3
 }
 
+variable "high_backend_cpu_cores" {
+  description = "Warning threshold for sustained backend container CPU usage, in CPU cores."
+  type        = number
+  default     = 0.9
+}
+
 variable "backend_recent_restart_seconds" {
   description = "How long after a backend container start to alert about a recent restart."
   type        = number


### PR DESCRIPTION
## Problém
Grafana posielal opakovane `DatasourceNoData` pre alert **Django - High CPU** (a **Django - High p99 Latency**). Šlo o prednastavené pravidlá z Grafana Cloud „Django integration" presetu (priečinok *GrafanaCloud*), ktoré očakávali metriky/labely, aké náš Alloy pipeline neposiela → navždy No Data. Tie orphan pravidlá už boli ručne zmazané v Grafana Cloud.

## Zmena
Pridané terraform-managed pravidlo **High backend CPU** (`observability/terraform/grafana-alerts/`), ktoré používa cAdvisor metriku reálne posielanú Alloy (`container_cpu_usage_seconds_total{job="cadvisor", name=~".*backend.*"}`):
- prah cez novú premennú `high_backend_cpu_cores` (default 0.9 jadra)
- `for = 10m`, severity `warning`
- **NoData → OK** (žiadny šum pri nulovej prevádzke)

p99 latency zámerne nepridané — už existuje `high_p95_latency`.

## Overenie
- `terraform fmt -check` ✅
- `terraform validate` ✅ (cez `hashicorp/terraform:1.10.5`, rovnako ako CI)

## Súvis
Nadväzuje na `f5946b7` (Fix observability sample forwarding), ktorý odstránil chybné cAdvisor `keep` pravidlo v Alloy — over, že je nasadený na prode a Alloy beží s novým configom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)