### PR TITLE
fix(backend): unblock deletes from legacy relations

### DIFF
--- a/backend/api/migrations/0059_fix_legacy_contract_delete_constraints.py
+++ b/backend/api/migrations/0059_fix_legacy_contract_delete_constraints.py
@@ -1,0 +1,65 @@
+from django.db import migrations
+
+forward_sql = """
+ALTER TABLE api_userprofile
+    DROP CONSTRAINT api_userprofile_celok_id_8d42dfa6_fk_api_celok_id,
+    ADD CONSTRAINT api_userprofile_celok_id_8d42dfa6_fk_api_celok_id
+        FOREIGN KEY (celok_id) REFERENCES api_celok(id)
+        ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE api_userprofile_prevadzky
+    DROP CONSTRAINT api_userprofile_prev_prevadzka_id_9103a9f6_fk_api_preva,
+    ADD CONSTRAINT api_userprofile_prev_prevadzka_id_9103a9f6_fk_api_preva
+        FOREIGN KEY (prevadzka_id) REFERENCES api_prevadzka(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    DROP CONSTRAINT api_userprofile_prev_userprofile_id_94dfae7f_fk_api_userp,
+    ADD CONSTRAINT api_userprofile_prev_userprofile_id_94dfae7f_fk_api_userp
+        FOREIGN KEY (userprofile_id) REFERENCES api_userprofile(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE api_clientsettings
+    DROP CONSTRAINT api_clientsettings_user_id_070e3596_fk_auth_user_id,
+    ADD CONSTRAINT api_clientsettings_user_id_070e3596_fk_auth_user_id
+        FOREIGN KEY (user_id) REFERENCES auth_user(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE api_clientsettings_visible_diets
+    DROP CONSTRAINT api_clientsettings_v_clientsettings_id_6ecbc8cc_fk_api_clien,
+    ADD CONSTRAINT api_clientsettings_v_clientsettings_id_6ecbc8cc_fk_api_clien
+        FOREIGN KEY (clientsettings_id) REFERENCES api_clientsettings(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    DROP CONSTRAINT api_clientsettings_v_diet_id_0e3eea9e_fk_api_diet_,
+    ADD CONSTRAINT api_clientsettings_v_diet_id_0e3eea9e_fk_api_diet_
+        FOREIGN KEY (diet_id) REFERENCES api_diet(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE api_edupageupload
+    DROP CONSTRAINT api_edupageupload_connection_id_ea124bb2_fk_api_edupa,
+    ADD CONSTRAINT api_edupageupload_connection_id_ea124bb2_fk_api_edupa
+        FOREIGN KEY (connection_id) REFERENCES api_edupageconnection(id)
+        ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED,
+    DROP CONSTRAINT api_edupageupload_operation_id_bb3bbb1e_fk_api_userprofile_id,
+    ADD CONSTRAINT api_edupageupload_operation_id_bb3bbb1e_fk_api_userprofile_id
+        FOREIGN KEY (operation_id) REFERENCES api_userprofile(id)
+        ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED,
+    DROP CONSTRAINT api_edupageupload_uploaded_by_id_5f969d4f_fk_auth_user_id,
+    ADD CONSTRAINT api_edupageupload_uploaded_by_id_5f969d4f_fk_auth_user_id
+        FOREIGN KEY (uploaded_by_id) REFERENCES auth_user(id)
+        ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED;
+"""
+
+
+reverse_sql = forward_sql.replace("ON DELETE SET NULL", "ON DELETE NO ACTION").replace(
+    "ON DELETE CASCADE", "ON DELETE NO ACTION"
+)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0058_delete_edupageupload"),
+    ]
+
+    operations = [
+        migrations.RunSQL(forward_sql, reverse_sql=reverse_sql),
+    ]

--- a/backend/tests/test_legacy_contract_migration.py
+++ b/backend/tests/test_legacy_contract_migration.py
@@ -5,9 +5,9 @@ from django.db.migrations.executor import MigrationExecutor
 
 @pytest.mark.migration
 @pytest.mark.django_db(transaction=True)
-def test_contract_migration_preserves_latest_legacy_facility_data():
+def test_contract_migration_preserves_data_and_allows_current_model_deletes():
     migrate_from = [("api", "0056_explicit_profile_access")]
-    migrate_to = [("api", "0058_delete_edupageupload")]
+    migrate_to = [("api", "0059_fix_legacy_contract_delete_constraints")]
     executor = MigrationExecutor(connection)
 
     try:
@@ -17,6 +17,7 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         Celok = old_apps.get_model("api", "Celok")
         ClientSettings = old_apps.get_model("api", "ClientSettings")
         Diet = old_apps.get_model("api", "Diet")
+        EdupageConnection = old_apps.get_model("api", "EdupageConnection")
         EdupageUpload = old_apps.get_model("api", "EdupageUpload")
         Prevadzka = old_apps.get_model("api", "Prevadzka")
         UserProfile = old_apps.get_model("api", "UserProfile")
@@ -52,11 +53,17 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
             admin_order_note="Fresh note",
         )
         settings.visible_diets.add(diet)
+        edupage_connection = EdupageConnection.objects.create(
+            name="Legacy connection",
+            mealsguest_url="https://legacy.edupage.org/menu/mealsGuest?id=test",
+        )
         EdupageUpload.objects.create(
             date="2026-07-24",
             filename="legacy.xlsx",
             file="edupage_uploads/legacy.xlsx",
             uploaded_by=user,
+            operation=profile,
+            connection=edupage_connection,
         )
 
         executor = MigrationExecutor(connection)
@@ -151,6 +158,59 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         assert "operation_id" in upload_columns
         assert profile_legacy_values == ("", "", "", "", False, "")
         assert celok_legacy_values == ("", "")
+
+        migrated_prevadzka.delete()
+        migrated_celok.delete()
+        new_apps.get_model("api", "Diet").objects.get(pk=diet.pk).delete()
+        new_apps.get_model("api", "EdupageConnection").objects.get(
+            pk=edupage_connection.pk
+        ).delete()
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT celok_id FROM api_userprofile WHERE id = %s",
+                [profile.pk],
+            )
+            assert cursor.fetchone() == (None,)
+            cursor.execute(
+                "SELECT operation_id, connection_id "
+                "FROM api_edupageupload "
+                "WHERE filename = 'legacy.xlsx'"
+            )
+            assert cursor.fetchone() == (profile.pk, None)
+            cursor.execute(
+                """
+                SELECT COUNT(*)
+                FROM api_userprofile_prevadzky
+                WHERE userprofile_id = %s
+                """,
+                [profile.pk],
+            )
+            assert cursor.fetchone() == (0,)
+            cursor.execute(
+                """
+                SELECT COUNT(*)
+                FROM api_clientsettings_visible_diets
+                WHERE clientsettings_id = %s
+                """,
+                [settings.pk],
+            )
+            assert cursor.fetchone() == (0,)
+
+        new_apps.get_model("auth", "User").objects.get(pk=user.pk).delete()
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT COUNT(*) FROM api_clientsettings WHERE id = %s",
+                [settings.pk],
+            )
+            assert cursor.fetchone() == (0,)
+            cursor.execute(
+                "SELECT operation_id, uploaded_by_id "
+                "FROM api_edupageupload "
+                "WHERE filename = 'legacy.xlsx'"
+            )
+            assert cursor.fetchone() == (None, None)
     finally:
         executor = MigrationExecutor(connection)
         executor.migrate(executor.loader.graph.leaf_nodes())


### PR DESCRIPTION
## Incident

Deleting Celok 155 failed in production because the state-only contract migration retained the physical `api_userprofile.celok_id` foreign key. The current Django model no longer knows that relation, so its deletion collector cannot clear it before deleting the celok. PostgreSQL therefore raised `IntegrityError`.

## Fix

Migration 0059 gives every retained, state-hidden legacy relation explicit database-level delete behavior:

- `SET NULL` for legacy informational references from `UserProfile` and `EdupageUpload`
- `CASCADE` for legacy ownership and many-to-many rows in `ClientSettings` and profile-prevadzka access
- active relations still represented in current Django models are unchanged

This preserves rolling-deploy and rollback compatibility while allowing the current model graph to delete records safely. No legacy table or column is physically removed.

## Verification

- historical 0056 -> 0059 migration test creates all legacy references and deletes current Celok, Prevadzka, Diet, EdupageConnection, and User records
- direct PostgreSQL constraint audit confirms the intended `SET NULL` / `CASCADE` actions
- backend: 869 passed, 1 deselected; coverage 84.98%
- Black 25 and 26, isort, flake8, mypy, and migration drift checks pass

## Rollout

Deploy this migration before retrying deletion of Celok 155. The failed delete transaction was rolled back, so no manual data repair should be necessary.