### PR TITLE
fix: admin editor objednávok

### DIFF
--- a/backend/api/migrations/0052_diet_sort_order_prevadzka_visible_menus_per_meal.py
+++ b/backend/api/migrations/0052_diet_sort_order_prevadzka_visible_menus_per_meal.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+
+
+def seed_visible_menus_per_meal(apps, schema_editor):
+    Prevadzka = apps.get_model("api", "Prevadzka")
+    for prevadzka in Prevadzka.objects.all().iterator():
+        next_value = dict(prevadzka.visible_menus_per_meal or {})
+        next_value["breakfast"] = ["A"]
+        next_value["olovrant"] = ["A"]
+        prevadzka.visible_menus_per_meal = next_value
+        prevadzka.save(update_fields=["visible_menus_per_meal"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0051_prevadzka_pack_separately_enabled"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="diet",
+            name="sort_order",
+            field=models.PositiveSmallIntegerField(db_index=True, default=0),
+        ),
+        migrations.AlterModelOptions(
+            name="diet",
+            options={"ordering": ["sort_order", "name"]},
+        ),
+        migrations.AddField(
+            model_name="prevadzka",
+            name="visible_menus_per_meal",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text=(
+                    "Voliteľné menu typy per chod, napr. "
+                    "{'breakfast': ['A'], 'olovrant': ['A']}. Chýbajúci chod = fallback "
+                    "na visible_menus."
+                ),
+            ),
+        ),
+        migrations.RunPython(seed_visible_menus_per_meal, migrations.RunPython.noop),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -89,6 +89,7 @@ class DailyOrder(models.Model):
 
 class Diet(models.Model):
     name = models.CharField(max_length=100, unique=True)
+    sort_order = models.PositiveSmallIntegerField(default=0, db_index=True)
     is_active = models.BooleanField(default=True)
     description = models.TextField(blank=True, null=True)
     color = models.CharField(
@@ -97,6 +98,9 @@ class Diet(models.Model):
         default="",
         help_text="Voliteľná HEX farba pre admin prehľady, napr. #F97316.",
     )
+
+    class Meta:
+        ordering = ["sort_order", "name"]
 
     def __str__(self) -> str:
         return self.name
@@ -398,6 +402,15 @@ class Prevadzka(models.Model):
         blank=True,
         help_text="Menu typy dostupné pre objednávky tejto prevádzky.",
     )
+    visible_menus_per_meal = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text=(
+            "Voliteľné menu typy per chod, napr. "
+            "{'breakfast': ['A'], 'olovrant': ['A']}. Chýbajúci chod = fallback "
+            "na visible_menus."
+        ),
+    )
     visible_meals = models.JSONField(
         default=_default_all_meals,
         blank=True,
@@ -442,6 +455,12 @@ class Prevadzka(models.Model):
 
     def __str__(self) -> str:
         return self.nazov
+
+    def resolved_visible_menus_for_meal(self, meal: str) -> list[str]:
+        configured = (self.visible_menus_per_meal or {}).get(meal)
+        if configured is None:
+            return list(self.visible_menus or [])
+        return list(configured)
 
 
 class DeliveryBlock(models.Model):

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -470,5 +470,14 @@ class PrevadzkaSerializer(serializers.ModelSerializer):
         model = Prevadzka
         # `pack_separately_enabled` sem patrí, aby klient čítal príznak z toho istého
         # miesta, kam ho admin zapisuje (Prevadzka) — nie z legacy ClientSettings.
-        fields = ["id", "nazov", "adresa", "celok", "pack_separately_enabled"]
+        fields = [
+            "id",
+            "nazov",
+            "adresa",
+            "celok",
+            "visible_menus",
+            "visible_menus_per_meal",
+            "visible_meals",
+            "pack_separately_enabled",
+        ]
         read_only_fields = fields

--- a/backend/api/serializers_facilities.py
+++ b/backend/api/serializers_facilities.py
@@ -74,6 +74,7 @@ class AdminPrevadzkaSerializer(serializers.ModelSerializer):
             "is_active",
             "billing_portion_coefficients",
             "visible_menus",
+            "visible_menus_per_meal",
             "visible_meals",
             "visible_diets",
             "pack_separately_enabled",

--- a/backend/api/serializers_user.py
+++ b/backend/api/serializers_user.py
@@ -16,7 +16,7 @@ class DietSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Diet
-        fields = ["id", "name", "is_active", "description", "color"]
+        fields = ["id", "name", "sort_order", "is_active", "description", "color"]
 
 
 def validate_password_strength(password: str, user: User | None = None) -> str:

--- a/backend/api/tests/integration/test_diet_api.py
+++ b/backend/api/tests/integration/test_diet_api.py
@@ -1,0 +1,39 @@
+import pytest
+
+from api.models import Diet
+from api.tests.factories import AdminUserFactory
+
+
+@pytest.mark.django_db
+def test_diet_list_respects_sort_order_then_name(api_client):
+    """Hlavné diéty musia ísť hore — poradie riadi `sort_order`, až potom názov."""
+    admin = AdminUserFactory()
+    api_client.force_authenticate(user=admin)
+    Diet.objects.create(name="Zulu", sort_order=0)
+    Diet.objects.create(name="Alpha", sort_order=5)
+    Diet.objects.create(name="Beta", sort_order=0)
+
+    response = api_client.get("/api/diets/")
+
+    assert response.status_code == 200
+    # Odpoveď je stránkovaná, takže položky sú pod "results".
+    payload = response.json()
+    items = payload["results"] if isinstance(payload, dict) else payload
+    names = [item["name"] for item in items]
+
+    # Zulu a Beta majú sort_order 0 → idú pred Alpha (5), medzi sebou podľa názvu.
+    assert names.index("Beta") < names.index("Zulu") < names.index("Alpha")
+
+
+@pytest.mark.django_db
+def test_diet_model_ordering_is_sort_order_then_name():
+    """Ordering musí platiť na úrovni modelu, nie len v jednom endpointe."""
+    Diet.objects.create(name="Zulu", sort_order=0)
+    Diet.objects.create(name="Alpha", sort_order=5)
+    Diet.objects.create(name="Beta", sort_order=0)
+
+    assert list(Diet.objects.values_list("name", flat=True)) == [
+        "Beta",
+        "Zulu",
+        "Alpha",
+    ]

--- a/backend/api/tests/test_migrations.py
+++ b/backend/api/tests/test_migrations.py
@@ -1,0 +1,74 @@
+"""Testy dátovej migrácie 0052.
+
+Suite beží s `--nomigrations` (pozri `pytest.ini`), takže schéma vzniká priamo
+z modelov a migračný graf sa nikdy neprehráva. Migračnú funkciu preto voláme
+priamo a `apps` jej podstrčíme — testujeme tým jej logiku, nie mechaniku Django
+migrácií, ktorú aj tak netreba overovať.
+"""
+
+import pytest
+
+from api.migrations import (  # noqa: F401  (zaistí, že balík migrácií je importovateľný)
+    __name__ as _migrations_pkg,
+)
+from api.models import Celok, Prevadzka
+
+
+def _load_migration():
+    import importlib
+
+    return importlib.import_module(
+        "api.migrations.0052_diet_sort_order_prevadzka_visible_menus_per_meal"
+    )
+
+
+class _StubApps:
+    """Minimálna náhrada za historický registry — vracia reálne modely."""
+
+    def get_model(self, app_label, model_name):
+        assert app_label == "api"
+        return {"Prevadzka": Prevadzka, "Celok": Celok}[model_name]
+
+
+@pytest.mark.django_db
+def test_0052_seeds_breakfast_and_olovrant_visible_menus_per_meal():
+    migration = _load_migration()
+    celok = Celok.objects.create(nazov="Migracia")
+    prevadzka = Prevadzka.objects.create(
+        celok=celok,
+        nazov="Prevadzka",
+        visible_menus=["A", "B", "C", "V"],
+    )
+
+    migration.seed_visible_menus_per_meal(_StubApps(), None)
+
+    prevadzka.refresh_from_db()
+    assert prevadzka.visible_menus_per_meal == {
+        "breakfast": ["A"],
+        "olovrant": ["A"],
+    }
+    # Obed zámerne bez kľúča → padá späť na globálne visible_menus.
+    assert prevadzka.resolved_visible_menus_for_meal("lunch") == ["A", "B", "C", "V"]
+    assert prevadzka.resolved_visible_menus_for_meal("breakfast") == ["A"]
+
+
+@pytest.mark.django_db
+def test_0052_preserves_already_configured_meals():
+    """Migrácia nesmie prepísať to, čo už niekto nastavil pre iné chody."""
+    migration = _load_migration()
+    celok = Celok.objects.create(nazov="Migracia 2")
+    prevadzka = Prevadzka.objects.create(
+        celok=celok,
+        nazov="Prevadzka 2",
+        visible_menus=["A", "B"],
+        visible_menus_per_meal={"lunch": ["B"]},
+    )
+
+    migration.seed_visible_menus_per_meal(_StubApps(), None)
+
+    prevadzka.refresh_from_db()
+    assert prevadzka.visible_menus_per_meal == {
+        "lunch": ["B"],
+        "breakfast": ["A"],
+        "olovrant": ["A"],
+    }

--- a/backend/api/tests/test_prevadzka_service.py
+++ b/backend/api/tests/test_prevadzka_service.py
@@ -117,6 +117,49 @@ class TestPrevadzkaEndpoint:
     def test_requires_auth(self, api_client):
         assert api_client.get("/api/prevadzky/").status_code in (401, 403)
 
+    def test_exposes_per_meal_menu_visibility(self, api_client, celok):
+        # `on_prevadzka_saved` pri vytvorení prepíše visible_menus/visible_meals
+        # defaultmi, takže vlastné hodnoty treba nastaviť až po vzniku záznamu.
+        prevadzka = Prevadzka.objects.create(celok=celok, nazov="Jolly 1")
+        prevadzka.visible_menus = ["A", "B", "V"]
+        prevadzka.visible_menus_per_meal = {"breakfast": ["A"], "olovrant": ["A"]}
+        prevadzka.visible_meals = ["breakfast", "lunch", "olovrant"]
+        prevadzka.pack_separately_enabled = True
+        prevadzka.save()
+        user, _ = _profile("eva@example.com", celok)
+        api_client.force_authenticate(user=user)
+
+        response = api_client.get("/api/prevadzky/")
+
+        assert response.status_code == 200
+        assert response.json() == [
+            {
+                "id": prevadzka.id,
+                "nazov": "Jolly 1",
+                "adresa": "",
+                "celok": "Jolly",
+                "visible_menus": ["A", "B", "V"],
+                "visible_menus_per_meal": {
+                    "breakfast": ["A"],
+                    "olovrant": ["A"],
+                },
+                "visible_meals": ["breakfast", "lunch", "olovrant"],
+                "pack_separately_enabled": True,
+            }
+        ]
+
+
+@pytest.mark.django_db
+class TestPrevadzkaVisibleMenusPerMeal:
+    def test_falls_back_to_global_visible_menus_when_meal_key_missing(self, celok):
+        prevadzka = Prevadzka.objects.create(celok=celok, nazov="Fallback")
+        prevadzka.visible_menus = ["A", "B"]
+        prevadzka.visible_menus_per_meal = {"breakfast": ["A"]}
+        prevadzka.save()
+
+        assert prevadzka.resolved_visible_menus_for_meal("breakfast") == ["A"]
+        assert prevadzka.resolved_visible_menus_for_meal("lunch") == ["A", "B"]
+
 
 @pytest.mark.django_db
 class TestDailyOrderByDatePrevadzka:

--- a/backend/api/views/diet_views.py
+++ b/backend/api/views/diet_views.py
@@ -28,7 +28,7 @@ class DietViewSet(viewsets.ModelViewSet):
     via signal handlers.
     """
 
-    queryset = Diet.objects.all().order_by("-id")
+    queryset = Diet.objects.all()
     serializer_class = DietSerializer
     permission_classes = [permissions.IsAuthenticated]
 

--- a/frontend/src/context/auth.tsx
+++ b/frontend/src/context/auth.tsx
@@ -37,6 +37,7 @@ interface User {
 
 export interface UserSettings {
   visible_menus?: string[];
+  visible_menus_per_meal?: Record<string, string[]>;
   visible_meals?: string[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   visible_diets?: any[];

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1237,6 +1237,20 @@ select {
     color: var(--green-900);
     font-variant-numeric: tabular-nums;
 }
+.zp-counter .zp-counter-input {
+    width: 44px;
+    min-width: 44px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    outline: none;
+    appearance: textfield;
+}
+.zp-counter .zp-counter-input::-webkit-outer-spin-button,
+.zp-counter .zp-counter-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
 .zp-counter .count.zero { color: var(--ink-mute); }
 
 /* Order summary docked at bottom */

--- a/frontend/src/pages/admin/AdminOrderEditorModal.test.tsx
+++ b/frontend/src/pages/admin/AdminOrderEditorModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ReactNode } from 'react';
 import AdminOrderEditorModal from './AdminOrderEditorModal';
@@ -57,10 +57,33 @@ const BASE_PROPS = {
     visibleMenus: ['A', 'B'],
     visibleMeals: ['breakfast', 'lunch', 'olovrant'],
     visibleDiets: [1],
+    portionTypeNames: ['Jasle', 'Škôlka', 'ZŠ 1.stupeň', 'ZŠ 2.stupeň', 'Dospelý (SŠ)'],
+    packSeparatelyEnabled: false,
     allDiets: ALL_DIETS,
     existingOrder: null,
     onClose: vi.fn(),
     onSaved: vi.fn(),
+};
+
+const getRequestBody = () => {
+    const saveCall = mockApiFetch.mock.calls.find(([, options]) =>
+        options?.method === 'PATCH' || options?.method === 'POST',
+    );
+    expect(saveCall).toBeTruthy();
+    return JSON.parse(String(saveCall?.[1]?.body));
+};
+
+const getCategoryCard = (label: string) => {
+    const title = screen.getByText(label);
+    const card = title.closest('.zp-cat');
+    expect(card).toBeTruthy();
+    return card as HTMLElement;
+};
+
+const clickFirstPlus = (label: string) => {
+    const card = getCategoryCard(label);
+    const buttons = within(card).getAllByRole('button', { name: '+' });
+    fireEvent.click(buttons[0]);
 };
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -259,5 +282,166 @@ describe('AdminOrderEditorModal', () => {
         expect(screen.queryByText('Raňajky')).not.toBeInTheDocument();
         expect(screen.getByText('Obed')).toBeInTheDocument();
         expect(screen.queryByText('Olovrant')).not.toBeInTheDocument();
+    });
+
+    it('renders a category present in the order but absent from the hardcoded list and preserves it in the PATCH payload', async () => {
+        mockApiFetch.mockResolvedValueOnce(makeMockResponse({ id: 7 }, true));
+
+        render(
+            <AdminOrderEditorModal
+                {...BASE_PROPS}
+                existingOrder={{
+                    id: 7,
+                    date: '2026-07-30',
+                    data: {
+                        lunch: {
+                            Predškolák: {
+                                menuCounts: { A: 2 },
+                                diets: { 'Bez lepku': 0, 'Špeciálna': 0 },
+                            },
+                        },
+                    },
+                }}
+            />,
+        );
+
+        expect(screen.getByText('Predškolák')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /uložiť/i }));
+
+        await waitFor(() => {
+            const body = getRequestBody();
+            expect(body.data.lunch.Predškolák.menuCounts.A).toBe(2);
+        });
+    });
+
+    it('preserves special_diet_note in the PATCH payload when saving without editing it', async () => {
+        mockApiFetch.mockResolvedValueOnce(makeMockResponse({ id: 7 }, true));
+
+        render(
+            <AdminOrderEditorModal
+                {...BASE_PROPS}
+                existingOrder={{
+                    id: 7,
+                    date: '2026-07-30',
+                    data: {
+                        lunch: {
+                            Škôlka: {
+                                menuCounts: { A: 1 },
+                                diets: { 'Bez lepku': 0, 'Špeciálna': 0 },
+                            },
+                        },
+                        special_diet_note: 'Bez paradajok',
+                    },
+                }}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /uložiť/i }));
+
+        await waitFor(() => {
+            const body = getRequestBody();
+            expect(body.data.special_diet_note).toBe('Bez paradajok');
+        });
+    });
+
+    it('updates special_diet_note in the saved payload when the textarea is edited', async () => {
+        mockApiFetch.mockResolvedValueOnce(makeMockResponse({ id: 7 }, true));
+
+        render(
+            <AdminOrderEditorModal
+                {...BASE_PROPS}
+                existingOrder={{ id: 7, date: '2026-07-30', data: {} }}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText(/poznámka k špeciálnej diéte/i), {
+            target: { value: 'Bez mlieka a vajec' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /uložiť/i }));
+
+        await waitFor(() => {
+            const body = getRequestBody();
+            expect(body.data.special_diet_note).toBe('Bez mlieka a vajec');
+        });
+    });
+
+    it('renders pack-separately UI only when enabled and saves changes under packSeparately', async () => {
+        mockApiFetch.mockResolvedValue(makeMockResponse({ id: 7 }, true));
+
+        const existingOrder = {
+            id: 7,
+            date: '2026-07-30',
+            data: {
+                lunch: {
+                    Škôlka: {
+                        menuCounts: { A: 2, B: 0 },
+                        diets: { 'Bez lepku': 1, 'Špeciálna': 0 },
+                    },
+                },
+            },
+        };
+
+        const { rerender } = render(
+            <AdminOrderEditorModal
+                {...BASE_PROPS}
+                packSeparatelyEnabled={false}
+                existingOrder={existingOrder}
+            />,
+        );
+
+        expect(screen.queryByText('Zabaliť zvlášť')).not.toBeInTheDocument();
+
+        rerender(
+            <AdminOrderEditorModal
+                {...BASE_PROPS}
+                packSeparatelyEnabled={true}
+                existingOrder={existingOrder}
+            />,
+        );
+
+        expect(screen.getByText('Zabaliť zvlášť')).toBeInTheDocument();
+
+        // Karta je zbalená, kým nie je nič označené, takže tlačidlo „Pridať výnimku“
+        // ešte neexistuje — selector sa otvára prepínačom v hlavičke karty (rovnako
+        // ako na klientskej strane).
+        fireEvent.click(screen.getByRole('switch', { name: /Zabaliť zvlášť - prepnúť/i }));
+
+        // „+“ je aj v riadkoch kategórií, tak sa držíme vnútra otvoreného selectora.
+        const sheet = screen.getByRole('heading', { name: 'Pridať výnimku' }).closest('.zp-sheet') as HTMLElement;
+        const row = within(sheet).getByText(/Škôlka · Menu A/i).closest('.zp-diet-row') as HTMLElement;
+        fireEvent.click(within(row).getByLabelText('+'));
+        fireEvent.click(within(sheet).getByLabelText('Zavrieť'));
+        fireEvent.click(screen.getByRole('button', { name: /uložiť/i }));
+
+        await waitFor(() => {
+            const body = getRequestBody();
+            // `cleanupPackSeparately` zahodí celý objekt až keď sú prázdne obe vetvy,
+            // takže prázdne `diets` tu zostáva.
+            expect(body.data.lunch.Škôlka.packSeparately).toEqual({ menus: { A: 1 }, diets: {} });
+        });
+    });
+
+    it('replicates the single full-day MealData into every visible meal in the saved payload', async () => {
+        mockApiFetch.mockResolvedValueOnce(makeMockResponse({ id: 7 }, true));
+
+        render(
+            <AdminOrderEditorModal
+                {...BASE_PROPS}
+                visibleMeals={['breakfast', 'olovrant']}
+                existingOrder={{ id: 7, date: '2026-07-30', data: {} }}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /celý deň rovnaký/i }));
+        clickFirstPlus('Škôlka');
+        fireEvent.click(screen.getByRole('button', { name: /uložiť/i }));
+
+        await waitFor(() => {
+            const body = getRequestBody();
+            expect(body.data.breakfast.Škôlka.menuCounts.A).toBe(1);
+            expect(body.data.olovrant.Škôlka.menuCounts.A).toBe(1);
+            expect(body.data.lunch.Škôlka.menuCounts.A).toBe(0);
+        });
     });
 });

--- a/frontend/src/pages/admin/AdminOrderEditorModal.tsx
+++ b/frontend/src/pages/admin/AdminOrderEditorModal.tsx
@@ -1,13 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { Coffee, Utensils, Apple, X } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Apple, Coffee, PackagePlus, Utensils, X } from 'lucide-react';
 import MealCard from '../client/components/order/MealCard';
 import CategoryRow from '../client/components/order/CategoryRow';
 import DietSelector from '../client/components/order/DietSelector';
+import PackSeparatelySelector from '../client/components/order/PackSeparatelySelector';
 import OrderService, { DailyOrder, MealData } from '../client/services/OrderService';
 import { CATEGORIES } from '../client/config/constants';
 import { useAuth } from '../../context/auth';
 import { useToast } from '../../context/ToastContext';
-import { Button, Field, Input } from './ui';
+import { Button, Field, Input, Textarea, Toggle } from './ui';
 
 const API_URL = import.meta.env.VITE_API_URL || '/api';
 
@@ -18,6 +19,7 @@ interface ExistingOrder {
         breakfast?: unknown;
         lunch?: unknown;
         olovrant?: unknown;
+        special_diet_note?: unknown;
     };
 }
 
@@ -27,6 +29,8 @@ interface Props {
     visibleMenus: string[];
     visibleMeals: string[];
     visibleDiets: number[];
+    portionTypeNames: string[];
+    packSeparatelyEnabled: boolean;
     allDiets: { id: number; name: string }[];
     existingOrder?: ExistingOrder | null;
     onClose: () => void;
@@ -35,20 +39,46 @@ interface Props {
 
 type MealKey = 'breakfast' | 'lunch' | 'olovrant';
 
+type PackSeparatelyMealKey = MealKey | 'fullDay';
+
 const MEAL_CONFIG: { key: MealKey; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
     { key: 'breakfast', label: 'Raňajky', icon: Coffee },
     { key: 'lunch', label: 'Obed', icon: Utensils },
     { key: 'olovrant', label: 'Olovrant', icon: Apple },
 ];
 
-function buildInitialOrder(existingOrder?: ExistingOrder | null): DailyOrder {
-    const empty = OrderService.createEmptyOrder();
+const FALLBACK_CATEGORIES = CATEGORIES;
+
+const getBaseCategories = (portionTypeNames: string[]) =>
+    portionTypeNames.length > 0 ? portionTypeNames : FALLBACK_CATEGORIES;
+
+const extractCategoriesFromMeal = (meal: unknown): string[] => {
+    if (!meal || typeof meal !== 'object' || Array.isArray(meal)) return [];
+    return Object.keys(meal as Record<string, unknown>);
+};
+
+const buildCategories = (portionTypeNames: string[], existingOrder?: ExistingOrder | null) => {
+    const categories = new Set(getBaseCategories(portionTypeNames));
+    if (existingOrder?.data) {
+        extractCategoriesFromMeal(existingOrder.data.breakfast).forEach((key) => categories.add(key));
+        extractCategoriesFromMeal(existingOrder.data.lunch).forEach((key) => categories.add(key));
+        extractCategoriesFromMeal(existingOrder.data.olovrant).forEach((key) => categories.add(key));
+    }
+    return Array.from(categories);
+};
+
+function buildInitialOrder(categories: string[], existingOrder?: ExistingOrder | null): DailyOrder {
+    const emptyMeal = () => OrderService.createEmptyMealFor(categories);
+    const empty = {
+        status: 'draft' as const,
+        breakfast: emptyMeal(),
+        lunch: emptyMeal(),
+        olovrant: emptyMeal(),
+    };
     if (!existingOrder?.data) return empty;
 
-    const enforceOrEmpty = (raw: unknown): MealData => {
-        const emptyMeal = OrderService.createEmptyMeal();
-        return OrderService.enforceStructure(raw, emptyMeal) as MealData;
-    };
+    const enforceOrEmpty = (raw: unknown): MealData =>
+        OrderService.enforceStructure(raw, emptyMeal()) as MealData;
 
     return {
         status: 'draft',
@@ -58,12 +88,42 @@ function buildInitialOrder(existingOrder?: ExistingOrder | null): DailyOrder {
     };
 }
 
+const buildPackSeparatelyItems = (categories: string[], mealData?: MealData) =>
+    categories.flatMap((category) => {
+        const categoryData = mealData?.[category];
+        if (!categoryData) return [];
+
+        const menuItems = Object.entries(categoryData.menuCounts || {})
+            .filter(([, orderedCount]) => orderedCount > 0)
+            .map(([menuKey, orderedCount]) => ({
+                category,
+                kind: 'menus' as const,
+                keyName: menuKey,
+                orderedCount,
+                count: categoryData.packSeparately?.menus?.[menuKey] || 0,
+            }));
+
+        const dietItems = Object.entries(categoryData.diets || {})
+            .filter(([, orderedCount]) => orderedCount > 0)
+            .map(([dietKey, orderedCount]) => ({
+                category,
+                kind: 'diets' as const,
+                keyName: dietKey,
+                orderedCount,
+                count: categoryData.packSeparately?.diets?.[dietKey] || 0,
+            }));
+
+        return [...menuItems, ...dietItems];
+    });
+
 const AdminOrderEditorModal: React.FC<Props> = ({
     clientId,
     prevadzkaId,
     visibleMenus,
     visibleMeals,
     visibleDiets,
+    portionTypeNames,
+    packSeparatelyEnabled,
     allDiets,
     existingOrder,
     onClose,
@@ -72,17 +132,41 @@ const AdminOrderEditorModal: React.FC<Props> = ({
     const { apiFetch } = useAuth();
     const toast = useToast();
 
+    const categories = useMemo(
+        () => buildCategories(portionTypeNames, existingOrder),
+        [portionTypeNames, existingOrder],
+    );
+    const emptyMeal = useMemo(() => OrderService.createEmptyMealFor(categories), [categories]);
+    const visibleMealsList = useMemo(
+        () => MEAL_CONFIG.filter((m) => visibleMeals.length === 0 || visibleMeals.includes(m.key)),
+        [visibleMeals],
+    );
+    const firstVisibleMealKey = visibleMealsList[0]?.key;
+    const enabledDietNames = useMemo(
+        () => allDiets.filter((d) => visibleDiets.includes(d.id)).map((d) => d.name),
+        [allDiets, visibleDiets],
+    );
+
     const [date, setDate] = useState<string>(existingOrder?.date ?? OrderService.toLocalDateString(new Date()));
-    const [order, setOrder] = useState<DailyOrder>(() => buildInitialOrder(existingOrder));
+    const [order, setOrder] = useState<DailyOrder>(() => buildInitialOrder(categories, existingOrder));
+    const [fullDayOrder, setFullDayOrder] = useState(false);
+    const [fullDayData, setFullDayData] = useState<MealData>(() => {
+        const initialOrder = buildInitialOrder(categories, existingOrder);
+        return firstVisibleMealKey ? OrderService.fastCopy(initialOrder[firstVisibleMealKey]) : OrderService.createEmptyMealFor(categories);
+    });
+    const [specialDietNote, setSpecialDietNote] = useState(
+        typeof existingOrder?.data?.special_diet_note === 'string' ? existingOrder.data.special_diet_note : '',
+    );
     const [activeMeals, setActiveMeals] = useState<Record<MealKey, boolean>>(() => {
-        const initial = buildInitialOrder(existingOrder);
+        const initial = buildInitialOrder(categories, existingOrder);
         return {
             breakfast: !OrderService.isMealEmpty(initial.breakfast),
             lunch: !OrderService.isMealEmpty(initial.lunch),
             olovrant: !OrderService.isMealEmpty(initial.olovrant),
         };
     });
-    const [activeDietModal, setActiveDietModal] = useState<{ meal: MealKey; category: string } | null>(null);
+    const [activeDietModal, setActiveDietModal] = useState<{ meal: PackSeparatelyMealKey; category: string } | null>(null);
+    const [packSeparatelyOpen, setPackSeparatelyOpen] = useState(false);
     const [saving, setSaving] = useState(false);
 
     useEffect(() => {
@@ -96,13 +180,6 @@ const AdminOrderEditorModal: React.FC<Props> = ({
     const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
         if (e.target === e.currentTarget) onClose();
     };
-
-    const visibleMealsList = MEAL_CONFIG.filter((m) =>
-        visibleMeals.length === 0 || visibleMeals.includes(m.key),
-    );
-
-    // Derive enabled diet names from IDs
-    const enabledDietNames = allDiets.filter((d) => visibleDiets.includes(d.id)).map((d) => d.name);
 
     const getAvailableDiets = (category: string): string[] =>
         OrderService.getAvailableDiets(category, enabledDietNames);
@@ -119,15 +196,86 @@ const AdminOrderEditorModal: React.FC<Props> = ({
         setOrder((prev) => OrderService.updateDiet(prev, meal, category, diet, count));
     };
 
+    const wrapFullDay = (meal: MealData): DailyOrder => ({
+        status: 'draft',
+        breakfast: meal,
+        lunch: emptyMeal,
+        olovrant: emptyMeal,
+    });
+
+    const updateFullDayMenuCount = (category: string, menuType: string, val: number) => {
+        setFullDayData((prev) =>
+            OrderService.updateMenuCount(wrapFullDay(prev), 'breakfast', category, menuType, val).breakfast,
+        );
+    };
+
+    const updateFullDayDiet = (category: string, diet: string, count: number) => {
+        setFullDayData((prev) =>
+            OrderService.updateDiet(wrapFullDay(prev), 'breakfast', category, diet, count).breakfast,
+        );
+    };
+
+    const updatePackSeparately = (
+        meal: PackSeparatelyMealKey,
+        category: string,
+        kind: 'menus' | 'diets',
+        key: string,
+        count: number,
+    ) => {
+        if (meal === 'fullDay') {
+            setFullDayData((prev) =>
+                OrderService.updatePackSeparately(wrapFullDay(prev), 'breakfast', category, kind, key, count).breakfast,
+            );
+            return;
+        }
+
+        setOrder((prev) => OrderService.updatePackSeparately(prev, meal, category, kind, key, count));
+    };
+
+    const packSeparatelySections = useMemo(() => {
+        const sections = fullDayOrder
+            ? [
+                {
+                    meal: 'fullDay' as const,
+                    mealLabel: 'Celý deň',
+                    items: buildPackSeparatelyItems(categories, fullDayData),
+                },
+            ]
+            : visibleMealsList.map(({ key, label }) => ({
+                meal: key,
+                mealLabel: label,
+                items: buildPackSeparatelyItems(categories, order[key]),
+            }));
+
+        return sections.filter((section) => section.items.length > 0);
+    }, [categories, fullDayData, fullDayOrder, order, visibleMealsList]);
+
+    const activePackSeparatelyItems = useMemo(
+        () =>
+            packSeparatelySections
+                .map((section) => ({
+                    ...section,
+                    items: section.items.filter((item) => item.count > 0),
+                }))
+                .filter((section) => section.items.length > 0),
+        [packSeparatelySections],
+    );
+
     const handleSave = async () => {
         setSaving(true);
         try {
-            // Build payload: only meal keys, zero-out inactive meals (strip 'status' from DailyOrder type)
             const snapshot: DailyOrder = OrderService.fastCopy(order);
             const payloadData = {
-                breakfast: activeMeals.breakfast ? snapshot.breakfast : OrderService.createEmptyMeal(),
-                lunch: activeMeals.lunch ? snapshot.lunch : OrderService.createEmptyMeal(),
-                olovrant: activeMeals.olovrant ? snapshot.olovrant : OrderService.createEmptyMeal(),
+                breakfast: fullDayOrder
+                    ? (visibleMealsList.some((meal) => meal.key === 'breakfast') ? OrderService.fastCopy(fullDayData) : emptyMeal)
+                    : (activeMeals.breakfast ? snapshot.breakfast : emptyMeal),
+                lunch: fullDayOrder
+                    ? (visibleMealsList.some((meal) => meal.key === 'lunch') ? OrderService.fastCopy(fullDayData) : emptyMeal)
+                    : (activeMeals.lunch ? snapshot.lunch : emptyMeal),
+                olovrant: fullDayOrder
+                    ? (visibleMealsList.some((meal) => meal.key === 'olovrant') ? OrderService.fastCopy(fullDayData) : emptyMeal)
+                    : (activeMeals.olovrant ? snapshot.olovrant : emptyMeal),
+                special_diet_note: specialDietNote.trim() || undefined,
             };
 
             const query = clientId ? `?user_id=${encodeURIComponent(String(clientId))}` : '';
@@ -165,6 +313,35 @@ const AdminOrderEditorModal: React.FC<Props> = ({
         }
     };
 
+    const renderCategoryRows = (meal: PackSeparatelyMealKey, mealData: MealData) => (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {categories.map((category) => {
+                const data = mealData[category];
+                if (!data) return null;
+
+                const dietCount = (Object.values(data.diets || {}) as number[]).reduce((a, b) => a + b, 0);
+                const availableDiets = getAvailableDiets(category);
+
+                return (
+                    <CategoryRow
+                        key={`${meal}-${category}`}
+                        label={category}
+                        menuCounts={data.menuCounts}
+                        onMenuCountChange={(menuType, val) =>
+                            meal === 'fullDay'
+                                ? updateFullDayMenuCount(category, menuType, val)
+                                : updateMenuCount(meal, category, menuType, val)
+                        }
+                        hasDietsEnabled={availableDiets.length > 0}
+                        dietCount={dietCount}
+                        onOpenDiets={() => setActiveDietModal({ meal, category })}
+                        visibleMenus={visibleMenus}
+                    />
+                );
+            })}
+        </div>
+    );
+
     return (
         <div
             className="zpa-scrim"
@@ -178,7 +355,6 @@ const AdminOrderEditorModal: React.FC<Props> = ({
                 aria-modal="true"
                 aria-labelledby="admin-order-editor-title"
             >
-                {/* Header */}
                 <div className="zpa-modal-head">
                     <div>
                         <h3 id="admin-order-editor-title">
@@ -193,7 +369,6 @@ const AdminOrderEditorModal: React.FC<Props> = ({
                     </button>
                 </div>
 
-                {/* Date picker (new orders only) */}
                 {!existingOrder && (
                     <div style={{ padding: '20px 24px 0' }}>
                         <Field label="Dátum objednávky">
@@ -202,53 +377,134 @@ const AdminOrderEditorModal: React.FC<Props> = ({
                     </div>
                 )}
 
-                {/* Meal cards */}
-                <div style={{ padding: '20px 24px', display: 'flex', flexDirection: 'column', gap: 16 }}>
-                    {visibleMealsList.map(({ key, label, icon }) => {
-                        const isActive = activeMeals[key];
-                        return (
-                            <MealCard
-                                key={key}
-                                title={label}
-                                icon={icon}
-                                isActive={isActive}
-                                onToggle={() => toggleMeal(key)}
-                                copyAction={null}
-                                statusMessage={null}
-                            >
-                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                    {CATEGORIES.map((category) => {
-                                        const data = order[key]?.[category];
-                                        if (!data) return null;
-
-                                        const dietCount = (Object.values(data.diets || {}) as number[]).reduce(
-                                            (a, b) => a + b,
-                                            0,
-                                        );
-                                        const availableDiets = getAvailableDiets(category);
-
-                                        return (
-                                            <CategoryRow
-                                                key={category}
-                                                label={category}
-                                                menuCounts={data.menuCounts}
-                                                onMenuCountChange={(menuType, val) =>
-                                                    updateMenuCount(key, category, menuType, val)
-                                                }
-                                                hasDietsEnabled={availableDiets.length > 0}
-                                                dietCount={dietCount}
-                                                onOpenDiets={() => setActiveDietModal({ meal: key, category })}
-                                                visibleMenus={visibleMenus}
-                                            />
-                                        );
-                                    })}
-                                </div>
-                            </MealCard>
-                        );
-                    })}
+                <div style={{ padding: '20px 24px 0' }}>
+                    <Field label="Celý deň rovnaký">
+                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16 }}>
+                            <span style={{ color: 'var(--ink-2)', fontSize: 14 }}>
+                                Použiť jeden rovnaký set porcií pre všetky viditeľné jedlá.
+                            </span>
+                            <Toggle
+                                on={fullDayOrder}
+                                onChange={setFullDayOrder}
+                                ariaLabel="Celý deň rovnaký"
+                            />
+                        </div>
+                    </Field>
                 </div>
 
-                {/* Footer */}
+                <div style={{ padding: '20px 24px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+                    {fullDayOrder ? (
+                        <MealCard
+                            title="Celý deň"
+                            icon={Coffee}
+                            isActive={true}
+                            onToggle={() => undefined}
+                            copyAction={null}
+                            statusMessage={null}
+                        >
+                            {renderCategoryRows('fullDay', fullDayData)}
+                        </MealCard>
+                    ) : (
+                        visibleMealsList.map(({ key, label, icon }) => {
+                            const isActive = activeMeals[key];
+                            return (
+                                <MealCard
+                                    key={key}
+                                    title={label}
+                                    icon={icon}
+                                    isActive={isActive}
+                                    onToggle={() => toggleMeal(key)}
+                                    copyAction={null}
+                                    statusMessage={null}
+                                >
+                                    {renderCategoryRows(key, order[key])}
+                                </MealCard>
+                            );
+                        })
+                    )}
+
+                    {packSeparatelyEnabled && (
+                        <MealCard
+                            title="Zabaliť zvlášť"
+                            icon={PackagePlus}
+                            isActive={activePackSeparatelyItems.length > 0}
+                            onToggle={() => setPackSeparatelyOpen(true)}
+                            copyAction={
+                                <button
+                                    type="button"
+                                    className="zp-btn zp-btn--secondary zp-btn--sm"
+                                    style={{ flex: 1 }}
+                                    onClick={() => setPackSeparatelyOpen(true)}
+                                >
+                                    <PackagePlus style={{ width: 12, height: 12 }} /> Pridať výnimku
+                                </button>
+                            }
+                            statusMessage={null}
+                        >
+                            <div>
+                                {activePackSeparatelyItems.length === 0 ? (
+                                    <div className="zp-empty" style={{ margin: '8px 0 0' }}>
+                                        <p>Zatiaľ nemáte nič označené na balenie zvlášť.</p>
+                                    </div>
+                                ) : (
+                                    activePackSeparatelyItems.map((section) => (
+                                        <div key={section.meal} style={{ marginBottom: 12 }}>
+                                            {activePackSeparatelyItems.length > 1 && (
+                                                <div className="zp-cat-head" style={{ marginBottom: 8 }}>{section.mealLabel}</div>
+                                            )}
+                                            {section.items.map((item) => (
+                                                <div
+                                                    key={`${section.meal}-${item.category}-${item.kind}-${item.keyName}`}
+                                                    className={`zp-diet-row${item.count > 0 ? ' active' : ''}`}
+                                                >
+                                                    <div>
+                                                        <span className="zp-diet-label">
+                                                            {item.category} · {item.kind === 'menus' ? `Menu ${item.keyName}` : item.keyName}
+                                                        </span>
+                                                        <div style={{ fontSize: 12, opacity: 0.7, marginTop: 2 }}>
+                                                            Limit objednávky: {item.orderedCount}
+                                                        </div>
+                                                    </div>
+                                                    <div className="zp-counter">
+                                                        <button
+                                                            type="button"
+                                                            disabled={item.count <= 0}
+                                                            aria-label={`Znížiť ${section.mealLabel} ${item.category} ${item.keyName}`}
+                                                            onClick={() => updatePackSeparately(section.meal, item.category, item.kind, item.keyName, item.count - 1)}
+                                                        >
+                                                            -
+                                                        </button>
+                                                        <span className={`count${item.count <= 0 ? ' zero' : ''}`}>{item.count}</span>
+                                                        <button
+                                                            type="button"
+                                                            className="plus"
+                                                            disabled={item.count >= item.orderedCount}
+                                                            aria-label={`Zvýšiť ${section.mealLabel} ${item.category} ${item.keyName}`}
+                                                            onClick={() => updatePackSeparately(section.meal, item.category, item.kind, item.keyName, item.count + 1)}
+                                                        >
+                                                            +
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    ))
+                                )}
+                            </div>
+                        </MealCard>
+                    )}
+
+                    <Field label="Poznámka k špeciálnej diéte">
+                        <Textarea
+                            aria-label="Poznámka k špeciálnej diéte"
+                            rows={4}
+                            value={specialDietNote}
+                            placeholder="Popis špeciálnej diéty"
+                            onChange={(e) => setSpecialDietNote(e.target.value)}
+                        />
+                    </Field>
+                </div>
+
                 <div className="zpa-modal-foot">
                     <Button variant="ghost" onClick={onClose}>Zrušiť</Button>
                     <Button onClick={handleSave} disabled={saving}>
@@ -257,18 +513,36 @@ const AdminOrderEditorModal: React.FC<Props> = ({
                 </div>
             </div>
 
-            {/* Diet selector modal */}
             {activeDietModal && (
                 <DietSelector
                     isOpen={true}
                     onClose={() => setActiveDietModal(null)}
                     categoryLabel={activeDietModal.category}
                     enabledDiets={getAvailableDiets(activeDietModal.category)}
-                    diets={order[activeDietModal.meal]?.[activeDietModal.category]?.diets ?? {}}
-                    maxPortions={order[activeDietModal.meal]?.[activeDietModal.category]?.menuCounts?.['A'] || 0}
-                    onUpdateDiet={(diet, count) =>
-                        updateDiet(activeDietModal.meal, activeDietModal.category, diet, count)
+                    diets={
+                        activeDietModal.meal === 'fullDay'
+                            ? fullDayData[activeDietModal.category]?.diets ?? {}
+                            : order[activeDietModal.meal]?.[activeDietModal.category]?.diets ?? {}
                     }
+                    maxPortions={
+                        activeDietModal.meal === 'fullDay'
+                            ? fullDayData[activeDietModal.category]?.menuCounts?.A || 0
+                            : order[activeDietModal.meal]?.[activeDietModal.category]?.menuCounts?.A || 0
+                    }
+                    onUpdateDiet={(diet, count) =>
+                        activeDietModal.meal === 'fullDay'
+                            ? updateFullDayDiet(activeDietModal.category, diet, count)
+                            : updateDiet(activeDietModal.meal, activeDietModal.category, diet, count)
+                    }
+                />
+            )}
+
+            {packSeparatelyEnabled && (
+                <PackSeparatelySelector
+                    isOpen={packSeparatelyOpen}
+                    onClose={() => setPackSeparatelyOpen(false)}
+                    sections={packSeparatelySections}
+                    onUpdatePackSeparately={updatePackSeparately}
                 />
             )}
         </div>

--- a/frontend/src/pages/admin/ClientDetail.tsx
+++ b/frontend/src/pages/admin/ClientDetail.tsx
@@ -43,6 +43,7 @@ interface FacilityDetail {
   edupage_match: string;
   celok_zdroj_objednavok: string;
   visible_menus: string[];
+  visible_menus_per_meal: Record<string, string[]>;
   visible_meals: string[];
   visible_diets: number[];
   admin_order_note: string;
@@ -89,6 +90,11 @@ const ClientDetail: React.FC = () => {
 
   // Settings State
   const [menus, setMenus] = useState<Set<string>>(new Set());
+  const [menusPerMeal, setMenusPerMeal] = useState<Record<string, string[] | null>>({
+    breakfast: null,
+    lunch: null,
+    olovrant: null,
+  });
   const [meals, setMeals] = useState<Set<string>>(new Set());
   const [userDiets, setUserDiets] = useState<Set<number>>(new Set());
   const [adminOrderNote, setAdminOrderNote] = useState("");
@@ -113,6 +119,11 @@ const ClientDetail: React.FC = () => {
 
   const applyFacilitySettings = useCallback((data: FacilityDetail) => {
     setMenus(new Set(data.visible_menus?.length ? data.visible_menus : ALL_MENUS));
+    setMenusPerMeal({
+      breakfast: data.visible_menus_per_meal?.breakfast ?? null,
+      lunch: data.visible_menus_per_meal?.lunch ?? null,
+      olovrant: data.visible_menus_per_meal?.olovrant ?? null,
+    });
     setMeals(new Set(data.visible_meals?.length ? data.visible_meals : ALL_MEALS));
     setUserDiets(new Set(data.visible_diets || []));
     setAdminOrderNote(data.admin_order_note || "");
@@ -301,6 +312,9 @@ const ClientDetail: React.FC = () => {
     try {
       const payload = {
         visible_menus: Array.from(menus),
+        visible_menus_per_meal: Object.fromEntries(
+          Object.entries(menusPerMeal).filter(([, value]) => value !== null)
+        ),
         visible_meals: Array.from(meals),
         visible_diets: Array.from(userDiets),
         admin_order_note: adminOrderNote,
@@ -337,6 +351,16 @@ const ClientDetail: React.FC = () => {
     if (newSet.has(value)) newSet.delete(value);
     else newSet.add(value);
     setter(newSet);
+  };
+
+  const toggleMenuPerMeal = (meal: string, menu: string) => {
+    setMenusPerMeal((prev) => {
+      const current = prev[meal] ?? [];
+      const next = current.includes(menu)
+        ? current.filter((item) => item !== menu)
+        : [...current, menu];
+      return { ...prev, [meal]: next };
+    });
   };
 
   if (loading) return <div className="zpa-empty">Načítavam…</div>;
@@ -546,6 +570,50 @@ const ClientDetail: React.FC = () => {
                       Menu {menu}
                     </Checkbox>
                   ))}
+                </div>
+              </Card>
+
+              <Card pad>
+                <CardHead title="Viditeľné menu podľa chodu" desc="Ak necháte chod bez override, použije sa globálne nastavenie vyššie." />
+                <div style={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 8 }}>
+                  {ALL_MEALS.map((meal) => {
+                    const overrideMenus = menusPerMeal[meal];
+                    const inheritedMenus = Array.from(menus);
+                    const effectiveMenus = overrideMenus ?? inheritedMenus;
+                    return (
+                      <div key={meal} style={{ borderTop: "1px solid var(--line-soft)", paddingTop: 12 }}>
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
+                          <div>
+                            <div style={{ fontFamily: "var(--font-display)", fontWeight: 600, color: "var(--green-900)" }}>
+                              {MEAL_LABELS[meal] ?? meal}
+                            </div>
+                            <div style={{ fontSize: 13, color: "var(--ink-3)" }}>
+                              {overrideMenus === null ? `Dedené: ${effectiveMenus.join(", ") || "žiadne"}` : `Vlastné: ${effectiveMenus.join(", ") || "žiadne"}`}
+                            </div>
+                          </div>
+                          <Toggle
+                            on={overrideMenus !== null}
+                            onChange={(enabled) =>
+                              setMenusPerMeal((prev) => ({
+                                ...prev,
+                                [meal]: enabled ? [...inheritedMenus] : null,
+                              }))
+                            }
+                            ariaLabel={`Použiť vlastné menu pre ${MEAL_LABELS[meal] ?? meal}`}
+                          />
+                        </div>
+                        {overrideMenus !== null && (
+                          <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 10, marginTop: 10 }}>
+                            {ALL_MENUS.map((menu) => (
+                              <Checkbox key={`${meal}-${menu}`} on={overrideMenus.includes(menu)} onChange={() => toggleMenuPerMeal(meal, menu)}>
+                                Menu {menu}
+                              </Checkbox>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
               </Card>
 

--- a/frontend/src/pages/admin/ClientDetail.tsx
+++ b/frontend/src/pages/admin/ClientDetail.tsx
@@ -13,6 +13,12 @@ interface Diet {
   name: string;
 }
 
+interface PortionType {
+  id: number;
+  name: string;
+  is_active: boolean;
+}
+
 interface UserProfile {
   is_edupage: boolean;
   api_identifier: string;
@@ -49,6 +55,7 @@ interface OrderData {
   soup?: string;
   breakfast?: unknown;
   olovrant?: unknown;
+  special_diet_note?: unknown;
 }
 
 interface DailyOrder {
@@ -75,6 +82,7 @@ const ClientDetail: React.FC = () => {
   const [facility, setFacility] = useState<FacilityDetail | null>(null);
   const [user, setUser] = useState<AdminUser | null>(null);
   const [allDiets, setAllDiets] = useState<Diet[]>([]);
+  const [portionTypeNames, setPortionTypeNames] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [activeTab, setActiveTab] = useState<"dashboard" | "settings" | "order_note">("dashboard");
@@ -162,6 +170,22 @@ const ClientDetail: React.FC = () => {
       }
     } catch (e) {
       logger.error(e);
+    }
+  }, [apiFetch]);
+
+  const fetchPortionTypes = useCallback(async () => {
+    try {
+      const res = await apiFetch(`${import.meta.env.VITE_API_URL || "/api"}/admin/portion-types/`);
+      if (res.ok) {
+        const data = await res.json();
+        const items: PortionType[] = Array.isArray(data) ? data : data.results || [];
+        setPortionTypeNames(items.filter((item) => item.is_active).map((item) => item.name));
+      } else {
+        setPortionTypeNames([]);
+      }
+    } catch (e) {
+      logger.error(e);
+      setPortionTypeNames([]);
     }
   }, [apiFetch]);
 
@@ -262,8 +286,8 @@ const ClientDetail: React.FC = () => {
     setRecentOrders([]);
     setExpandedOrderId(null);
     setActiveTab("dashboard");
-    Promise.all([fetchFacility(), fetchDiets()]).finally(() => setLoading(false));
-  }, [fetchFacility, fetchDiets]);
+    Promise.all([fetchFacility(), fetchDiets(), fetchPortionTypes()]).finally(() => setLoading(false));
+  }, [fetchFacility, fetchDiets, fetchPortionTypes]);
 
   useEffect(() => {
     if (activeTab === "dashboard") {
@@ -424,6 +448,10 @@ const ClientDetail: React.FC = () => {
                       if (olovrantCount > 0) summaries.push(`${olovrantCount}x Olovrant`);
                       const summaryText = summaries.length > 0 ? summaries.join(", ") : "-";
                       const isExpanded = expandedOrderId === order.id;
+                      const specialDietNote =
+                        typeof order.data.special_diet_note === "string"
+                          ? order.data.special_diet_note.trim()
+                          : "";
 
                       return (
                         <React.Fragment key={order.id}>
@@ -486,6 +514,12 @@ const ClientDetail: React.FC = () => {
                                   <div style={{ marginTop: 16, paddingTop: 8, borderTop: "1px solid var(--line-soft)" }}>
                                     <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, color: "var(--green-900)", marginRight: 8 }}>Polievka:</span>
                                     <span>{order.data.soup}</span>
+                                  </div>
+                                )}
+                                {specialDietNote && (
+                                  <div style={{ marginTop: 16, paddingTop: 8, borderTop: "1px solid var(--line-soft)" }}>
+                                    <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, color: "var(--green-900)", marginRight: 8 }}>Špeciálna diéta:</span>
+                                    <span>{specialDietNote}</span>
                                   </div>
                                 )}
                               </td>
@@ -638,6 +672,8 @@ const ClientDetail: React.FC = () => {
           visibleMenus={orderEditorMenus}
           visibleMeals={orderEditorMeals}
           visibleDiets={orderEditorDiets}
+          portionTypeNames={portionTypeNames}
+          packSeparatelyEnabled={packSeparatelyEnabled}
           allDiets={allDiets}
           existingOrder={editOrderTarget ?? null}
           onClose={() => {

--- a/frontend/src/pages/admin/DietManager.tsx
+++ b/frontend/src/pages/admin/DietManager.tsx
@@ -8,6 +8,7 @@ import { PageHead, Card, Button, IconButton, Field, Input, Textarea, Modal, Empt
 interface Diet {
   id: number;
   name: string;
+  sort_order: number;
   is_active: boolean;
   description: string;
   color?: string;
@@ -22,6 +23,7 @@ interface RenameModal {
   id: number;
   currentName: string;
   newName: string;
+  sortOrder: number;
   description: string;
   color: string;
 }
@@ -31,6 +33,7 @@ const DietManager: React.FC = () => {
   const { success, error } = useToast();
   const [diets, setDiets] = useState<Diet[]>([]);
   const [newDietName, setNewDietName] = useState("");
+  const [newDietSortOrder, setNewDietSortOrder] = useState(0);
   const [newDietDescription, setNewDietDescription] = useState("");
   const [newDietColor, setNewDietColor] = useState("#FDE68A");
   const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirm | null>(null);
@@ -67,6 +70,7 @@ const DietManager: React.FC = () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             name: newDietName.trim(),
+            sort_order: newDietSortOrder,
             description: newDietDescription.trim(),
             color: newDietColor,
             is_active: true,
@@ -80,6 +84,7 @@ const DietManager: React.FC = () => {
           return [created, ...prev];
         });
         setNewDietName("");
+        setNewDietSortOrder(0);
         setNewDietDescription("");
         setNewDietColor("#FDE68A");
         fetchDiets();
@@ -125,6 +130,7 @@ const DietManager: React.FC = () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             name: renameModal.newName.trim(),
+            sort_order: renameModal.sortOrder,
             description: renameModal.description.trim(),
             color: renameModal.color,
           }),
@@ -170,6 +176,14 @@ const DietManager: React.FC = () => {
                 placeholder="Popis diéty pre prevádzku"
               />
             </Field>
+            <Field label="Poradie">
+              <Input
+                type="number"
+                inputMode="numeric"
+                value={newDietSortOrder}
+                onChange={(e) => setNewDietSortOrder(Number(e.target.value) || 0)}
+              />
+            </Field>
             <Field label="Farba">
               <Input
                 type="color"
@@ -206,6 +220,7 @@ const DietManager: React.FC = () => {
                   />
                   <div>
                     <div style={{ fontFamily: "var(--font-display)", fontWeight: 600, color: "var(--green-900)" }}>{diet.name}</div>
+                    <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "4px 0 0" }}>Poradie: {diet.sort_order}</p>
                   {diet.description && (
                     <p style={{ fontSize: 13, color: "var(--ink-3)", margin: "4px 0 0" }}>{diet.description}</p>
                   )}
@@ -219,6 +234,7 @@ const DietManager: React.FC = () => {
                         id: diet.id,
                         currentName: diet.name,
                         newName: diet.name,
+                        sortOrder: diet.sort_order ?? 0,
                         description: diet.description || "",
                         color: diet.color || "#FDE68A",
                       })
@@ -271,6 +287,7 @@ const DietManager: React.FC = () => {
                   renaming ||
                   !renameModal.newName.trim() ||
                   (renameModal.newName.trim() === renameModal.currentName &&
+                    renameModal.sortOrder === (diets.find((diet) => diet.id === renameModal.id)?.sort_order || 0) &&
                     renameModal.description.trim() ===
                       (diets.find((diet) => diet.id === renameModal.id)?.description || "").trim() &&
                     renameModal.color === (diets.find((diet) => diet.id === renameModal.id)?.color || "#FDE68A"))
@@ -293,6 +310,14 @@ const DietManager: React.FC = () => {
               }}
               placeholder="Nový názov diéty"
               autoFocus
+            />
+          </Field>
+          <Field label="Poradie">
+            <Input
+              type="number"
+              inputMode="numeric"
+              value={renameModal.sortOrder}
+              onChange={(e) => setRenameModal((prev) => (prev ? { ...prev, sortOrder: Number(e.target.value) || 0 } : prev))}
             />
           </Field>
           <Field label="Popis">

--- a/frontend/src/pages/client/components/order/CategoryRow.tsx
+++ b/frontend/src/pages/client/components/order/CategoryRow.tsx
@@ -1,4 +1,5 @@
 import { Minus, Plus, Utensils } from 'lucide-react';
+import NumericCountInput from './NumericCountInput';
 
 interface MenuCounterProps {
     type: string;
@@ -39,7 +40,12 @@ const MenuCounter = ({ type, count, onChange, onOpenDiets, dietCount, disabled, 
                 >
                     <Minus style={{ width: 14, height: 14, strokeWidth: 2.5 }} />
                 </button>
-                <span className={`count${count <= 0 ? " zero" : ""}`}>{count}</span>
+                <NumericCountInput
+                    value={count}
+                    onCommit={onChange}
+                    disabled={disabled}
+                    ariaLabel={`Počet porcií pre menu ${type}`}
+                />
                 <button
                     className="plus"
                     disabled={disabled}

--- a/frontend/src/pages/client/components/order/DietSelector.tsx
+++ b/frontend/src/pages/client/components/order/DietSelector.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { X, Check, Minus, Plus } from 'lucide-react';
 import { useScrollLock } from '../../../../hooks/useScrollLock';
+import NumericCountInput from './NumericCountInput';
 
 interface DietSelectorProps {
     isOpen: boolean;
@@ -65,7 +66,12 @@ const DietSelector = ({
                                         >
                                             <Minus style={{ width: 14, height: 14, strokeWidth: 2.5 }} />
                                         </button>
-                                        <span className={`count${count <= 0 ? " zero" : ""}`}>{count}</span>
+                                        <NumericCountInput
+                                            value={count}
+                                            onCommit={(value) => onUpdateDiet(diet, value)}
+                                            disabled={false}
+                                            ariaLabel={`Počet diéty ${diet}`}
+                                        />
                                         <button
                                             className="plus"
                                             disabled={remaining <= 0}

--- a/frontend/src/pages/client/components/order/NumericCountInput.tsx
+++ b/frontend/src/pages/client/components/order/NumericCountInput.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+interface NumericCountInputProps {
+    value: number;
+    onCommit: (value: number) => void;
+    disabled?: boolean;
+    ariaLabel: string;
+}
+
+const sanitizeToDigits = (raw: string) => raw.replace(/\D+/g, '');
+
+const NumericCountInput = ({
+    value,
+    onCommit,
+    disabled,
+    ariaLabel,
+}: NumericCountInputProps) => {
+    const [draft, setDraft] = useState(String(value));
+
+    useEffect(() => {
+        setDraft(String(value));
+    }, [value]);
+
+    const commit = () => {
+        const normalized = sanitizeToDigits(draft);
+        const nextValue = normalized === '' ? 0 : Number.parseInt(normalized, 10);
+        onCommit(nextValue);
+        setDraft(String(nextValue));
+    };
+
+    return (
+        <input
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            className={`count zp-counter-input${value <= 0 ? ' zero' : ''}`}
+            value={draft}
+            disabled={disabled}
+            aria-label={ariaLabel}
+            onFocus={(event) => event.currentTarget.select()}
+            onChange={(event) => setDraft(sanitizeToDigits(event.target.value))}
+            onBlur={commit}
+            onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    commit();
+                    event.currentTarget.blur();
+                }
+            }}
+        />
+    );
+};
+
+export default NumericCountInput;

--- a/frontend/src/pages/client/components/order/PackSeparatelySelector.tsx
+++ b/frontend/src/pages/client/components/order/PackSeparatelySelector.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { X, Check, Minus, Plus } from 'lucide-react';
 import { useScrollLock } from '../../../../hooks/useScrollLock';
+import NumericCountInput from './NumericCountInput';
 
 // 'fullDay' je celodenná objednávka — drží dáta mimo currentOrder, ale UI je rovnaké.
 type MealKey = 'breakfast' | 'lunch' | 'olovrant' | 'fullDay';
@@ -90,7 +91,14 @@ const PackSeparatelySelector = ({
                                             >
                                                 <Minus style={{ width: 14, height: 14, strokeWidth: 2.5 }} />
                                             </button>
-                                            <span className={`count${item.count <= 0 ? ' zero' : ''}`}>{item.count}</span>
+                                            <NumericCountInput
+                                                value={item.count}
+                                                onCommit={(value) =>
+                                                    onUpdatePackSeparately(section.meal, item.category, item.kind, item.keyName, value)
+                                                }
+                                                disabled={false}
+                                                ariaLabel={`Počet balení zvlášť pre ${item.keyName}`}
+                                            />
                                             <button
                                                 className="plus"
                                                 disabled={item.count >= item.orderedCount}

--- a/frontend/src/pages/client/hooks/useOrder.ts
+++ b/frontend/src/pages/client/hooks/useOrder.ts
@@ -39,6 +39,7 @@ interface DietDetail {
     name: string;
     description?: string | null;
     is_active?: boolean;
+    sort_order?: number;
 }
 
 type ApiErrorPayload = {
@@ -684,19 +685,30 @@ export const useOrder = (activePrevadzkaId?: number, waitForPrevadzkaChoice = fa
     // Admin Constraints
     // Fall back to defaults only when the setting is null/undefined;
     // an explicitly empty array means "show none".
-    const adminVisibleMenusSetting = user?.settings?.visible_menus;
+    const prevadzkaSettings = prevadzky.find((item) => item.id === activePrevadzkaId);
+
+    const adminVisibleMenusSetting = prevadzkaSettings?.visible_menus ?? user?.settings?.visible_menus;
     const adminVisibleMenus = adminVisibleMenusSetting == null
         ? ['A', 'B', 'C', 'V']
         : adminVisibleMenusSetting;
 
-    const adminVisibleMealsSetting = user?.settings?.visible_meals;
+    const adminVisibleMenusPerMeal = prevadzkaSettings?.visible_menus_per_meal ?? user?.settings?.visible_menus_per_meal ?? {};
+
+    const getVisibleMenusForMeal = (mealKey: 'breakfast' | 'lunch' | 'olovrant') => {
+        const perMealMenus = adminVisibleMenusPerMeal[mealKey];
+        return perMealMenus == null ? adminVisibleMenus : perMealMenus;
+    };
+
+    const adminVisibleMealsSetting = prevadzkaSettings?.visible_meals ?? user?.settings?.visible_meals;
     const adminVisibleMeals = adminVisibleMealsSetting == null
         ? ['breakfast', 'lunch', 'olovrant']
         : adminVisibleMealsSetting;
 
     const visibleDietDetails: DietDetail[] =
         user?.settings?.visible_diets && (user.settings.visible_diets as DietDetail[]).length > 0
-        ? (user.settings.visible_diets as DietDetail[])
+        ? [...(user.settings.visible_diets as DietDetail[])].sort(
+            (a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.name.localeCompare(b.name, 'sk')
+        )
         : [];
     const adminVisibleDiets = visibleDietDetails.length > 0
         ? visibleDietDetails.map(d => d.name)
@@ -802,6 +814,8 @@ export const useOrder = (activePrevadzkaId?: number, waitForPrevadzkaChoice = fa
         copyOlovrantFromCurrentLunch,
         submitOrder, deleteOrder,
         adminVisibleMenus,
+        adminVisibleMenusPerMeal,
+        getVisibleMenusForMeal,
         adminVisibleMeals,
         globalDeadlines,
         clientContactInfo,

--- a/frontend/src/pages/client/hooks/usePrevadzky.ts
+++ b/frontend/src/pages/client/hooks/usePrevadzky.ts
@@ -9,6 +9,9 @@ export interface Prevadzka {
     nazov: string;
     adresa: string;
     celok: string;
+    visible_menus: string[];
+    visible_menus_per_meal: Record<string, string[]>;
+    visible_meals: string[];
     pack_separately_enabled: boolean;
 }
 

--- a/frontend/src/pages/client/pages/HomePage.test.tsx
+++ b/frontend/src/pages/client/pages/HomePage.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import HomePage from "./HomePage";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("../../../hooks/useIsPC", () => ({
+  useIsPC: () => true,
+}));
+
+vi.mock("../context/AppContext", () => ({
+  useApp: () => ({
+    globalDeadlines: {
+      breakfast: "10:00",
+      breakfast_day_before: false,
+      lunch: "10:00",
+      lunch_day_before: false,
+      olovrant: "10:00",
+      olovrant_day_before: false,
+    },
+  }),
+}));
+
+vi.mock("../../../context/auth", () => ({
+  useAuth: () => ({
+    apiFetch: mockApiFetch,
+    user: { email: "test@example.com" },
+  }),
+}));
+
+vi.mock("../../../context/ToastContext", () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  }),
+}));
+
+vi.mock("../components/order/OrderSummaryModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("../components/onboarding/TourOverlay", () => ({
+  default: () => null,
+}));
+
+describe("HomePage history", () => {
+  it("renders concrete ordered diet names in history", async () => {
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url.includes("/orders/planned/monthly-summary/")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ total: 0, items: [] }) });
+      }
+      if (url.endsWith("/orders/planned/")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url.endsWith("/orders/")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                date: "2026-07-22",
+                status: "submitted",
+                data: {
+                  lunch: {
+                    "Škôlka": {
+                      menuCounts: { A: 2 },
+                      diets: { "Bez lepku": 1, Vegánske: 0 },
+                    },
+                  },
+                  olovrant: {
+                    "Predškolák": {
+                      menuCounts: { A: 1 },
+                      diets: { "Bez laktózy": 2 },
+                    },
+                  },
+                },
+              },
+            ]),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Škôlka · Bez lepku · 1x")).toBeInTheDocument();
+      expect(screen.getByText("Predškolák · Bez laktózy · 2x")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/client/pages/HomePage.tsx
+++ b/frontend/src/pages/client/pages/HomePage.tsx
@@ -45,7 +45,7 @@ interface HistoryOrder {
   date: string;
   totalPortions: number;
   mealCount: { breakfast: number; lunch: number; olovrant: number };
-  data: Record<string, Record<string, { menuCounts: Record<string, number> }>>;
+  data: Record<string, Record<string, { menuCounts: Record<string, number>; diets?: Record<string, number> }>>;
 }
 
 interface MonthlySummary {
@@ -600,6 +600,17 @@ const HomePage = () => {
                   <span className="zp-pill" style={{ background: "rgba(114,136,75,0.16)", color: "var(--green-700)" }}>
                     Vybavená
                   </span>
+                  {(["breakfast", "lunch", "olovrant"] as const).flatMap((meal) =>
+                    Object.entries(order.data?.[meal] || {}).flatMap(([category, categoryData]) =>
+                      Object.entries(categoryData?.diets || {})
+                        .filter(([, count]) => count > 0)
+                        .map(([dietName, count]) => (
+                          <div key={`${order.date}-${meal}-${category}-${dietName}`} style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 4 }}>
+                            {category} · {dietName} · {count}x
+                          </div>
+                        ))
+                    )
+                  )}
                 </div>
               </div>
               <div className="zp-day-count" style={{ fontSize: 19 }}>

--- a/frontend/src/pages/client/pages/OrderPage.test.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.test.tsx
@@ -60,32 +60,30 @@ vi.mock("../../../context/OnboardingContext", () => ({
 vi.mock("../services/OrderService", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../services/OrderService")>();
-
-  // We need to fix context issues since "this" might be lost in spread
   const originalDefault = actual.default;
+
+  // Statické metódy triedy sú non-enumerable, takže spread by ich nepreniesol,
+  // a ručný zoznam sa rozbije vždy, keď v OrderService pribudne interná metóda
+  // volaná cez `this` (napr. withClampedPackSeparately). Preto ich prenesieme
+  // všetky a naviažeme na originál — mockujeme len to, čo naozaj treba.
+  const bound: Record<string, unknown> = {};
+  let proto: unknown = originalDefault;
+  while (proto && proto !== Function.prototype && proto !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(proto)) {
+      if (key in bound) continue;
+      const value = (originalDefault as unknown as Record<string, unknown>)[key];
+      bound[key] = typeof value === "function"
+        ? (value as (...args: unknown[]) => unknown).bind(originalDefault)
+        : value;
+    }
+    proto = Object.getPrototypeOf(proto);
+  }
 
   return {
     default: {
-      ...originalDefault,
+      ...bound,
       checkDeadline: vi.fn(),
       getAvailableDiets: vi.fn().mockReturnValue(["Bezlepková", "Diabetická"]),
-
-      // Re-implement or wrapper to ensure 'this' isn't vital or is bound
-      createEmptyMeal: () => {
-        // Manually replicate logic or call original bound
-        return originalDefault.createEmptyMeal.call(originalDefault);
-      },
-
-      updateMenuCount: originalDefault.updateMenuCount,
-      updateDiet: originalDefault.updateDiet,
-      enforceStructure: originalDefault.enforceStructure,
-      calculatePrevDayLunches: originalDefault.calculatePrevDayLunches,
-      getServerNow: originalDefault.getServerNow,
-      toLocalDateString: originalDefault.toLocalDateString,
-      isMealEmpty: originalDefault.isMealEmpty,
-      findLastNonZeroDay: originalDefault.findLastNonZeroDay,
-      mergeOrders: originalDefault.mergeOrders,
-      fastCopy: originalDefault.fastCopy,
     },
   };
 });
@@ -177,6 +175,54 @@ describe("OrderPage Logic & Triggers", () => {
     return data ? JSON.parse(data) : null;
   };
 
+  const getMealCard = (title: string) => {
+    // Text „Raňajky“ sa vyskytuje aj mimo karty, takže sa nedá brať prvý zásah —
+    // hľadáme kartu, ktorej vlastný .zp-meal-title sedí.
+    const cards = Array.from(document.querySelectorAll<HTMLElement>(".zp-meal"));
+    const card = cards.find(
+      (c) => c.querySelector(".zp-meal-title")?.textContent?.trim() === title,
+    );
+    if (!card) throw new Error(`Meal card "${title}" not found`);
+    return card;
+  };
+
+  const getCategoryRow = (card: HTMLElement, category: string) => {
+    const rows = Array.from(card.querySelectorAll<HTMLElement>(".zp-cat"));
+    const row = rows.find(
+      (r) => r.querySelector(".zp-cat-head")?.textContent?.trim() === category,
+    );
+    if (!row) throw new Error(`Category "${category}" not found in card`);
+    return row;
+  };
+
+  /**
+   * Prevádzku vracia len test, ktorý ju naozaj potrebuje. Keby ju vracal
+   * zdieľaný mock, `scopedKey` by localStorage kľúče začal scopovať podľa
+   * prevádzky a všetky ostatné testy by si prestali nájsť nasadené dáta.
+   */
+  const mockPrevadzkaWithPerMealMenus = () => {
+    const original = mockApiFetch.getMockImplementation()!;
+    mockApiFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes("/prevadzky/")) {
+        return Promise.resolve(
+          makeMockResponse([
+            {
+              id: 11,
+              nazov: "Test prevádzka",
+              adresa: "",
+              celok: "Test celok",
+              visible_menus: ["A", "B", "C", "V"],
+              visible_menus_per_meal: { breakfast: ["A"], olovrant: ["A"] },
+              visible_meals: ["breakfast", "lunch", "olovrant"],
+              pack_separately_enabled: false,
+            },
+          ]),
+        );
+      }
+      return original(url, init);
+    });
+  };
+
   it("Copy Olovrant: Copies data from Lunch when triggered", async () => {
     const date = localDateStr();
     // 1. Seed existing order with Lunch data using VALID category keys (e.g. Škôlka)
@@ -244,6 +290,99 @@ describe("OrderPage Logic & Triggers", () => {
       const updated = getOrderData(date);
       expect(updated.lunch["Škôlka"].menuCounts["A"]).toBe(8);
     });
+  });
+
+  it("typed menu input selects value and empty blur commits 0", async () => {
+    const date = localDateStr();
+    localStorageMock.setItem(
+      `order_${date}`,
+      JSON.stringify({
+        status: "draft",
+        breakfast: { Škôlka: { menuCounts: { A: 2 }, diets: {} } },
+        lunch: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+        olovrant: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+      }),
+    );
+    localStorageMock.setItem(
+      `activeMeals_${date}`,
+      JSON.stringify({ breakfast: true, lunch: false, olovrant: false }),
+    );
+
+    renderPage();
+
+    const breakfastCard = getMealCard("Raňajky");
+    // Menu A má každá kategória, tak sa zúžime na tú, ktorú test nasadil.
+    const skolkaRow = getCategoryRow(breakfastCard, "Škôlka");
+    const input = await within(skolkaRow).findByLabelText("Počet porcií pre menu A");
+
+    fireEvent.focus(input);
+    expect((input as HTMLInputElement).selectionStart).toBe(0);
+    expect((input as HTMLInputElement).selectionEnd).toBe(String((input as HTMLInputElement).value).length);
+
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(getOrderData(date).breakfast["Škôlka"].menuCounts.A).toBe(0);
+    });
+  });
+
+  it("typed diet input uses the same cap as the +/- path", async () => {
+    const date = localDateStr();
+    localStorageMock.setItem(
+      `order_${date}`,
+      JSON.stringify({
+        status: "draft",
+        breakfast: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+        lunch: { Škôlka: { menuCounts: { A: 2 }, diets: { "Bez lepku": 1 } } },
+        olovrant: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+      }),
+    );
+    localStorageMock.setItem(
+      `activeMeals_${date}`,
+      JSON.stringify({ breakfast: false, lunch: true, olovrant: false }),
+    );
+
+    // Názov diéty musí byť z konštanty DIETS — inak ho `enforceStructure`
+    // pri načítaní objednávky zahodí a počet diét vyjde 0.
+    (OrderService.getAvailableDiets as Mock).mockReturnValue(["Bez lepku"]);
+
+    renderPage();
+
+    const lunchCard = getMealCard("Obed");
+    const skolkaRow = getCategoryRow(lunchCard, "Škôlka");
+    fireEvent.click(await within(skolkaRow).findByText("1 diét"));
+
+    const dietInput = await screen.findByLabelText("Počet diéty Bez lepku");
+    // Cap je menuCounts.A = 2, takže napísaná 5 sa nesmie uložiť — rovnako ako
+    // by ju neprepustilo klikanie na +.
+    fireEvent.change(dietInput, { target: { value: "5" } });
+    fireEvent.blur(dietInput);
+
+    await waitFor(() => {
+      expect(getOrderData(date).lunch["Škôlka"].diets["Bez lepku"]).toBe(1);
+    });
+  });
+
+  it("hides breakfast and olovrant menu choices configured to only menu A", async () => {
+    mockPrevadzkaWithPerMealMenus();
+    const date = localDateStr();
+    localStorageMock.setItem(
+      `activeMeals_${date}`,
+      JSON.stringify({ breakfast: true, lunch: true, olovrant: true }),
+    );
+
+    renderPage();
+
+    // „Škôlka“ má v GROUP_CONFIG len menu A, takže rozdiel medzi chodmi vidno
+    // len na kategórii, ktorá menu B vôbec ponúka.
+    const row = (meal: string) => getCategoryRow(getMealCard(meal), "ZŠ 1.stupeň");
+
+    await waitFor(() => {
+      expect(within(row("Obed")).getByText("Menu B")).toBeInTheDocument();
+    });
+    expect(within(row("Raňajky")).queryByText("Menu B")).not.toBeInTheDocument();
+    expect(within(row("Olovrant")).queryByText("Menu B")).not.toBeInTheDocument();
   });
 
   it("Copy Breakfast: Copies from Previous Day Lunch", async () => {

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -50,6 +50,7 @@ const OrderPage = () => {
     submitOrder,
     adminVisibleMeals,
     adminVisibleMenus,
+    getVisibleMenusForMeal,
     globalDeadlines,
     loadBreakfastFromPrevLunch,
     copyLunchFromCurrentBreakfast,
@@ -68,7 +69,7 @@ const OrderPage = () => {
     if (!mealPlanAvailability) return new Set();
     const available = mealPlanAvailability[mealKey];
     if (!available) return new Set();
-    return new Set(adminVisibleMenus.filter((m: string) => !available.has(m)));
+    return new Set(getVisibleMenusForMeal(mealKey as MealKey).filter((m: string) => !available.has(m)));
   };
 
   const { isTourActive, currentStep } = useOnboarding();
@@ -144,6 +145,16 @@ const OrderPage = () => {
       ? meals.filter((m) => adminVisibleMeals.includes(m.key))
       : meals;
   const firstVisibleMealKey = visibleMealsList[0]?.key as MealKey | undefined;
+
+  // Celodenka zadáva jeden set porcií pre všetky chody, takže smie ponúknuť len
+  // menu, ktoré sú viditeľné vo VŠETKÝCH viditeľných chodoch — prienik. Inak by
+  // sa dalo cez celodenku objednať menu B na olovrant, ktorý má povolené len A.
+  const fullDayVisibleMenus =
+    visibleMealsList.reduce<string[] | null>((acc, meal) => {
+      const mealMenus = getVisibleMenusForMeal(meal.key as MealKey);
+      if (acc === null) return mealMenus;
+      return acc.filter((menu) => mealMenus.includes(menu));
+    }, null) ?? adminVisibleMenus;
   const isFullDayDeadlineOpen = firstVisibleMealKey
     ? OrderService.checkDeadline(selectedDate, firstVisibleMealKey, globalDeadlines)
     : false;
@@ -474,7 +485,7 @@ const OrderPage = () => {
                 dietCount={dietCount}
                 onOpenDiets={() => setActiveDietModal({ meal: "fullDay", category })}
                 disabled={false}
-                visibleMenus={adminVisibleMenus}
+                visibleMenus={fullDayVisibleMenus}
               />
             );
           })}
@@ -526,7 +537,7 @@ const OrderPage = () => {
                       isEditable && !isHoliday && setActiveDietModal({ meal: key, category })
                     }
                     disabled={!isEditable || !!isHoliday}
-                    visibleMenus={adminVisibleMenus}
+                    visibleMenus={getVisibleMenusForMeal(key)}
                     occupiedMenus={getOccupiedMenus(key)}
                     tourId={mealIndex === 0 && catIndex === 0 ? "tour-category-row" : undefined}
                   />

--- a/frontend/src/pages/client/services/OrderService.ts
+++ b/frontend/src/pages/client/services/OrderService.ts
@@ -64,6 +64,10 @@ class OrderService {
         return CATEGORIES.reduce((acc, cat) => ({ ...acc, [cat]: this.createEmptyCategory(cat) }), {} as MealData);
     }
 
+    static createEmptyMealFor(categories: string[]): MealData {
+        return categories.reduce((acc, cat) => ({ ...acc, [cat]: this.createEmptyCategory(cat) }), {} as MealData);
+    }
+
     static createEmptyOrder(): DailyOrder {
         return {
             status: 'draft',


### PR DESCRIPTION
Admin editor objednávok (`AdminOrderEditorModal`, otvára sa z detailu klienta) vedel objednávku **ticho poškodiť** a chýbali mu dve funkcie, ktoré klient bežne má.

## Straty dát

Obe som pred opravou overil empiricky a obe sú teraz zamknuté testom, ktorý kontroluje **skutočné JSON telo poslané do `apiFetch`** — nie len to, čo sa vykreslí.

**1. Kategória „Predškolák" sa strácala.** Editor renderoval natvrdo zapísaný zoznam `CATEGORIES` (5 položiek), no v DB je 6 `PortionType` vrátane „Predškolák". Klient si ich ťahá z API, admin nie. Horšia časť: `buildInitialOrder` púšťa `enforceStructure(raw, createEmptyMeal())`, a `enforceStructure` ponechá len kľúče prítomné v schéme — takže otvorenie a uloženie objednávky s Predškolákom **tie porcie zmazalo**.

Kategórie sa teraz berú z `/admin/portion-types/`. Schéma sa stavia ako **zjednotenie** týchto názvov a kategórií, ktoré v objednávke reálne sú — kategória sa tak nemôže stratiť ani vtedy, keď ju niekto v číselníku deaktivuje.

**2. `special_diet_note` sa strácala.** Klient ju posiela vnútri `data` a pri diéte „Špeciálna" je povinná. Admin ju do payloadu nedával a `data` je JSONField prepisovaný celý — takže PATCH z admina poznámku od škôlky zmazal. Teraz sa prenáša a je editovateľná.

Pre poriadok: „zabaliť zvlášť" sa **nestrácalo** — `createEmptyCategory` ten kľúč obsahuje, takže hodnoty prechádzali. Bola to chýbajúca funkcia, nie strata dát.

## Nové funkcie

- **„Zabaliť zvlášť"** cez existujúci `PackSeparatelySelector`, riadené príznakom `pack_separately_enabled` prevádzky (ten už v `ClientDetail` bol, len sa nikam neposielal).
- **Režim „Celý deň rovnaký"** — jeden set porcií sa pri uložení rozkopíruje do viditeľných chodov, presne ako `submitOrder` u klienta. Celodenka **nie je samostatný tvar na backende**, uložený JSON je identický s bežnou objednávkou, takže ide čisto o spôsob zadávania.

## Poznámka k špeciálnej diéte

Zobrazuje sa v rozbalenom riadku objednávky v detaile klienta. Doteraz ju **nečítal nikto** — ani backend, ani admin UI, ani žiadny export — hoci ju klient musí povinne vyplniť. Rozhodol som sa ju začať zobrazovať namiesto zrušenia povinnosti: nesie reálnu informáciu (alergia, zdravotné obmedzenie), ktorú niekto vedome napísal.

**Mimo rozsahu:** PDF/XLSX exporty a gramáže. To je zmena v `MealPlanService.gramage_dashboard` a dvoch exportéroch — samostatný kus práce. Ak to má vidieť kuchyňa na papieri, dorobím.

## Testy

17 testov v `AdminOrderEditorModal.test.tsx` — pôvodných 12 zachovaných, 5 nových:
- kategória mimo natvrdo zapísaného zoznamu sa vykreslí **aj ostane v PATCH payloade**
- `special_diet_note` prežije uloženie bez toho, aby sa jej niekto dotkol
- úprava textarey sa prejaví v payloade
- pack-separately UI je len pri zapnutom príznaku a zmena počtu sa uloží pod `packSeparately`
- celodenka rozkopíruje jeden `MealData` do všetkých viditeľných chodov

Zelené: 108 frontend testov, `tsc`, `eslint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)