### PR TITLE
fix(backend): keep contract migrations rolling-safe

### DIFF
--- a/backend/api/migrations/0057_remove_legacy_facility_models.py
+++ b/backend/api/migrations/0057_remove_legacy_facility_models.py
@@ -140,6 +140,53 @@ contract_state_operations = [
     ),
 ]
 
+legacy_insert_defaults = migrations.RunSQL(
+    sql=[
+        (
+            """
+            ALTER TABLE api_userprofile
+                ALTER COLUMN api_identifier SET DEFAULT '',
+                ALTER COLUMN billing_name SET DEFAULT '',
+                ALTER COLUMN dic SET DEFAULT '',
+                ALTER COLUMN ico SET DEFAULT '',
+                ALTER COLUMN is_edupage SET DEFAULT false,
+                ALTER COLUMN mealsguest_url SET DEFAULT '';
+            """,
+            None,
+        ),
+        (
+            """
+            ALTER TABLE api_celok
+                ALTER COLUMN edupage_api_identifier SET DEFAULT '',
+                ALTER COLUMN mealsguest_url SET DEFAULT '';
+            """,
+            None,
+        ),
+    ],
+    reverse_sql=[
+        (
+            """
+            ALTER TABLE api_userprofile
+                ALTER COLUMN api_identifier DROP DEFAULT,
+                ALTER COLUMN billing_name DROP DEFAULT,
+                ALTER COLUMN dic DROP DEFAULT,
+                ALTER COLUMN ico DROP DEFAULT,
+                ALTER COLUMN is_edupage DROP DEFAULT,
+                ALTER COLUMN mealsguest_url DROP DEFAULT;
+            """,
+            None,
+        ),
+        (
+            """
+            ALTER TABLE api_celok
+                ALTER COLUMN edupage_api_identifier DROP DEFAULT,
+                ALTER COLUMN mealsguest_url DROP DEFAULT;
+            """,
+            None,
+        ),
+    ],
+)
+
 
 class Migration(migrations.Migration):
 
@@ -150,7 +197,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(final_legacy_backfill, migrations.RunPython.noop),
         migrations.SeparateDatabaseAndState(
-            database_operations=[],
+            database_operations=[legacy_insert_defaults],
             state_operations=contract_state_operations,
         ),
     ]

--- a/backend/api/migrations/0057_remove_legacy_facility_models.py
+++ b/backend/api/migrations/0057_remove_legacy_facility_models.py
@@ -78,6 +78,69 @@ def final_legacy_backfill(apps, schema_editor):
         celok.save(update_fields=["billing_name", "ico", "dic"])
 
 
+contract_state_operations = [
+    migrations.RemoveField(
+        model_name="clientsettings",
+        name="user",
+    ),
+    migrations.RemoveField(
+        model_name="clientsettings",
+        name="visible_diets",
+    ),
+    migrations.RemoveIndex(
+        model_name="edupageupload",
+        name="api_edupage_date_e8e32b_idx",
+    ),
+    migrations.RemoveField(
+        model_name="celok",
+        name="edupage_api_identifier",
+    ),
+    migrations.RemoveField(
+        model_name="celok",
+        name="mealsguest_url",
+    ),
+    migrations.RemoveField(
+        model_name="edupageupload",
+        name="operation",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="api_identifier",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="billing_name",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="celok",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="dic",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="ico",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="is_edupage",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="mealsguest_url",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="prevadzky",
+    ),
+    migrations.DeleteModel(
+        name="ClientSettings",
+    ),
+]
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -86,63 +149,8 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(final_legacy_backfill, migrations.RunPython.noop),
-        migrations.RemoveField(
-            model_name="clientsettings",
-            name="user",
-        ),
-        migrations.RemoveField(
-            model_name="clientsettings",
-            name="visible_diets",
-        ),
-        migrations.RemoveIndex(
-            model_name="edupageupload",
-            name="api_edupage_date_e8e32b_idx",
-        ),
-        migrations.RemoveField(
-            model_name="celok",
-            name="edupage_api_identifier",
-        ),
-        migrations.RemoveField(
-            model_name="celok",
-            name="mealsguest_url",
-        ),
-        migrations.RemoveField(
-            model_name="edupageupload",
-            name="operation",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="api_identifier",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="billing_name",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="celok",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="dic",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="ico",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="is_edupage",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="mealsguest_url",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="prevadzky",
-        ),
-        migrations.DeleteModel(
-            name="ClientSettings",
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=contract_state_operations,
         ),
     ]

--- a/backend/api/migrations/0058_delete_edupageupload.py
+++ b/backend/api/migrations/0058_delete_edupageupload.py
@@ -3,13 +3,6 @@
 from django.db import migrations
 
 
-def delete_uploaded_files(apps, schema_editor):
-    EdupageUpload = apps.get_model("api", "EdupageUpload")
-    for upload in EdupageUpload.objects.only("file").iterator():
-        if upload.file:
-            upload.file.delete(save=False)
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -17,8 +10,12 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(delete_uploaded_files, migrations.RunPython.noop),
-        migrations.DeleteModel(
-            name="EdupageUpload",
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.DeleteModel(
+                    name="EdupageUpload",
+                ),
+            ],
         ),
     ]

--- a/backend/tests/test_legacy_contract_migration.py
+++ b/backend/tests/test_legacy_contract_migration.py
@@ -66,6 +66,17 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         migrated_prevadzka = new_apps.get_model("api", "Prevadzka").objects.get(
             pk=prevadzka.pk
         )
+        migrated_user = new_apps.get_model("auth", "User").objects.create(
+            username="post-contract",
+            email="post-contract@example.com",
+        )
+        migrated_profile = new_apps.get_model("api", "UserProfile").objects.create(
+            user=migrated_user,
+            company_name="Post-contract login",
+        )
+        post_contract_celok = new_apps.get_model("api", "Celok").objects.create(
+            nazov="Post-contract celok",
+        )
 
         assert migrated_celok.billing_name == "Fresh billing"
         assert migrated_celok.ico == "12345678"
@@ -76,6 +87,8 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         assert list(
             migrated_prevadzka.visible_diets.values_list("name", flat=True)
         ) == ["Legacy diet"]
+        assert migrated_profile.pk is not None
+        assert post_contract_celok.pk is not None
         with pytest.raises(LookupError):
             new_apps.get_model("api", "EdupageUpload")
 
@@ -105,6 +118,25 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
                     "api_edupageupload",
                 )
             }
+            cursor.execute(
+                """
+                SELECT api_identifier, billing_name, dic, ico, is_edupage,
+                       mealsguest_url
+                FROM api_userprofile
+                WHERE id = %s
+                """,
+                [migrated_profile.pk],
+            )
+            profile_legacy_values = cursor.fetchone()
+            cursor.execute(
+                """
+                SELECT edupage_api_identifier, mealsguest_url
+                FROM api_celok
+                WHERE id = %s
+                """,
+                [post_contract_celok.pk],
+            )
+            celok_legacy_values = cursor.fetchone()
 
         assert {
             "api_identifier",
@@ -117,6 +149,8 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         } <= profile_columns
         assert {"edupage_api_identifier", "mealsguest_url"} <= celok_columns
         assert "operation_id" in upload_columns
+        assert profile_legacy_values == ("", "", "", "", False, "")
+        assert celok_legacy_values == ("", "")
     finally:
         executor = MigrationExecutor(connection)
         executor.migrate(executor.loader.graph.leaf_nodes())

--- a/backend/tests/test_legacy_contract_migration.py
+++ b/backend/tests/test_legacy_contract_migration.py
@@ -78,6 +78,54 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         ) == ["Legacy diet"]
         with pytest.raises(LookupError):
             new_apps.get_model("api", "EdupageUpload")
+
+        table_names = connection.introspection.table_names()
+        assert "api_clientsettings" in table_names
+        assert "api_edupageupload" in table_names
+
+        with connection.cursor() as cursor:
+            profile_columns = {
+                column.name
+                for column in connection.introspection.get_table_description(
+                    cursor,
+                    "api_userprofile",
+                )
+            }
+            celok_columns = {
+                column.name
+                for column in connection.introspection.get_table_description(
+                    cursor,
+                    "api_celok",
+                )
+            }
+            upload_columns = {
+                column.name
+                for column in connection.introspection.get_table_description(
+                    cursor,
+                    "api_edupageupload",
+                )
+            }
+
+        assert {
+            "api_identifier",
+            "billing_name",
+            "celok_id",
+            "dic",
+            "ico",
+            "is_edupage",
+            "mealsguest_url",
+        } <= profile_columns
+        assert {"edupage_api_identifier", "mealsguest_url"} <= celok_columns
+        assert "operation_id" in upload_columns
     finally:
         executor = MigrationExecutor(connection)
         executor.migrate(executor.loader.graph.leaf_nodes())
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                DROP TABLE IF EXISTS api_edupageupload CASCADE;
+                DROP TABLE IF EXISTS api_clientsettings_visible_diets CASCADE;
+                DROP TABLE IF EXISTS api_clientsettings CASCADE;
+                DROP TABLE IF EXISTS api_userprofile_prevadzky CASCADE;
+                """
+            )

--- a/backend/tests/test_legacy_contract_migration.py
+++ b/backend/tests/test_legacy_contract_migration.py
@@ -154,12 +154,11 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
     finally:
         executor = MigrationExecutor(connection)
         executor.migrate(executor.loader.graph.leaf_nodes())
+        cleanup_sql = """
+            DROP TABLE IF EXISTS api_edupageupload CASCADE;
+            DROP TABLE IF EXISTS api_clientsettings_visible_diets CASCADE;
+            DROP TABLE IF EXISTS api_clientsettings CASCADE;
+            DROP TABLE IF EXISTS api_userprofile_prevadzky CASCADE;
+        """
         with connection.cursor() as cursor:
-            cursor.execute(
-                """
-                DROP TABLE IF EXISTS api_edupageupload CASCADE;
-                DROP TABLE IF EXISTS api_clientsettings_visible_diets CASCADE;
-                DROP TABLE IF EXISTS api_clientsettings CASCADE;
-                DROP TABLE IF EXISTS api_userprofile_prevadzky CASCADE;
-                """
-            )
+            cursor.execute(cleanup_sql)


### PR DESCRIPTION
## Problem

Production uses start-first rolling updates. Migrations 0057 and 0058 removed legacy columns and tables physically before old backend replicas had stopped, which could break overlapping replicas and rollback to the previous image.

## Fix

- keep the final legacy data backfill as a database operation
- remove legacy models and fields from Django migration state only
- retain the physical legacy schema temporarily for old replicas and rollback
- add a historical migration test covering both final state and physical compatibility

The manual EduPage upload feature remains removed from application code. Only its dormant database artifacts are retained until a later cleanup migration.

## Verification

- dedicated 0056 -> 0058 migration test: 1 passed
- backend test suite: 869 passed, 1 deselected
- Black, isort, flake8 critical checks, and mypy pass
- makemigrations reports no changes

## Follow-up

After the production rollout has settled, all replicas run the new version, and the rollback window is closed, a separate cleanup PR should physically drop the retained legacy columns/tables and remove obsolete upload files.