### PR TITLE
fix: unblock Grafana alerts apply (plan backend init)

### DIFF
--- a/.github/workflows/grafana-alerts.yml
+++ b/.github/workflows/grafana-alerts.yml
@@ -65,7 +65,7 @@ jobs:
             -e TF_VAR_environment \
             -e TF_DATA_DIR=/tmp/terraform-data \
             --entrypoint sh \
-            "$TF_IMAGE" -c "terraform init -backend=false -lockfile=readonly && terraform plan -no-color"
+            "$TF_IMAGE" -c "terraform init -backend-config=path=/tmp/plan-state.tfstate -lockfile=readonly && terraform plan -no-color"
 
       - name: Explain skipped plan
         if: ${{ env.TF_VAR_grafana_url == '' || env.TF_VAR_grafana_auth == '' || env.TF_VAR_prometheus_datasource_uid == '' }}


### PR DESCRIPTION
## Problém
Predchádzajúci `backend "local"` blok (pridaný pre auto-apply na self-hosted runneri) rozbil `terraform plan` v `validate-and-plan` jobe, ktorý beží s `init -backend=false`. Plan padal na `Backend initialization required` → job zlyhal → `apply` job (má `needs: validate-and-plan`) sa **preskočil**, takže sa alerty do Grafany nikdy nenasadili.

## Oprava
Plan-krok teraz inicializuje backend so **zahadzovacím** state path (`-backend-config=path=/tmp/plan-state.tfstate`), takže plan prebehne bez dotyku perzistentného state na runneri. Apply job ostáva nezmenený.

## Overenie
- `terraform init -backend-config=path=/tmp/plan-state.tfstate` + `terraform validate` ✅ (docker `hashicorp/terraform:1.10.5`)

Po merge push do `main` znovu spustí workflow — tentokrát validate prejde a **apply job po prvýkrát reálne vytvorí** folder „Zdravy Projekt" + 12 pravidiel (vrátane „High backend CPU") v Grafane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)