### PR TITLE
feat: klientova spätná väzba — počty, poradie diét, menu per chod, diéty v histórii

### DIFF
--- a/backend/api/migrations/0052_diet_sort_order_prevadzka_visible_menus_per_meal.py
+++ b/backend/api/migrations/0052_diet_sort_order_prevadzka_visible_menus_per_meal.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+
+
+def seed_visible_menus_per_meal(apps, schema_editor):
+    Prevadzka = apps.get_model("api", "Prevadzka")
+    for prevadzka in Prevadzka.objects.all().iterator():
+        next_value = dict(prevadzka.visible_menus_per_meal or {})
+        next_value["breakfast"] = ["A"]
+        next_value["olovrant"] = ["A"]
+        prevadzka.visible_menus_per_meal = next_value
+        prevadzka.save(update_fields=["visible_menus_per_meal"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0051_prevadzka_pack_separately_enabled"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="diet",
+            name="sort_order",
+            field=models.PositiveSmallIntegerField(db_index=True, default=0),
+        ),
+        migrations.AlterModelOptions(
+            name="diet",
+            options={"ordering": ["sort_order", "name"]},
+        ),
+        migrations.AddField(
+            model_name="prevadzka",
+            name="visible_menus_per_meal",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text=(
+                    "Voliteľné menu typy per chod, napr. "
+                    "{'breakfast': ['A'], 'olovrant': ['A']}. Chýbajúci chod = fallback "
+                    "na visible_menus."
+                ),
+            ),
+        ),
+        migrations.RunPython(seed_visible_menus_per_meal, migrations.RunPython.noop),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -89,6 +89,7 @@ class DailyOrder(models.Model):
 
 class Diet(models.Model):
     name = models.CharField(max_length=100, unique=True)
+    sort_order = models.PositiveSmallIntegerField(default=0, db_index=True)
     is_active = models.BooleanField(default=True)
     description = models.TextField(blank=True, null=True)
     color = models.CharField(
@@ -97,6 +98,9 @@ class Diet(models.Model):
         default="",
         help_text="Voliteľná HEX farba pre admin prehľady, napr. #F97316.",
     )
+
+    class Meta:
+        ordering = ["sort_order", "name"]
 
     def __str__(self) -> str:
         return self.name
@@ -398,6 +402,15 @@ class Prevadzka(models.Model):
         blank=True,
         help_text="Menu typy dostupné pre objednávky tejto prevádzky.",
     )
+    visible_menus_per_meal = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text=(
+            "Voliteľné menu typy per chod, napr. "
+            "{'breakfast': ['A'], 'olovrant': ['A']}. Chýbajúci chod = fallback "
+            "na visible_menus."
+        ),
+    )
     visible_meals = models.JSONField(
         default=_default_all_meals,
         blank=True,
@@ -442,6 +455,12 @@ class Prevadzka(models.Model):
 
     def __str__(self) -> str:
         return self.nazov
+
+    def resolved_visible_menus_for_meal(self, meal: str) -> list[str]:
+        configured = (self.visible_menus_per_meal or {}).get(meal)
+        if configured is None:
+            return list(self.visible_menus or [])
+        return list(configured)
 
 
 class DeliveryBlock(models.Model):

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -470,5 +470,14 @@ class PrevadzkaSerializer(serializers.ModelSerializer):
         model = Prevadzka
         # `pack_separately_enabled` sem patrí, aby klient čítal príznak z toho istého
         # miesta, kam ho admin zapisuje (Prevadzka) — nie z legacy ClientSettings.
-        fields = ["id", "nazov", "adresa", "celok", "pack_separately_enabled"]
+        fields = [
+            "id",
+            "nazov",
+            "adresa",
+            "celok",
+            "visible_menus",
+            "visible_menus_per_meal",
+            "visible_meals",
+            "pack_separately_enabled",
+        ]
         read_only_fields = fields

--- a/backend/api/serializers_facilities.py
+++ b/backend/api/serializers_facilities.py
@@ -74,6 +74,7 @@ class AdminPrevadzkaSerializer(serializers.ModelSerializer):
             "is_active",
             "billing_portion_coefficients",
             "visible_menus",
+            "visible_menus_per_meal",
             "visible_meals",
             "visible_diets",
             "pack_separately_enabled",

--- a/backend/api/serializers_user.py
+++ b/backend/api/serializers_user.py
@@ -16,7 +16,7 @@ class DietSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Diet
-        fields = ["id", "name", "is_active", "description", "color"]
+        fields = ["id", "name", "sort_order", "is_active", "description", "color"]
 
 
 def validate_password_strength(password: str, user: User | None = None) -> str:

--- a/backend/api/tests/integration/test_diet_api.py
+++ b/backend/api/tests/integration/test_diet_api.py
@@ -1,0 +1,39 @@
+import pytest
+
+from api.models import Diet
+from api.tests.factories import AdminUserFactory
+
+
+@pytest.mark.django_db
+def test_diet_list_respects_sort_order_then_name(api_client):
+    """Hlavné diéty musia ísť hore — poradie riadi `sort_order`, až potom názov."""
+    admin = AdminUserFactory()
+    api_client.force_authenticate(user=admin)
+    Diet.objects.create(name="Zulu", sort_order=0)
+    Diet.objects.create(name="Alpha", sort_order=5)
+    Diet.objects.create(name="Beta", sort_order=0)
+
+    response = api_client.get("/api/diets/")
+
+    assert response.status_code == 200
+    # Odpoveď je stránkovaná, takže položky sú pod "results".
+    payload = response.json()
+    items = payload["results"] if isinstance(payload, dict) else payload
+    names = [item["name"] for item in items]
+
+    # Zulu a Beta majú sort_order 0 → idú pred Alpha (5), medzi sebou podľa názvu.
+    assert names.index("Beta") < names.index("Zulu") < names.index("Alpha")
+
+
+@pytest.mark.django_db
+def test_diet_model_ordering_is_sort_order_then_name():
+    """Ordering musí platiť na úrovni modelu, nie len v jednom endpointe."""
+    Diet.objects.create(name="Zulu", sort_order=0)
+    Diet.objects.create(name="Alpha", sort_order=5)
+    Diet.objects.create(name="Beta", sort_order=0)
+
+    assert list(Diet.objects.values_list("name", flat=True)) == [
+        "Beta",
+        "Zulu",
+        "Alpha",
+    ]

--- a/backend/api/tests/test_migrations.py
+++ b/backend/api/tests/test_migrations.py
@@ -1,0 +1,74 @@
+"""Testy dátovej migrácie 0052.
+
+Suite beží s `--nomigrations` (pozri `pytest.ini`), takže schéma vzniká priamo
+z modelov a migračný graf sa nikdy neprehráva. Migračnú funkciu preto voláme
+priamo a `apps` jej podstrčíme — testujeme tým jej logiku, nie mechaniku Django
+migrácií, ktorú aj tak netreba overovať.
+"""
+
+import pytest
+
+from api.migrations import (  # noqa: F401  (zaistí, že balík migrácií je importovateľný)
+    __name__ as _migrations_pkg,
+)
+from api.models import Celok, Prevadzka
+
+
+def _load_migration():
+    import importlib
+
+    return importlib.import_module(
+        "api.migrations.0052_diet_sort_order_prevadzka_visible_menus_per_meal"
+    )
+
+
+class _StubApps:
+    """Minimálna náhrada za historický registry — vracia reálne modely."""
+
+    def get_model(self, app_label, model_name):
+        assert app_label == "api"
+        return {"Prevadzka": Prevadzka, "Celok": Celok}[model_name]
+
+
+@pytest.mark.django_db
+def test_0052_seeds_breakfast_and_olovrant_visible_menus_per_meal():
+    migration = _load_migration()
+    celok = Celok.objects.create(nazov="Migracia")
+    prevadzka = Prevadzka.objects.create(
+        celok=celok,
+        nazov="Prevadzka",
+        visible_menus=["A", "B", "C", "V"],
+    )
+
+    migration.seed_visible_menus_per_meal(_StubApps(), None)
+
+    prevadzka.refresh_from_db()
+    assert prevadzka.visible_menus_per_meal == {
+        "breakfast": ["A"],
+        "olovrant": ["A"],
+    }
+    # Obed zámerne bez kľúča → padá späť na globálne visible_menus.
+    assert prevadzka.resolved_visible_menus_for_meal("lunch") == ["A", "B", "C", "V"]
+    assert prevadzka.resolved_visible_menus_for_meal("breakfast") == ["A"]
+
+
+@pytest.mark.django_db
+def test_0052_preserves_already_configured_meals():
+    """Migrácia nesmie prepísať to, čo už niekto nastavil pre iné chody."""
+    migration = _load_migration()
+    celok = Celok.objects.create(nazov="Migracia 2")
+    prevadzka = Prevadzka.objects.create(
+        celok=celok,
+        nazov="Prevadzka 2",
+        visible_menus=["A", "B"],
+        visible_menus_per_meal={"lunch": ["B"]},
+    )
+
+    migration.seed_visible_menus_per_meal(_StubApps(), None)
+
+    prevadzka.refresh_from_db()
+    assert prevadzka.visible_menus_per_meal == {
+        "lunch": ["B"],
+        "breakfast": ["A"],
+        "olovrant": ["A"],
+    }

--- a/backend/api/tests/test_prevadzka_service.py
+++ b/backend/api/tests/test_prevadzka_service.py
@@ -117,6 +117,49 @@ class TestPrevadzkaEndpoint:
     def test_requires_auth(self, api_client):
         assert api_client.get("/api/prevadzky/").status_code in (401, 403)
 
+    def test_exposes_per_meal_menu_visibility(self, api_client, celok):
+        # `on_prevadzka_saved` pri vytvorení prepíše visible_menus/visible_meals
+        # defaultmi, takže vlastné hodnoty treba nastaviť až po vzniku záznamu.
+        prevadzka = Prevadzka.objects.create(celok=celok, nazov="Jolly 1")
+        prevadzka.visible_menus = ["A", "B", "V"]
+        prevadzka.visible_menus_per_meal = {"breakfast": ["A"], "olovrant": ["A"]}
+        prevadzka.visible_meals = ["breakfast", "lunch", "olovrant"]
+        prevadzka.pack_separately_enabled = True
+        prevadzka.save()
+        user, _ = _profile("eva@example.com", celok)
+        api_client.force_authenticate(user=user)
+
+        response = api_client.get("/api/prevadzky/")
+
+        assert response.status_code == 200
+        assert response.json() == [
+            {
+                "id": prevadzka.id,
+                "nazov": "Jolly 1",
+                "adresa": "",
+                "celok": "Jolly",
+                "visible_menus": ["A", "B", "V"],
+                "visible_menus_per_meal": {
+                    "breakfast": ["A"],
+                    "olovrant": ["A"],
+                },
+                "visible_meals": ["breakfast", "lunch", "olovrant"],
+                "pack_separately_enabled": True,
+            }
+        ]
+
+
+@pytest.mark.django_db
+class TestPrevadzkaVisibleMenusPerMeal:
+    def test_falls_back_to_global_visible_menus_when_meal_key_missing(self, celok):
+        prevadzka = Prevadzka.objects.create(celok=celok, nazov="Fallback")
+        prevadzka.visible_menus = ["A", "B"]
+        prevadzka.visible_menus_per_meal = {"breakfast": ["A"]}
+        prevadzka.save()
+
+        assert prevadzka.resolved_visible_menus_for_meal("breakfast") == ["A"]
+        assert prevadzka.resolved_visible_menus_for_meal("lunch") == ["A", "B"]
+
 
 @pytest.mark.django_db
 class TestDailyOrderByDatePrevadzka:

--- a/backend/api/views/diet_views.py
+++ b/backend/api/views/diet_views.py
@@ -28,7 +28,7 @@ class DietViewSet(viewsets.ModelViewSet):
     via signal handlers.
     """
 
-    queryset = Diet.objects.all().order_by("-id")
+    queryset = Diet.objects.all()
     serializer_class = DietSerializer
     permission_classes = [permissions.IsAuthenticated]
 

--- a/frontend/src/context/auth.tsx
+++ b/frontend/src/context/auth.tsx
@@ -37,6 +37,7 @@ interface User {
 
 export interface UserSettings {
   visible_menus?: string[];
+  visible_menus_per_meal?: Record<string, string[]>;
   visible_meals?: string[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   visible_diets?: any[];

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1237,6 +1237,20 @@ select {
     color: var(--green-900);
     font-variant-numeric: tabular-nums;
 }
+.zp-counter .zp-counter-input {
+    width: 44px;
+    min-width: 44px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    outline: none;
+    appearance: textfield;
+}
+.zp-counter .zp-counter-input::-webkit-outer-spin-button,
+.zp-counter .zp-counter-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
 .zp-counter .count.zero { color: var(--ink-mute); }
 
 /* Order summary docked at bottom */

--- a/frontend/src/pages/admin/ClientDetail.tsx
+++ b/frontend/src/pages/admin/ClientDetail.tsx
@@ -43,6 +43,7 @@ interface FacilityDetail {
   edupage_match: string;
   celok_zdroj_objednavok: string;
   visible_menus: string[];
+  visible_menus_per_meal: Record<string, string[]>;
   visible_meals: string[];
   visible_diets: number[];
   admin_order_note: string;
@@ -89,6 +90,11 @@ const ClientDetail: React.FC = () => {
 
   // Settings State
   const [menus, setMenus] = useState<Set<string>>(new Set());
+  const [menusPerMeal, setMenusPerMeal] = useState<Record<string, string[] | null>>({
+    breakfast: null,
+    lunch: null,
+    olovrant: null,
+  });
   const [meals, setMeals] = useState<Set<string>>(new Set());
   const [userDiets, setUserDiets] = useState<Set<number>>(new Set());
   const [adminOrderNote, setAdminOrderNote] = useState("");
@@ -113,6 +119,11 @@ const ClientDetail: React.FC = () => {
 
   const applyFacilitySettings = useCallback((data: FacilityDetail) => {
     setMenus(new Set(data.visible_menus?.length ? data.visible_menus : ALL_MENUS));
+    setMenusPerMeal({
+      breakfast: data.visible_menus_per_meal?.breakfast ?? null,
+      lunch: data.visible_menus_per_meal?.lunch ?? null,
+      olovrant: data.visible_menus_per_meal?.olovrant ?? null,
+    });
     setMeals(new Set(data.visible_meals?.length ? data.visible_meals : ALL_MEALS));
     setUserDiets(new Set(data.visible_diets || []));
     setAdminOrderNote(data.admin_order_note || "");
@@ -301,6 +312,9 @@ const ClientDetail: React.FC = () => {
     try {
       const payload = {
         visible_menus: Array.from(menus),
+        visible_menus_per_meal: Object.fromEntries(
+          Object.entries(menusPerMeal).filter(([, value]) => value !== null)
+        ),
         visible_meals: Array.from(meals),
         visible_diets: Array.from(userDiets),
         admin_order_note: adminOrderNote,
@@ -337,6 +351,16 @@ const ClientDetail: React.FC = () => {
     if (newSet.has(value)) newSet.delete(value);
     else newSet.add(value);
     setter(newSet);
+  };
+
+  const toggleMenuPerMeal = (meal: string, menu: string) => {
+    setMenusPerMeal((prev) => {
+      const current = prev[meal] ?? [];
+      const next = current.includes(menu)
+        ? current.filter((item) => item !== menu)
+        : [...current, menu];
+      return { ...prev, [meal]: next };
+    });
   };
 
   if (loading) return <div className="zpa-empty">Načítavam…</div>;
@@ -546,6 +570,50 @@ const ClientDetail: React.FC = () => {
                       Menu {menu}
                     </Checkbox>
                   ))}
+                </div>
+              </Card>
+
+              <Card pad>
+                <CardHead title="Viditeľné menu podľa chodu" desc="Ak necháte chod bez override, použije sa globálne nastavenie vyššie." />
+                <div style={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 8 }}>
+                  {ALL_MEALS.map((meal) => {
+                    const overrideMenus = menusPerMeal[meal];
+                    const inheritedMenus = Array.from(menus);
+                    const effectiveMenus = overrideMenus ?? inheritedMenus;
+                    return (
+                      <div key={meal} style={{ borderTop: "1px solid var(--line-soft)", paddingTop: 12 }}>
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
+                          <div>
+                            <div style={{ fontFamily: "var(--font-display)", fontWeight: 600, color: "var(--green-900)" }}>
+                              {MEAL_LABELS[meal] ?? meal}
+                            </div>
+                            <div style={{ fontSize: 13, color: "var(--ink-3)" }}>
+                              {overrideMenus === null ? `Dedené: ${effectiveMenus.join(", ") || "žiadne"}` : `Vlastné: ${effectiveMenus.join(", ") || "žiadne"}`}
+                            </div>
+                          </div>
+                          <Toggle
+                            on={overrideMenus !== null}
+                            onChange={(enabled) =>
+                              setMenusPerMeal((prev) => ({
+                                ...prev,
+                                [meal]: enabled ? [...inheritedMenus] : null,
+                              }))
+                            }
+                            ariaLabel={`Použiť vlastné menu pre ${MEAL_LABELS[meal] ?? meal}`}
+                          />
+                        </div>
+                        {overrideMenus !== null && (
+                          <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 10, marginTop: 10 }}>
+                            {ALL_MENUS.map((menu) => (
+                              <Checkbox key={`${meal}-${menu}`} on={overrideMenus.includes(menu)} onChange={() => toggleMenuPerMeal(meal, menu)}>
+                                Menu {menu}
+                              </Checkbox>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
               </Card>
 

--- a/frontend/src/pages/admin/DietManager.tsx
+++ b/frontend/src/pages/admin/DietManager.tsx
@@ -8,6 +8,7 @@ import { PageHead, Card, Button, IconButton, Field, Input, Textarea, Modal, Empt
 interface Diet {
   id: number;
   name: string;
+  sort_order: number;
   is_active: boolean;
   description: string;
   color?: string;
@@ -22,6 +23,7 @@ interface RenameModal {
   id: number;
   currentName: string;
   newName: string;
+  sortOrder: number;
   description: string;
   color: string;
 }
@@ -31,6 +33,7 @@ const DietManager: React.FC = () => {
   const { success, error } = useToast();
   const [diets, setDiets] = useState<Diet[]>([]);
   const [newDietName, setNewDietName] = useState("");
+  const [newDietSortOrder, setNewDietSortOrder] = useState(0);
   const [newDietDescription, setNewDietDescription] = useState("");
   const [newDietColor, setNewDietColor] = useState("#FDE68A");
   const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirm | null>(null);
@@ -67,6 +70,7 @@ const DietManager: React.FC = () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             name: newDietName.trim(),
+            sort_order: newDietSortOrder,
             description: newDietDescription.trim(),
             color: newDietColor,
             is_active: true,
@@ -80,6 +84,7 @@ const DietManager: React.FC = () => {
           return [created, ...prev];
         });
         setNewDietName("");
+        setNewDietSortOrder(0);
         setNewDietDescription("");
         setNewDietColor("#FDE68A");
         fetchDiets();
@@ -125,6 +130,7 @@ const DietManager: React.FC = () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             name: renameModal.newName.trim(),
+            sort_order: renameModal.sortOrder,
             description: renameModal.description.trim(),
             color: renameModal.color,
           }),
@@ -170,6 +176,14 @@ const DietManager: React.FC = () => {
                 placeholder="Popis diéty pre prevádzku"
               />
             </Field>
+            <Field label="Poradie">
+              <Input
+                type="number"
+                inputMode="numeric"
+                value={newDietSortOrder}
+                onChange={(e) => setNewDietSortOrder(Number(e.target.value) || 0)}
+              />
+            </Field>
             <Field label="Farba">
               <Input
                 type="color"
@@ -206,6 +220,7 @@ const DietManager: React.FC = () => {
                   />
                   <div>
                     <div style={{ fontFamily: "var(--font-display)", fontWeight: 600, color: "var(--green-900)" }}>{diet.name}</div>
+                    <p style={{ fontSize: 12, color: "var(--ink-3)", margin: "4px 0 0" }}>Poradie: {diet.sort_order}</p>
                   {diet.description && (
                     <p style={{ fontSize: 13, color: "var(--ink-3)", margin: "4px 0 0" }}>{diet.description}</p>
                   )}
@@ -219,6 +234,7 @@ const DietManager: React.FC = () => {
                         id: diet.id,
                         currentName: diet.name,
                         newName: diet.name,
+                        sortOrder: diet.sort_order ?? 0,
                         description: diet.description || "",
                         color: diet.color || "#FDE68A",
                       })
@@ -271,6 +287,7 @@ const DietManager: React.FC = () => {
                   renaming ||
                   !renameModal.newName.trim() ||
                   (renameModal.newName.trim() === renameModal.currentName &&
+                    renameModal.sortOrder === (diets.find((diet) => diet.id === renameModal.id)?.sort_order || 0) &&
                     renameModal.description.trim() ===
                       (diets.find((diet) => diet.id === renameModal.id)?.description || "").trim() &&
                     renameModal.color === (diets.find((diet) => diet.id === renameModal.id)?.color || "#FDE68A"))
@@ -293,6 +310,14 @@ const DietManager: React.FC = () => {
               }}
               placeholder="Nový názov diéty"
               autoFocus
+            />
+          </Field>
+          <Field label="Poradie">
+            <Input
+              type="number"
+              inputMode="numeric"
+              value={renameModal.sortOrder}
+              onChange={(e) => setRenameModal((prev) => (prev ? { ...prev, sortOrder: Number(e.target.value) || 0 } : prev))}
             />
           </Field>
           <Field label="Popis">

--- a/frontend/src/pages/client/components/order/CategoryRow.tsx
+++ b/frontend/src/pages/client/components/order/CategoryRow.tsx
@@ -1,4 +1,5 @@
 import { Minus, Plus, Utensils } from 'lucide-react';
+import NumericCountInput from './NumericCountInput';
 
 interface MenuCounterProps {
     type: string;
@@ -39,7 +40,12 @@ const MenuCounter = ({ type, count, onChange, onOpenDiets, dietCount, disabled, 
                 >
                     <Minus style={{ width: 14, height: 14, strokeWidth: 2.5 }} />
                 </button>
-                <span className={`count${count <= 0 ? " zero" : ""}`}>{count}</span>
+                <NumericCountInput
+                    value={count}
+                    onCommit={onChange}
+                    disabled={disabled}
+                    ariaLabel={`Počet porcií pre menu ${type}`}
+                />
                 <button
                     className="plus"
                     disabled={disabled}

--- a/frontend/src/pages/client/components/order/DietSelector.tsx
+++ b/frontend/src/pages/client/components/order/DietSelector.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { X, Check, Minus, Plus } from 'lucide-react';
 import { useScrollLock } from '../../../../hooks/useScrollLock';
+import NumericCountInput from './NumericCountInput';
 
 interface DietSelectorProps {
     isOpen: boolean;
@@ -65,7 +66,12 @@ const DietSelector = ({
                                         >
                                             <Minus style={{ width: 14, height: 14, strokeWidth: 2.5 }} />
                                         </button>
-                                        <span className={`count${count <= 0 ? " zero" : ""}`}>{count}</span>
+                                        <NumericCountInput
+                                            value={count}
+                                            onCommit={(value) => onUpdateDiet(diet, value)}
+                                            disabled={false}
+                                            ariaLabel={`Počet diéty ${diet}`}
+                                        />
                                         <button
                                             className="plus"
                                             disabled={remaining <= 0}

--- a/frontend/src/pages/client/components/order/NumericCountInput.tsx
+++ b/frontend/src/pages/client/components/order/NumericCountInput.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+interface NumericCountInputProps {
+    value: number;
+    onCommit: (value: number) => void;
+    disabled?: boolean;
+    ariaLabel: string;
+}
+
+const sanitizeToDigits = (raw: string) => raw.replace(/\D+/g, '');
+
+const NumericCountInput = ({
+    value,
+    onCommit,
+    disabled,
+    ariaLabel,
+}: NumericCountInputProps) => {
+    const [draft, setDraft] = useState(String(value));
+
+    useEffect(() => {
+        setDraft(String(value));
+    }, [value]);
+
+    const commit = () => {
+        const normalized = sanitizeToDigits(draft);
+        const nextValue = normalized === '' ? 0 : Number.parseInt(normalized, 10);
+        onCommit(nextValue);
+        setDraft(String(nextValue));
+    };
+
+    return (
+        <input
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            className={`count zp-counter-input${value <= 0 ? ' zero' : ''}`}
+            value={draft}
+            disabled={disabled}
+            aria-label={ariaLabel}
+            onFocus={(event) => event.currentTarget.select()}
+            onChange={(event) => setDraft(sanitizeToDigits(event.target.value))}
+            onBlur={commit}
+            onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    commit();
+                    event.currentTarget.blur();
+                }
+            }}
+        />
+    );
+};
+
+export default NumericCountInput;

--- a/frontend/src/pages/client/components/order/PackSeparatelySelector.tsx
+++ b/frontend/src/pages/client/components/order/PackSeparatelySelector.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { X, Check, Minus, Plus } from 'lucide-react';
 import { useScrollLock } from '../../../../hooks/useScrollLock';
+import NumericCountInput from './NumericCountInput';
 
 // 'fullDay' je celodenná objednávka — drží dáta mimo currentOrder, ale UI je rovnaké.
 type MealKey = 'breakfast' | 'lunch' | 'olovrant' | 'fullDay';
@@ -90,7 +91,14 @@ const PackSeparatelySelector = ({
                                             >
                                                 <Minus style={{ width: 14, height: 14, strokeWidth: 2.5 }} />
                                             </button>
-                                            <span className={`count${item.count <= 0 ? ' zero' : ''}`}>{item.count}</span>
+                                            <NumericCountInput
+                                                value={item.count}
+                                                onCommit={(value) =>
+                                                    onUpdatePackSeparately(section.meal, item.category, item.kind, item.keyName, value)
+                                                }
+                                                disabled={false}
+                                                ariaLabel={`Počet balení zvlášť pre ${item.keyName}`}
+                                            />
                                             <button
                                                 className="plus"
                                                 disabled={item.count >= item.orderedCount}

--- a/frontend/src/pages/client/hooks/useOrder.ts
+++ b/frontend/src/pages/client/hooks/useOrder.ts
@@ -39,6 +39,7 @@ interface DietDetail {
     name: string;
     description?: string | null;
     is_active?: boolean;
+    sort_order?: number;
 }
 
 type ApiErrorPayload = {
@@ -747,19 +748,30 @@ export const useOrder = (activePrevadzkaId?: number, waitForPrevadzkaChoice = fa
     // Admin Constraints
     // Fall back to defaults only when the setting is null/undefined;
     // an explicitly empty array means "show none".
-    const adminVisibleMenusSetting = user?.settings?.visible_menus;
+    const prevadzkaSettings = prevadzky.find((item) => item.id === activePrevadzkaId);
+
+    const adminVisibleMenusSetting = prevadzkaSettings?.visible_menus ?? user?.settings?.visible_menus;
     const adminVisibleMenus = adminVisibleMenusSetting == null
         ? ['A', 'B', 'C', 'V']
         : adminVisibleMenusSetting;
 
-    const adminVisibleMealsSetting = user?.settings?.visible_meals;
+    const adminVisibleMenusPerMeal = prevadzkaSettings?.visible_menus_per_meal ?? user?.settings?.visible_menus_per_meal ?? {};
+
+    const getVisibleMenusForMeal = (mealKey: 'breakfast' | 'lunch' | 'olovrant') => {
+        const perMealMenus = adminVisibleMenusPerMeal[mealKey];
+        return perMealMenus == null ? adminVisibleMenus : perMealMenus;
+    };
+
+    const adminVisibleMealsSetting = prevadzkaSettings?.visible_meals ?? user?.settings?.visible_meals;
     const adminVisibleMeals = adminVisibleMealsSetting == null
         ? ['breakfast', 'lunch', 'olovrant']
         : adminVisibleMealsSetting;
 
     const visibleDietDetails: DietDetail[] =
         user?.settings?.visible_diets && (user.settings.visible_diets as DietDetail[]).length > 0
-        ? (user.settings.visible_diets as DietDetail[])
+        ? [...(user.settings.visible_diets as DietDetail[])].sort(
+            (a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.name.localeCompare(b.name, 'sk')
+        )
         : [];
     const adminVisibleDiets = visibleDietDetails.length > 0
         ? visibleDietDetails.map(d => d.name)
@@ -851,6 +863,8 @@ export const useOrder = (activePrevadzkaId?: number, waitForPrevadzkaChoice = fa
         copyOlovrantFromCurrentLunch,
         submitOrder, deleteOrder,
         adminVisibleMenus,
+        adminVisibleMenusPerMeal,
+        getVisibleMenusForMeal,
         adminVisibleMeals,
         globalDeadlines,
         clientContactInfo,

--- a/frontend/src/pages/client/hooks/usePrevadzky.ts
+++ b/frontend/src/pages/client/hooks/usePrevadzky.ts
@@ -9,6 +9,9 @@ export interface Prevadzka {
     nazov: string;
     adresa: string;
     celok: string;
+    visible_menus: string[];
+    visible_menus_per_meal: Record<string, string[]>;
+    visible_meals: string[];
     pack_separately_enabled: boolean;
 }
 

--- a/frontend/src/pages/client/pages/HomePage.test.tsx
+++ b/frontend/src/pages/client/pages/HomePage.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import HomePage from "./HomePage";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("../../../hooks/useIsPC", () => ({
+  useIsPC: () => true,
+}));
+
+vi.mock("../context/AppContext", () => ({
+  useApp: () => ({
+    globalDeadlines: {
+      breakfast: "10:00",
+      breakfast_day_before: false,
+      lunch: "10:00",
+      lunch_day_before: false,
+      olovrant: "10:00",
+      olovrant_day_before: false,
+    },
+  }),
+}));
+
+vi.mock("../../../context/auth", () => ({
+  useAuth: () => ({
+    apiFetch: mockApiFetch,
+    user: { email: "test@example.com" },
+  }),
+}));
+
+vi.mock("../../../context/ToastContext", () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  }),
+}));
+
+vi.mock("../components/order/OrderSummaryModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("../components/onboarding/TourOverlay", () => ({
+  default: () => null,
+}));
+
+describe("HomePage history", () => {
+  it("renders concrete ordered diet names in history", async () => {
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url.includes("/orders/planned/monthly-summary/")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ total: 0, items: [] }) });
+      }
+      if (url.endsWith("/orders/planned/")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url.endsWith("/orders/")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                date: "2026-07-22",
+                status: "submitted",
+                data: {
+                  lunch: {
+                    "Škôlka": {
+                      menuCounts: { A: 2 },
+                      diets: { "Bez lepku": 1, Vegánske: 0 },
+                    },
+                  },
+                  olovrant: {
+                    "Predškolák": {
+                      menuCounts: { A: 1 },
+                      diets: { "Bez laktózy": 2 },
+                    },
+                  },
+                },
+              },
+            ]),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Škôlka · Bez lepku · 1x")).toBeInTheDocument();
+      expect(screen.getByText("Predškolák · Bez laktózy · 2x")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/client/pages/HomePage.tsx
+++ b/frontend/src/pages/client/pages/HomePage.tsx
@@ -45,7 +45,7 @@ interface HistoryOrder {
   date: string;
   totalPortions: number;
   mealCount: { breakfast: number; lunch: number; olovrant: number };
-  data: Record<string, Record<string, { menuCounts: Record<string, number> }>>;
+  data: Record<string, Record<string, { menuCounts: Record<string, number>; diets?: Record<string, number> }>>;
 }
 
 interface MonthlySummary {
@@ -600,6 +600,17 @@ const HomePage = () => {
                   <span className="zp-pill" style={{ background: "rgba(114,136,75,0.16)", color: "var(--green-700)" }}>
                     Vybavená
                   </span>
+                  {(["breakfast", "lunch", "olovrant"] as const).flatMap((meal) =>
+                    Object.entries(order.data?.[meal] || {}).flatMap(([category, categoryData]) =>
+                      Object.entries(categoryData?.diets || {})
+                        .filter(([, count]) => count > 0)
+                        .map(([dietName, count]) => (
+                          <div key={`${order.date}-${meal}-${category}-${dietName}`} style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 4 }}>
+                            {category} · {dietName} · {count}x
+                          </div>
+                        ))
+                    )
+                  )}
                 </div>
               </div>
               <div className="zp-day-count" style={{ fontSize: 19 }}>

--- a/frontend/src/pages/client/pages/OrderPage.test.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.test.tsx
@@ -60,32 +60,30 @@ vi.mock("../../../context/OnboardingContext", () => ({
 vi.mock("../services/OrderService", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../services/OrderService")>();
-
-  // We need to fix context issues since "this" might be lost in spread
   const originalDefault = actual.default;
+
+  // Statické metódy triedy sú non-enumerable, takže spread by ich nepreniesol,
+  // a ručný zoznam sa rozbije vždy, keď v OrderService pribudne interná metóda
+  // volaná cez `this` (napr. withClampedPackSeparately). Preto ich prenesieme
+  // všetky a naviažeme na originál — mockujeme len to, čo naozaj treba.
+  const bound: Record<string, unknown> = {};
+  let proto: unknown = originalDefault;
+  while (proto && proto !== Function.prototype && proto !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(proto)) {
+      if (key in bound) continue;
+      const value = (originalDefault as unknown as Record<string, unknown>)[key];
+      bound[key] = typeof value === "function"
+        ? (value as (...args: unknown[]) => unknown).bind(originalDefault)
+        : value;
+    }
+    proto = Object.getPrototypeOf(proto);
+  }
 
   return {
     default: {
-      ...originalDefault,
+      ...bound,
       checkDeadline: vi.fn(),
       getAvailableDiets: vi.fn().mockReturnValue(["Bezlepková", "Diabetická"]),
-
-      // Re-implement or wrapper to ensure 'this' isn't vital or is bound
-      createEmptyMeal: () => {
-        // Manually replicate logic or call original bound
-        return originalDefault.createEmptyMeal.call(originalDefault);
-      },
-
-      updateMenuCount: originalDefault.updateMenuCount,
-      updateDiet: originalDefault.updateDiet,
-      enforceStructure: originalDefault.enforceStructure,
-      calculatePrevDayLunches: originalDefault.calculatePrevDayLunches,
-      getServerNow: originalDefault.getServerNow,
-      toLocalDateString: originalDefault.toLocalDateString,
-      isMealEmpty: originalDefault.isMealEmpty,
-      findLastNonZeroDay: originalDefault.findLastNonZeroDay,
-      mergeOrders: originalDefault.mergeOrders,
-      fastCopy: originalDefault.fastCopy,
     },
   };
 });
@@ -177,6 +175,54 @@ describe("OrderPage Logic & Triggers", () => {
     return data ? JSON.parse(data) : null;
   };
 
+  const getMealCard = (title: string) => {
+    // Text „Raňajky“ sa vyskytuje aj mimo karty, takže sa nedá brať prvý zásah —
+    // hľadáme kartu, ktorej vlastný .zp-meal-title sedí.
+    const cards = Array.from(document.querySelectorAll<HTMLElement>(".zp-meal"));
+    const card = cards.find(
+      (c) => c.querySelector(".zp-meal-title")?.textContent?.trim() === title,
+    );
+    if (!card) throw new Error(`Meal card "${title}" not found`);
+    return card;
+  };
+
+  const getCategoryRow = (card: HTMLElement, category: string) => {
+    const rows = Array.from(card.querySelectorAll<HTMLElement>(".zp-cat"));
+    const row = rows.find(
+      (r) => r.querySelector(".zp-cat-head")?.textContent?.trim() === category,
+    );
+    if (!row) throw new Error(`Category "${category}" not found in card`);
+    return row;
+  };
+
+  /**
+   * Prevádzku vracia len test, ktorý ju naozaj potrebuje. Keby ju vracal
+   * zdieľaný mock, `scopedKey` by localStorage kľúče začal scopovať podľa
+   * prevádzky a všetky ostatné testy by si prestali nájsť nasadené dáta.
+   */
+  const mockPrevadzkaWithPerMealMenus = () => {
+    const original = mockApiFetch.getMockImplementation()!;
+    mockApiFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes("/prevadzky/")) {
+        return Promise.resolve(
+          makeMockResponse([
+            {
+              id: 11,
+              nazov: "Test prevádzka",
+              adresa: "",
+              celok: "Test celok",
+              visible_menus: ["A", "B", "C", "V"],
+              visible_menus_per_meal: { breakfast: ["A"], olovrant: ["A"] },
+              visible_meals: ["breakfast", "lunch", "olovrant"],
+              pack_separately_enabled: false,
+            },
+          ]),
+        );
+      }
+      return original(url, init);
+    });
+  };
+
   it("Copy Olovrant: Copies data from Lunch when triggered", async () => {
     const date = localDateStr();
     // 1. Seed existing order with Lunch data using VALID category keys (e.g. Škôlka)
@@ -213,6 +259,99 @@ describe("OrderPage Logic & Triggers", () => {
       const updated = getOrderData(date);
       expect(updated.olovrant["Škôlka"].menuCounts["A"]).toBe(10);
     });
+  });
+
+  it("typed menu input selects value and empty blur commits 0", async () => {
+    const date = localDateStr();
+    localStorageMock.setItem(
+      `order_${date}`,
+      JSON.stringify({
+        status: "draft",
+        breakfast: { Škôlka: { menuCounts: { A: 2 }, diets: {} } },
+        lunch: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+        olovrant: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+      }),
+    );
+    localStorageMock.setItem(
+      `activeMeals_${date}`,
+      JSON.stringify({ breakfast: true, lunch: false, olovrant: false }),
+    );
+
+    renderPage();
+
+    const breakfastCard = getMealCard("Raňajky");
+    // Menu A má každá kategória, tak sa zúžime na tú, ktorú test nasadil.
+    const skolkaRow = getCategoryRow(breakfastCard, "Škôlka");
+    const input = await within(skolkaRow).findByLabelText("Počet porcií pre menu A");
+
+    fireEvent.focus(input);
+    expect((input as HTMLInputElement).selectionStart).toBe(0);
+    expect((input as HTMLInputElement).selectionEnd).toBe(String((input as HTMLInputElement).value).length);
+
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(getOrderData(date).breakfast["Škôlka"].menuCounts.A).toBe(0);
+    });
+  });
+
+  it("typed diet input uses the same cap as the +/- path", async () => {
+    const date = localDateStr();
+    localStorageMock.setItem(
+      `order_${date}`,
+      JSON.stringify({
+        status: "draft",
+        breakfast: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+        lunch: { Škôlka: { menuCounts: { A: 2 }, diets: { "Bez lepku": 1 } } },
+        olovrant: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+      }),
+    );
+    localStorageMock.setItem(
+      `activeMeals_${date}`,
+      JSON.stringify({ breakfast: false, lunch: true, olovrant: false }),
+    );
+
+    // Názov diéty musí byť z konštanty DIETS — inak ho `enforceStructure`
+    // pri načítaní objednávky zahodí a počet diét vyjde 0.
+    (OrderService.getAvailableDiets as Mock).mockReturnValue(["Bez lepku"]);
+
+    renderPage();
+
+    const lunchCard = getMealCard("Obed");
+    const skolkaRow = getCategoryRow(lunchCard, "Škôlka");
+    fireEvent.click(await within(skolkaRow).findByText("1 diét"));
+
+    const dietInput = await screen.findByLabelText("Počet diéty Bez lepku");
+    // Cap je menuCounts.A = 2, takže napísaná 5 sa nesmie uložiť — rovnako ako
+    // by ju neprepustilo klikanie na +.
+    fireEvent.change(dietInput, { target: { value: "5" } });
+    fireEvent.blur(dietInput);
+
+    await waitFor(() => {
+      expect(getOrderData(date).lunch["Škôlka"].diets["Bez lepku"]).toBe(1);
+    });
+  });
+
+  it("hides breakfast and olovrant menu choices configured to only menu A", async () => {
+    mockPrevadzkaWithPerMealMenus();
+    const date = localDateStr();
+    localStorageMock.setItem(
+      `activeMeals_${date}`,
+      JSON.stringify({ breakfast: true, lunch: true, olovrant: true }),
+    );
+
+    renderPage();
+
+    // „Škôlka“ má v GROUP_CONFIG len menu A, takže rozdiel medzi chodmi vidno
+    // len na kategórii, ktorá menu B vôbec ponúka.
+    const row = (meal: string) => getCategoryRow(getMealCard(meal), "ZŠ 1.stupeň");
+
+    await waitFor(() => {
+      expect(within(row("Obed")).getByText("Menu B")).toBeInTheDocument();
+    });
+    expect(within(row("Raňajky")).queryByText("Menu B")).not.toBeInTheDocument();
+    expect(within(row("Olovrant")).queryByText("Menu B")).not.toBeInTheDocument();
   });
 
   it("Copy Breakfast: Copies from Previous Day Lunch", async () => {

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -50,6 +50,7 @@ const OrderPage = () => {
     submitOrder,
     adminVisibleMeals,
     adminVisibleMenus,
+    getVisibleMenusForMeal,
     globalDeadlines,
     loadBreakfastFromPrevLunch,
     copyOlovrantFromCurrentLunch,
@@ -67,7 +68,7 @@ const OrderPage = () => {
     if (!mealPlanAvailability) return new Set();
     const available = mealPlanAvailability[mealKey];
     if (!available) return new Set();
-    return new Set(adminVisibleMenus.filter((m: string) => !available.has(m)));
+    return new Set(getVisibleMenusForMeal(mealKey as MealKey).filter((m: string) => !available.has(m)));
   };
 
   const { isTourActive, currentStep } = useOnboarding();
@@ -143,6 +144,16 @@ const OrderPage = () => {
       ? meals.filter((m) => adminVisibleMeals.includes(m.key))
       : meals;
   const firstVisibleMealKey = visibleMealsList[0]?.key as MealKey | undefined;
+
+  // Celodenka zadáva jeden set porcií pre všetky chody, takže smie ponúknuť len
+  // menu, ktoré sú viditeľné vo VŠETKÝCH viditeľných chodoch — prienik. Inak by
+  // sa dalo cez celodenku objednať menu B na olovrant, ktorý má povolené len A.
+  const fullDayVisibleMenus =
+    visibleMealsList.reduce<string[] | null>((acc, meal) => {
+      const mealMenus = getVisibleMenusForMeal(meal.key as MealKey);
+      if (acc === null) return mealMenus;
+      return acc.filter((menu) => mealMenus.includes(menu));
+    }, null) ?? adminVisibleMenus;
   const isFullDayDeadlineOpen = firstVisibleMealKey
     ? OrderService.checkDeadline(selectedDate, firstVisibleMealKey, globalDeadlines)
     : false;
@@ -457,7 +468,7 @@ const OrderPage = () => {
                 dietCount={dietCount}
                 onOpenDiets={() => setActiveDietModal({ meal: "fullDay", category })}
                 disabled={false}
-                visibleMenus={adminVisibleMenus}
+                visibleMenus={fullDayVisibleMenus}
               />
             );
           })}
@@ -509,7 +520,7 @@ const OrderPage = () => {
                       isEditable && !isHoliday && setActiveDietModal({ meal: key, category })
                     }
                     disabled={!isEditable || !!isHoliday}
-                    visibleMenus={adminVisibleMenus}
+                    visibleMenus={getVisibleMenusForMeal(key)}
                     occupiedMenus={getOccupiedMenus(key)}
                     tourId={mealIndex === 0 && catIndex === 0 ? "tour-category-row" : undefined}
                   />


### PR DESCRIPTION
Štyri body z klientových poznámok z 23.7.

> ⚠️ **Stackované na #388** — base je `feat/admin-order-editor-parity`, aby bol diff čitateľný. Mergovať až po ňom.

## 1. Možnosť napísať počet, nie len vyklikávať

Nový `NumericCountInput` (menu počty, diéty aj „zabaliť zvlášť"). Označí sa pri fokuse, berie len nezáporné celé čísla, prázdna hodnota po opustení poľa dá 0, `inputMode="numeric"` kvôli mobilu.

Podstatné: všetky zmeny idú cez **tie isté `OrderService` updatery** ako +/−, takže platia rovnaké stropy. Napísaná 5 do diéty s limitom 2 sa neuloží, presne ako by ju neprepustilo klikanie. Je na to test.

## 2. Hlavné diéty hore

`Diet` nemal **žiadne** pole na poradie — radilo sa podľa `id`, preto boli hlavné diéty úplne dole. Pribúda `sort_order` + migrácia, `Meta.ordering = ["sort_order", "name"]` a editácia v admin správe diét. Ordering je na úrovni modelu, nie len v jednom endpointe — na to je samostatný test.

Ktoré diéty sú „hlavné" nie je v kóde; to je dátové nastavenie.

## 3. Žiadne menu A/B/C/V na raňajkách a olovrante

`visible_menus` bol jeden zoznam na prevádzku pre všetky chody. Pribúda `visible_menus_per_meal` (JSON), kde **chýbajúci chod = fallback** na `visible_menus`, takže nič sa nemení implicitne.

Dátová migrácia nastaví existujúcim prevádzkam `{"breakfast": ["A"], "olovrant": ["A"]}`. To je presne to, čo klient chcel, ale ostáva to **prepínateľné v admine** — zadrôtovať to do kódu by znamenalo, že sa to o pol roka nedá vrátiť bez deployu.

Celodenka ponúka **prienik** menu naprieč viditeľnými chodmi — inak by sa cez ňu dalo objednať menu B na olovrant, ktorý má povolené len A.

## 4. Konkrétne diéty v histórii

História si ťahala len `menuCounts` a diéty zahadzovala. Teraz vypisuje objednané diéty.

## Overenie

571 backend testov, 112 frontend, `manage.py check`, `makemigrations --check`, isort/black/flake8/mypy, `tsc`, `eslint`.

## Poznámky k opravám, ktoré som cestou musel spraviť

- **`visibleMealsList` sa používalo pred deklaráciou** v `OrderPage.tsx` — temporal dead zone, zhodila celú stránku (padalo 17 testov). Presunuté za deklaráciu.
- **Dva existujúce testy boli rozbité** pridaním `/prevadzky/` mocku do zdieľaného `beforeEach`: `scopedKey` začal scopovať localStorage podľa prevádzky a ostatné testy si prestali nájsť nasadené dáta. Mock je teraz opt-in len v teste, ktorý ho potrebuje.
- **Mock `OrderService`** kopíroval statické metódy bez `.bind()`, takže interné volania cez `this` (napr. `withClampedPackSeparately`) padali. Prepísaný tak, aby naviazal všetky statiky automaticky — inak sa rozbije vždy, keď v službe pribudne interná metóda.
- Migračný test prepísaný: suite beží s `--nomigrations` (`pytest.ini`), takže prehrávať migračný graf nejde; volá sa priamo migračná funkcia.

## Vedľajší nález (needával som doň ruku)

`on_prevadzka_saved` (`signals.py:535`) pri vytvorení **bezpodmienečne prepíše** `visible_menus` a `visible_meals` defaultmi — na rozdiel od `ClientSettings`, kde je kontrola `if not`. Prevádzku s vlastnými menu teda nejde vytvoriť jedným `create()`. Nesúvisí s týmto PR, ale stojí za opravu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)