### PR TITLE
chore: release develop to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,8 +400,8 @@ docker compose -f compose/observability.yml up -d
 ```
 
 Configure the stack from [env/observability.example](env/observability.example).
-Alloy tails Docker logs through the Docker socket and scrapes Django metrics from
-`ALLOY_METRICS_TARGET` over the Dokploy network.
+Alloy tails Docker logs and discovers Django backend replicas to scrape, both
+through the Docker socket — no static scrape target to configure.
 
 See [observability/README.md](observability/README.md) for the full production
 setup checklist, the importable Grafana dashboard

--- a/backend/api/exception_handlers.py
+++ b/backend/api/exception_handlers.py
@@ -10,7 +10,7 @@ from django.core.exceptions import PermissionDenied as DjangoPermissionDenied
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import Http404
 from rest_framework import status
-from rest_framework.exceptions import APIException, ValidationError
+from rest_framework.exceptions import APIException, Throttled, ValidationError
 from rest_framework.response import Response
 from rest_framework.views import exception_handler as drf_exception_handler
 
@@ -106,6 +106,22 @@ def custom_exception_handler(exc, context):
             "code": exc.error_code,
             "message": str(exc.detail),
             "details": exc.extra,
+        }
+        response.data = {"error": error_data}
+        return response
+
+    # DRF's built-in Throttled (used by GlobalRateThrottle) — reshape into the
+    # same rate_limit_exceeded/retry_after_seconds shape as the hand-rolled
+    # RateLimitExceeded in exceptions.py, so callers only handle one format.
+    if isinstance(exc, Throttled):
+        wait = exc.wait or 0
+        error_data = {
+            "code": "rate_limit_exceeded",
+            "message": "Príliš veľa požiadaviek. Skúste to znova o chvíľu.",
+            "details": {
+                "retry_after_seconds": wait,
+                "retry_after_minutes": round(wait / 60),
+            },
         }
         response.data = {"error": error_data}
         return response

--- a/backend/api/management/commands/import_real_gram_distributions.py
+++ b/backend/api/management/commands/import_real_gram_distributions.py
@@ -148,7 +148,12 @@ def _upsert_template(
 
 def import_workbook(path: Path) -> date:
     workbook = load_workbook(path, data_only=True, read_only=True)
-    sheet = workbook.active
+    # Explicit by name, never `.active` — `.active` is whatever sheet the file
+    # last happened to have selected when saved, not necessarily Hárok1. Only
+    # Hárok1 is the client-maintained source of truth (see reconcile_real.py).
+    if "Hárok1" not in workbook.sheetnames:
+        raise CommandError(f"{path}: no 'Hárok1' sheet found")
+    sheet = workbook["Hárok1"]
     rows = list(sheet.iter_rows(values_only=True))
     if len(rows) < 2:
         raise CommandError(f"{path}: workbook does not contain enough rows")

--- a/backend/api/migrations/0057_remove_legacy_facility_models.py
+++ b/backend/api/migrations/0057_remove_legacy_facility_models.py
@@ -140,6 +140,53 @@ contract_state_operations = [
     ),
 ]
 
+legacy_insert_defaults = migrations.RunSQL(
+    sql=[
+        (
+            """
+            ALTER TABLE api_userprofile
+                ALTER COLUMN api_identifier SET DEFAULT '',
+                ALTER COLUMN billing_name SET DEFAULT '',
+                ALTER COLUMN dic SET DEFAULT '',
+                ALTER COLUMN ico SET DEFAULT '',
+                ALTER COLUMN is_edupage SET DEFAULT false,
+                ALTER COLUMN mealsguest_url SET DEFAULT '';
+            """,
+            None,
+        ),
+        (
+            """
+            ALTER TABLE api_celok
+                ALTER COLUMN edupage_api_identifier SET DEFAULT '',
+                ALTER COLUMN mealsguest_url SET DEFAULT '';
+            """,
+            None,
+        ),
+    ],
+    reverse_sql=[
+        (
+            """
+            ALTER TABLE api_userprofile
+                ALTER COLUMN api_identifier DROP DEFAULT,
+                ALTER COLUMN billing_name DROP DEFAULT,
+                ALTER COLUMN dic DROP DEFAULT,
+                ALTER COLUMN ico DROP DEFAULT,
+                ALTER COLUMN is_edupage DROP DEFAULT,
+                ALTER COLUMN mealsguest_url DROP DEFAULT;
+            """,
+            None,
+        ),
+        (
+            """
+            ALTER TABLE api_celok
+                ALTER COLUMN edupage_api_identifier DROP DEFAULT,
+                ALTER COLUMN mealsguest_url DROP DEFAULT;
+            """,
+            None,
+        ),
+    ],
+)
+
 
 class Migration(migrations.Migration):
 
@@ -150,7 +197,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(final_legacy_backfill, migrations.RunPython.noop),
         migrations.SeparateDatabaseAndState(
-            database_operations=[],
+            database_operations=[legacy_insert_defaults],
             state_operations=contract_state_operations,
         ),
     ]

--- a/backend/api/migrations/0057_remove_legacy_facility_models.py
+++ b/backend/api/migrations/0057_remove_legacy_facility_models.py
@@ -78,6 +78,69 @@ def final_legacy_backfill(apps, schema_editor):
         celok.save(update_fields=["billing_name", "ico", "dic"])
 
 
+contract_state_operations = [
+    migrations.RemoveField(
+        model_name="clientsettings",
+        name="user",
+    ),
+    migrations.RemoveField(
+        model_name="clientsettings",
+        name="visible_diets",
+    ),
+    migrations.RemoveIndex(
+        model_name="edupageupload",
+        name="api_edupage_date_e8e32b_idx",
+    ),
+    migrations.RemoveField(
+        model_name="celok",
+        name="edupage_api_identifier",
+    ),
+    migrations.RemoveField(
+        model_name="celok",
+        name="mealsguest_url",
+    ),
+    migrations.RemoveField(
+        model_name="edupageupload",
+        name="operation",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="api_identifier",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="billing_name",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="celok",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="dic",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="ico",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="is_edupage",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="mealsguest_url",
+    ),
+    migrations.RemoveField(
+        model_name="userprofile",
+        name="prevadzky",
+    ),
+    migrations.DeleteModel(
+        name="ClientSettings",
+    ),
+]
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -86,63 +149,8 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(final_legacy_backfill, migrations.RunPython.noop),
-        migrations.RemoveField(
-            model_name="clientsettings",
-            name="user",
-        ),
-        migrations.RemoveField(
-            model_name="clientsettings",
-            name="visible_diets",
-        ),
-        migrations.RemoveIndex(
-            model_name="edupageupload",
-            name="api_edupage_date_e8e32b_idx",
-        ),
-        migrations.RemoveField(
-            model_name="celok",
-            name="edupage_api_identifier",
-        ),
-        migrations.RemoveField(
-            model_name="celok",
-            name="mealsguest_url",
-        ),
-        migrations.RemoveField(
-            model_name="edupageupload",
-            name="operation",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="api_identifier",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="billing_name",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="celok",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="dic",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="ico",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="is_edupage",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="mealsguest_url",
-        ),
-        migrations.RemoveField(
-            model_name="userprofile",
-            name="prevadzky",
-        ),
-        migrations.DeleteModel(
-            name="ClientSettings",
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=contract_state_operations,
         ),
     ]

--- a/backend/api/migrations/0058_delete_edupageupload.py
+++ b/backend/api/migrations/0058_delete_edupageupload.py
@@ -3,13 +3,6 @@
 from django.db import migrations
 
 
-def delete_uploaded_files(apps, schema_editor):
-    EdupageUpload = apps.get_model("api", "EdupageUpload")
-    for upload in EdupageUpload.objects.only("file").iterator():
-        if upload.file:
-            upload.file.delete(save=False)
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -17,8 +10,12 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(delete_uploaded_files, migrations.RunPython.noop),
-        migrations.DeleteModel(
-            name="EdupageUpload",
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.DeleteModel(
+                    name="EdupageUpload",
+                ),
+            ],
         ),
     ]

--- a/backend/api/migrations/0059_fix_legacy_contract_delete_constraints.py
+++ b/backend/api/migrations/0059_fix_legacy_contract_delete_constraints.py
@@ -1,0 +1,65 @@
+from django.db import migrations
+
+forward_sql = """
+ALTER TABLE api_userprofile
+    DROP CONSTRAINT api_userprofile_celok_id_8d42dfa6_fk_api_celok_id,
+    ADD CONSTRAINT api_userprofile_celok_id_8d42dfa6_fk_api_celok_id
+        FOREIGN KEY (celok_id) REFERENCES api_celok(id)
+        ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE api_userprofile_prevadzky
+    DROP CONSTRAINT api_userprofile_prev_prevadzka_id_9103a9f6_fk_api_preva,
+    ADD CONSTRAINT api_userprofile_prev_prevadzka_id_9103a9f6_fk_api_preva
+        FOREIGN KEY (prevadzka_id) REFERENCES api_prevadzka(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    DROP CONSTRAINT api_userprofile_prev_userprofile_id_94dfae7f_fk_api_userp,
+    ADD CONSTRAINT api_userprofile_prev_userprofile_id_94dfae7f_fk_api_userp
+        FOREIGN KEY (userprofile_id) REFERENCES api_userprofile(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE api_clientsettings
+    DROP CONSTRAINT api_clientsettings_user_id_070e3596_fk_auth_user_id,
+    ADD CONSTRAINT api_clientsettings_user_id_070e3596_fk_auth_user_id
+        FOREIGN KEY (user_id) REFERENCES auth_user(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE api_clientsettings_visible_diets
+    DROP CONSTRAINT api_clientsettings_v_clientsettings_id_6ecbc8cc_fk_api_clien,
+    ADD CONSTRAINT api_clientsettings_v_clientsettings_id_6ecbc8cc_fk_api_clien
+        FOREIGN KEY (clientsettings_id) REFERENCES api_clientsettings(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    DROP CONSTRAINT api_clientsettings_v_diet_id_0e3eea9e_fk_api_diet_,
+    ADD CONSTRAINT api_clientsettings_v_diet_id_0e3eea9e_fk_api_diet_
+        FOREIGN KEY (diet_id) REFERENCES api_diet(id)
+        ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE api_edupageupload
+    DROP CONSTRAINT api_edupageupload_connection_id_ea124bb2_fk_api_edupa,
+    ADD CONSTRAINT api_edupageupload_connection_id_ea124bb2_fk_api_edupa
+        FOREIGN KEY (connection_id) REFERENCES api_edupageconnection(id)
+        ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED,
+    DROP CONSTRAINT api_edupageupload_operation_id_bb3bbb1e_fk_api_userprofile_id,
+    ADD CONSTRAINT api_edupageupload_operation_id_bb3bbb1e_fk_api_userprofile_id
+        FOREIGN KEY (operation_id) REFERENCES api_userprofile(id)
+        ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED,
+    DROP CONSTRAINT api_edupageupload_uploaded_by_id_5f969d4f_fk_auth_user_id,
+    ADD CONSTRAINT api_edupageupload_uploaded_by_id_5f969d4f_fk_auth_user_id
+        FOREIGN KEY (uploaded_by_id) REFERENCES auth_user(id)
+        ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED;
+"""
+
+
+reverse_sql = forward_sql.replace("ON DELETE SET NULL", "ON DELETE NO ACTION").replace(
+    "ON DELETE CASCADE", "ON DELETE NO ACTION"
+)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0058_delete_edupageupload"),
+    ]
+
+    operations = [
+        migrations.RunSQL(forward_sql, reverse_sql=reverse_sql),
+    ]

--- a/backend/api/services/meal_plan_service.py
+++ b/backend/api/services/meal_plan_service.py
@@ -17,7 +17,12 @@ from ..models import (
     MealTemplate,
 )
 from ..order_data import OrderData
-from ..utils import order_row_label
+from ..utils import (
+    SNACK_DOUBLE_BILLING_PORTIONS,
+    SNACK_MIRRORS_LUNCH_PREVADZKY,
+    _meal_rule_key,
+    order_row_label,
+)
 
 
 def _normalize_portion_name(value: object) -> str:
@@ -707,6 +712,11 @@ class MealPlanService:
         for order in orders:
             client_label = order_row_label(order)
             prevadzka = getattr(order, "prevadzka", None)
+            prevadzka_key = (
+                _meal_rule_key(prevadzka.report_alias or prevadzka.nazov)
+                if prevadzka is not None
+                else ""
+            )
             billing_coeffs = (
                 {
                     name: prevadzka.billing_coefficient(name)
@@ -714,6 +724,9 @@ class MealPlanService:
                 }
                 if prevadzka is not None
                 else {}
+            )
+            snack_double_billing_portions: set[str] = SNACK_DOUBLE_BILLING_PORTIONS.get(
+                prevadzka_key, set()
             )
             sub_rows: list[dict] = []
             # Decimal len tam, kde prevádzka účtuje zlomkovú porciu
@@ -723,6 +736,12 @@ class MealPlanService:
             diet_summary_totals: dict[str, list[list[Decimal]]] = {}
             diet_summary_counts: dict[str, int | Decimal] = {}
             order_data = order.data if isinstance(order.data, dict) else {}
+            if prevadzka_key in SNACK_MIRRORS_LUNCH_PREVADZKY:
+                # Report-only: klientov Excel neráta olovrant zo skutočných
+                # EduPage objednávok, len skopíruje počet z obeda. `order.data`
+                # ostáva nedotknuté — pracujeme na lokálnej kópii.
+                order_data = dict(order_data)
+                order_data["olovrant"] = order_data.get("lunch", {})
 
             for order_meal, meal_data in order_data.items():
                 if order_meal == "__gram_corrections__":
@@ -765,6 +784,14 @@ class MealPlanService:
                             _BILLING_MERGE_TARGET.get(portion_name, portion_name)
                             if billing_coeff != 1
                             else portion_name
+                        )
+                        # Krásňanko "KZ" (Dospelý (SŠ)): klient reálne pripravuje aj
+                        # účtuje olovrant pre túto porciu ako dvojnásobok hláv — na
+                        # rozdiel od billing_coeff sa tu zdvojnásobujú aj gramy
+                        # (kuchyňa fyzicky pripraví 2x jedlo), nielen vykázaný počet.
+                        double_snack_portion = (
+                            meal == "afternoon_snack"
+                            and portion_name in snack_double_billing_portions
                         )
                         menu_counts = category.menu_counts
                         diets = category.diets
@@ -828,6 +855,8 @@ class MealPlanService:
                         for variant, count in adjusted_variant_counts:
                             if count <= 0:
                                 continue
+                            if double_snack_portion:
+                                count = count * 2
                             # Gramy z počtu hláv, nie z fakturovaného počtu.
                             grams = _col_grams(
                                 meal, variant, coeff, count, portion_name
@@ -862,6 +891,8 @@ class MealPlanService:
                             diet_count = _safe_nonneg_int(diet_count_raw)
                             if diet_count <= 0:
                                 continue
+                            if double_snack_portion:
+                                diet_count = diet_count * 2
                             diet_grams = _col_grams_diet(
                                 meal, diet_name, coeff, diet_count, portion_name
                             )

--- a/backend/api/signals.py
+++ b/backend/api/signals.py
@@ -6,7 +6,7 @@ GlobalSettings post_save → keeps the Celery Beat PeriodicTasks for:
   deadline_olovrant)
 - daily reports: fires at breakfast deadline (breakfast only) and
   olovrant deadline (all meals)
-- push reminders: fires 15 min before each meal deadline (one task per
+- push reminders: fires 30 min before each meal deadline (one task per
   meal type)
 """
 
@@ -23,7 +23,11 @@ PERIODIC_TASK_NAME_REPORT_BREAKFAST = "daily-report-breakfast"
 PERIODIC_TASK_NAME_REPORT_ALL = "daily-report-all-meals"
 
 PUSH_REMINDER_TASK_PREFIX = "push-reminder-"
-PUSH_REMINDER_OFFSET_MINUTES = 15
+# Widened from 15 to 30 min: with the login being CPU-bound (see
+# load-tests/README.md "Measured Capacity"), a longer lead time before the
+# deadline gives users more room to arrive spread out rather than all at
+# once, on top of the send-side batching in api/tasks.py.
+PUSH_REMINDER_OFFSET_MINUTES = 30
 
 WEEKLY_REMINDER_TASK_NAME = "weekly-order-reminder-sunday"
 

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -3,8 +3,10 @@ Celery tasks for the api app.
 """
 
 import logging
+import time
 
 from celery import shared_task
+from django.conf import settings
 from django.db import DatabaseError
 from django.utils import timezone
 
@@ -13,6 +15,34 @@ from api.services.push_notification_service import PushNotificationService
 logger = logging.getLogger(__name__)
 
 REPORT_CACHE_TIMEOUT = 3600  # 1 hour
+
+# Spreads push-reminder delivery across batches instead of sending to every
+# subscriber in one instant. A single "uzávierka o chvíľu" push to everyone
+# tends to make everyone open the app and log in within the same few
+# seconds — measured load testing showed the backend collapses at roughly
+# 4x its comfortable sustained rate (load-tests/README.md "Measured
+# Capacity"), so a genuine simultaneous-open burst can realistically hit
+# that. 0 by default (dev/test): only set via env in staging/prod settings.
+#
+# Batch size scales with recipient count (capped at PUSH_REMINDER_MAX_BATCHES
+# batches) rather than using a fixed size, so total stagger time stays
+# bounded regardless of how many users are subscribed —
+# send_weekly_order_reminder_task has a 290s soft time limit.
+PUSH_REMINDER_MIN_BATCH_SIZE = 25
+PUSH_REMINDER_MAX_BATCHES = 10
+
+
+def _push_batch_stagger_seconds() -> float:
+    return getattr(settings, "PUSH_REMINDER_BATCH_STAGGER_SECONDS", 0)
+
+
+def _push_batch_size(total_recipients: int) -> int:
+    if total_recipients <= 0:
+        return PUSH_REMINDER_MIN_BATCH_SIZE
+    return max(
+        PUSH_REMINDER_MIN_BATCH_SIZE,
+        -(-total_recipients // PUSH_REMINDER_MAX_BATCHES),  # ceil division
+    )
 
 
 @shared_task(
@@ -201,7 +231,11 @@ def send_push_deadline_reminder_task(self, meal_types: list[str]):
                 f"Nezabudnite objednať {meal_str} na {date_fmt}. Uzávierka je o chvíľu!"
             )
             date_sent = 0
-            for user_id in subscribed_user_ids:
+            stagger = _push_batch_stagger_seconds()
+            batch_size = _push_batch_size(len(subscribed_user_ids))
+            for idx, user_id in enumerate(subscribed_user_ids):
+                if stagger and idx and idx % batch_size == 0:
+                    time.sleep(stagger)
                 result = PushNotificationService.send_to_user(
                     user_id=user_id,
                     title="Pripomienka objednávky",
@@ -300,7 +334,11 @@ def send_weekly_order_reminder_task(self):
         body = f"Nezabudnite vyplniť objednávku na budúci týždeň ({week_label})."
 
         sent = 0
-        for user_id in recipients:
+        stagger = _push_batch_stagger_seconds()
+        batch_size = _push_batch_size(len(recipients))
+        for idx, user_id in enumerate(recipients):
+            if stagger and idx and idx % batch_size == 0:
+                time.sleep(stagger)
             result = PushNotificationService.send_to_user(
                 user_id=user_id,
                 title="Pripomienka objednávky",

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -137,7 +137,7 @@ def generate_report_xlsx_task(self, date_str: str):
 )
 def send_push_deadline_reminder_task(self, meal_types: list[str]):
     """
-    Send push notifications to all subscribed clients 15 minutes before
+    Send push notifications to all subscribed clients 30 minutes before
     a meal deadline. When multiple meals share the same deadline they are
     passed together so that users receive a single combined notification.
 

--- a/backend/api/tests/test_snack_billing_overrides.py
+++ b/backend/api/tests/test_snack_billing_overrides.py
@@ -1,0 +1,167 @@
+"""Report-only olovrant (afternoon_snack) billing overrides for specific prevádzky.
+
+Klientov účtovný Excel neráta olovrant vždy zo skutočných EduPage objednávok —
+pozri `api.utils.SNACK_MIRRORS_LUNCH_PREVADZKY` a `SNACK_DOUBLE_BILLING_PORTIONS`.
+Tieto pravidlá menia len výstup `gramage_dashboard`, nikdy `DailyOrder.data`.
+"""
+
+import datetime
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.management import call_command
+
+from api.models import (
+    Celok,
+    DailyMealPlan,
+    DailyOrder,
+    MealPlanItem,
+    MealTemplate,
+    Prevadzka,
+)
+from api.services.meal_plan_service import MealPlanService
+
+
+def _make_plan(date):
+    call_command("init_reference_data")
+    plan = DailyMealPlan.objects.create(date=date)
+    MealPlanItem.objects.create(
+        meal_plan=plan,
+        template=MealTemplate.objects.create(
+            name="Polievka",
+            category="soup",
+            components=[{"label": "Polievka", "grams": "200", "unit": "g"}],
+            base_weight_grams="200",
+        ),
+        category="soup",
+        menu_variant="",
+    )
+    MealPlanItem.objects.create(
+        meal_plan=plan,
+        template=MealTemplate.objects.create(
+            name="Obed",
+            category="main_course",
+            components=[{"label": "Hlavné jedlo", "grams": "300", "unit": "g"}],
+            base_weight_grams="300",
+        ),
+        category="main_course",
+        menu_variant="",
+    )
+    MealPlanItem.objects.create(
+        meal_plan=plan,
+        template=MealTemplate.objects.create(
+            name="Olovrant",
+            category="afternoon_snack",
+            components=[
+                {"label": "Kváskový chlieb", "grams": "40", "unit": "g"},
+                {"label": "Nátierka", "grams": "20", "unit": "g"},
+            ],
+            base_weight_grams="60",
+        ),
+        category="afternoon_snack",
+        menu_variant="",
+    )
+    return plan
+
+
+def _sub_rows_for_meal(data, meal):
+    return [sr for sr in data["rows"][0]["sub_rows"] if sr["meal"] == meal]
+
+
+@pytest.mark.django_db
+def test_filipa_neriho_snack_mirrors_lunch_ignoring_real_snack_orders():
+    """Excel má na olovrante vzorec = obedový počet; skutočné (nižšie) EduPage
+    olovrant objednávky sa v reporte ignorujú."""
+    plan = _make_plan(datetime.date(2026, 7, 28))
+    celok = Celok.objects.create(nazov="MŠ Filipáneriho")
+    prevadzka = Prevadzka.objects.create(
+        celok=celok, nazov="MŠ Filipáneriho", report_alias="Filipa Nériho"
+    )
+    user = User.objects.create_user(username="filipa@example.com", password="x")
+    DailyOrder.objects.create(
+        user=user,
+        prevadzka=prevadzka,
+        date=plan.date,
+        data={
+            "lunch": {"Škôlka": {"menuCounts": {"": 19}, "diets": {}}},
+            # Real EduPage olovrant orders undercount vs lunch — must be ignored.
+            "olovrant": {"Škôlka": {"menuCounts": {"": 16}, "diets": {}}},
+        },
+    )
+
+    data = MealPlanService.gramage_dashboard(plan.date.isoformat())
+    snack_rows = _sub_rows_for_meal(data, "afternoon_snack")
+
+    assert len(snack_rows) == 1
+    assert snack_rows[0]["count"] == 19
+    assert snack_rows[0]["col_grams"][-1] == ["760.00", "380.00"]
+
+
+@pytest.mark.django_db
+def test_facility_without_mirror_rule_keeps_real_snack_orders():
+    """Regresný test: bez pravidla (napr. Rozmanitá) sa olovrant NEPREPÍŠE obedom."""
+    plan = _make_plan(datetime.date(2026, 7, 28))
+    celok = Celok.objects.create(nazov="MŠ Rozmanitá")
+    prevadzka = Prevadzka.objects.create(
+        celok=celok, nazov="MŠ Rozmanitá", report_alias="Rozmanita Škôlka"
+    )
+    user = User.objects.create_user(username="rozmanita@example.com", password="x")
+    DailyOrder.objects.create(
+        user=user,
+        prevadzka=prevadzka,
+        date=plan.date,
+        data={
+            "lunch": {"Škôlka": {"menuCounts": {"": 24}, "diets": {}}},
+            "olovrant": {"Škôlka": {"menuCounts": {"": 20}, "diets": {}}},
+        },
+    )
+
+    data = MealPlanService.gramage_dashboard(plan.date.isoformat())
+    snack_rows = _sub_rows_for_meal(data, "afternoon_snack")
+
+    assert len(snack_rows) == 1
+    assert snack_rows[0]["count"] == 20
+
+
+@pytest.mark.django_db
+def test_krasnanko_kz_portion_is_doubled_in_snack_only():
+    """Krásňanko 'KZ' (Dospelý (SŠ)) sa v olovrante počíta 2x — v obede ostáva 1x."""
+    plan = _make_plan(datetime.date(2026, 7, 28))
+    celok = Celok.objects.create(nazov="MŠ Krásnanko")
+    prevadzka = Prevadzka.objects.create(
+        celok=celok, nazov="MŠ Krásnanko", report_alias="Krasňanko"
+    )
+    user = User.objects.create_user(username="krasnanko@example.com", password="x")
+    DailyOrder.objects.create(
+        user=user,
+        prevadzka=prevadzka,
+        date=plan.date,
+        data={
+            "lunch": {
+                "Škôlka": {"menuCounts": {"": 27}, "diets": {}},
+                "Dospelý (SŠ)": {"menuCounts": {"": 2}, "diets": {}},
+            },
+            "olovrant": {
+                "Škôlka": {"menuCounts": {"": 21}, "diets": {}},
+                "Dospelý (SŠ)": {"menuCounts": {"": 1}, "diets": {}},
+            },
+        },
+    )
+
+    data = MealPlanService.gramage_dashboard(plan.date.isoformat())
+    lunch_rows = {
+        sr["portion_name"]: sr for sr in _sub_rows_for_meal(data, "main_course")
+    }
+    snack_rows = {
+        sr["portion_name"]: sr for sr in _sub_rows_for_meal(data, "afternoon_snack")
+    }
+
+    # Lunch stays untouched — the doubling is scoped to olovrant only.
+    assert lunch_rows["Dospelý (SŠ)"]["count"] == 2
+
+    # Snack: the real 1 KZ order is billed/prepared as 2 (Dospelý (SŠ) portion
+    # coefficient 2.0 also applies, as it does everywhere else: 40g x 2 x 2.0).
+    assert snack_rows["Dospelý (SŠ)"]["count"] == 2
+    assert snack_rows["Dospelý (SŠ)"]["col_grams"][-1] == ["160.00", "80.00"]
+    # Škôlka portion in snack is untouched by the doubling rule.
+    assert snack_rows["Škôlka"]["count"] == 21

--- a/backend/api/throttles.py
+++ b/backend/api/throttles.py
@@ -1,0 +1,45 @@
+"""
+Global (not per-user/per-IP) throttles for the endpoints that saturate first
+under load.
+
+DRF's built-in throttle classes key by user or IP, which does nothing when
+the overload comes from many *different* legitimate users arriving at once
+(e.g. everyone opening the app right after the 09:45 order-deadline push
+notification) — each of those users is nowhere near a per-user rate limit.
+
+These throttles instead share one cache key across all requests to the view,
+capping total throughput. Past the limit, DRF's default `Throttled` handling
+returns 429 with a `Retry-After` header immediately, instead of the request
+queueing behind gunicorn's backlog until it hits the client's own timeout.
+
+Rates are set below the measured collapse point (see load-tests/README.md
+"Measured Capacity"), not at DRF's per-endpoint default, so they should be
+re-tuned if backend capacity changes (more CPU, more replicas).
+"""
+
+from rest_framework.settings import api_settings
+from rest_framework.throttling import SimpleRateThrottle
+
+
+class GlobalRateThrottle(SimpleRateThrottle):
+    """Rate-limits ALL requests to the view combined, regardless of caller."""
+
+    def get_cache_key(self, request, view):
+        return f"throttle_global_{self.scope}"
+
+    def get_rate(self):
+        # SimpleRateThrottle.THROTTLE_RATES is a class attribute snapshotted
+        # from api_settings at import time — it never sees changes to
+        # settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] made afterwards
+        # (e.g. via override_settings in tests, or any runtime settings
+        # reload). Read api_settings directly instead so rate changes apply
+        # without needing a process restart.
+        return api_settings.DEFAULT_THROTTLE_RATES[self.scope]
+
+
+class LoginRateThrottle(GlobalRateThrottle):
+    scope = "login_global"
+
+
+class OrderSubmitRateThrottle(GlobalRateThrottle):
+    scope = "order_submit_global"

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -12,6 +12,26 @@ NON_SERVED_ORDER_MEALS_BY_PREVADZKA = {
     "deutsche schule": {"breakfast", "olovrant"},
 }
 
+# Nižšie dve mapy menia len vykázaný (billing) výstup v gramage_dashboard —
+# na rozdiel od NON_SERVED_ORDER_MEALS_BY_PREVADZKA sa neaplikujú pri importe
+# a `DailyOrder.data` teda zostáva presným odrazom EduPage. Klientov účtovný
+# Excel má pre tieto prevádzky vlastnú (nie EduPage) logiku počtu olovrantov;
+# aby appka produkovala rovnaké číslo, aké klient reálne fakturuje, report
+# preberie tú istú logiku len na výstupe.
+
+# Filipa Nériho: klientov Excel má na olovrant riadku vzorec, ktorý počet
+# automaticky preberá z obedového riadku (nepočíta sa samostatne, koľko
+# olovrantov si kto reálne objednal na EduPage). Reálne dáta to potvrdzujú
+# 1:1 (obed == olovrant každý deň) — u Rozmanitej Škôlky to NEPLATÍ (obed a
+# olovrant sa v exceli líšia o "dospelá"/Škola blok, ktorý má explicitne
+# "bez olovrantu"), preto tam mirror-lunch zámerne nie je.
+SNACK_MIRRORS_LUNCH_PREVADZKY = {"filipa neriho"}
+
+# Krásňanko: položka "KZ" (Dospelý (SŠ) porcia) sa v olovrante v klientovom
+# Exceli počíta ako dvojitá porcia. Overené na obedovom stĺpci, ktorý sedí
+# appke 1:1 bez úpravy — dvojnásobok sa týka výhradne olovrantu.
+SNACK_DOUBLE_BILLING_PORTIONS = {"krasnanko": {"Dospelý (SŠ)"}}
+
 
 def _meal_rule_key(value: object) -> str:
     normalized = unicodedata.normalize("NFKD", str(value or "").casefold())

--- a/backend/api/views/auth_views.py
+++ b/backend/api/views/auth_views.py
@@ -17,6 +17,7 @@ from api.management.commands.init_roles import DEMO_ADMIN_EMAIL, DEMO_OPERATION_
 
 from ..exceptions import InvalidCredentialsError, MissingRequiredFieldError
 from ..metrics import login_attempts_total
+from ..throttles import LoginRateThrottle
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +157,7 @@ class EmailTokenObtainPairView(TokenObtainPairView):
     """JWT login view. Returns access token in body; sets refresh token as httpOnly cookie."""
 
     serializer_class = EmailTokenObtainPairSerializer
+    throttle_classes = [LoginRateThrottle]
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)

--- a/backend/api/views/order_views.py
+++ b/backend/api/views/order_views.py
@@ -17,6 +17,7 @@ from ..models import DailyOrder
 from ..serializers import DailyOrderSerializer, PrevadzkaSerializer
 from ..services import OrderService
 from ..services.prevadzka_service import dostupne_prevadzky
+from ..throttles import OrderSubmitRateThrottle
 
 
 @extend_schema_view(
@@ -93,6 +94,11 @@ class DailyOrderViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(prevadzka_id=prevadzka_id_int)
 
         return queryset
+
+    def get_throttles(self):
+        if self.action == "create":
+            return [OrderSubmitRateThrottle()]
+        return super().get_throttles()
 
     def perform_create(self, serializer: DailyOrderSerializer) -> None:
         """

--- a/backend/app/settings/base.py
+++ b/backend/app/settings/base.py
@@ -292,6 +292,16 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 20,
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "EXCEPTION_HANDLER": "api.exception_handlers.custom_exception_handler",
+    # Global (not per-user) caps on the two endpoints that saturate first
+    # under load — see api/throttles.py and load-tests/README.md "Measured
+    # Capacity". Env-overridable so raising backend capacity (CPU/replicas)
+    # doesn't need a code change to move the ceiling.
+    "DEFAULT_THROTTLE_RATES": {
+        "login_global": os.environ.get("LOGIN_GLOBAL_THROTTLE_RATE", "150/min"),
+        "order_submit_global": os.environ.get(
+            "ORDER_SUBMIT_GLOBAL_THROTTLE_RATE", "150/min"
+        ),
+    },
 }
 
 LOGGING = {

--- a/backend/app/settings/prod.py
+++ b/backend/app/settings/prod.py
@@ -140,3 +140,10 @@ LOGGING = {
         },
     },
 }
+
+# Spreads push-deadline-reminder delivery across batches so a big subscriber
+# list doesn't wake every client in the same instant (see api/tasks.py and
+# load-tests/README.md "Overload Plan"). 0 disables staggering.
+PUSH_REMINDER_BATCH_STAGGER_SECONDS = int(
+    os.environ.get("PUSH_REMINDER_BATCH_STAGGER_SECONDS", "15")
+)

--- a/backend/app/settings/staging.py
+++ b/backend/app/settings/staging.py
@@ -134,3 +134,10 @@ LOGGING = {
         },
     },
 }
+
+# Spreads push-deadline-reminder delivery across batches so a big subscriber
+# list doesn't wake every client in the same instant (see api/tasks.py and
+# load-tests/README.md "Overload Plan"). 0 disables staggering.
+PUSH_REMINDER_BATCH_STAGGER_SECONDS = int(
+    os.environ.get("PUSH_REMINDER_BATCH_STAGGER_SECONDS", "15")
+)

--- a/backend/tests/test_global_throttles.py
+++ b/backend/tests/test_global_throttles.py
@@ -1,0 +1,116 @@
+"""
+Global (not per-user) throttles on /api/token/ and /api/orders/ create.
+
+See api/throttles.py and load-tests/README.md "Overload Plan": these cap
+aggregate throughput across ALL callers, so a burst of many different
+legitimate users gets a fast 429 instead of piling up behind gunicorn's
+backlog until requests time out.
+"""
+
+import pytest
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+
+from api.models import UserProfile
+
+
+def _low_throttle_settings():
+    # Replace only DEFAULT_THROTTLE_RATES; keep the rest of REST_FRAMEWORK
+    # (EXCEPTION_HANDLER, DEFAULT_AUTHENTICATION_CLASSES, ...) intact, since
+    # overriding the whole dict would silently fall back to DRF's own
+    # defaults for everything else.
+    return {
+        "REST_FRAMEWORK": {
+            **settings.REST_FRAMEWORK,
+            "DEFAULT_THROTTLE_RATES": {
+                "login_global": "1/min",
+                "order_submit_global": "1/min",
+            },
+        }
+    }
+
+
+def _user_with_profile(**kwargs):
+    kwargs.setdefault("email", kwargs.get("username"))
+    user = User.objects.create_user(**kwargs)
+    UserProfile.objects.get_or_create(user=user, defaults={"company_name": user.email})
+    return user
+
+
+@pytest.mark.django_db
+class TestLoginGlobalThrottle:
+    def test_second_login_within_window_is_throttled_regardless_of_user(
+        self, api_client
+    ):
+        """A global throttle blocks request #2 even from a DIFFERENT user —
+        this is the whole point: per-user throttles don't protect against
+        many distinct users arriving at once."""
+        _user_with_profile(username="a@example.com", password="pw12345678")
+        _user_with_profile(username="b@example.com", password="pw12345678")
+        auth_url = reverse("token_obtain_pair")
+
+        with override_settings(**_low_throttle_settings()):
+            first = api_client.post(
+                auth_url,
+                {"email": "a@example.com", "password": "pw12345678"},
+                format="json",
+            )
+            assert first.status_code == status.HTTP_200_OK
+
+            second = api_client.post(
+                auth_url,
+                {"email": "b@example.com", "password": "pw12345678"},
+                format="json",
+            )
+
+        assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert second.data["error"]["code"] == "rate_limit_exceeded"
+        assert "retry_after_seconds" in second.data["error"]["details"]
+        assert "Retry-After" in second.headers
+
+
+@pytest.mark.django_db
+class TestOrderSubmitGlobalThrottle:
+    def test_second_order_create_within_window_is_throttled(self, api_client):
+        user_a = _user_with_profile(username="c@example.com", password="pw12345678")
+        user_b = _user_with_profile(username="d@example.com", password="pw12345678")
+        orders_url = reverse("dailyorder-list")
+
+        with override_settings(**_low_throttle_settings()):
+            api_client.force_authenticate(user=user_a)
+            first = api_client.post(
+                orders_url,
+                {"date": "2099-01-05", "data": {}},
+                format="json",
+            )
+            assert first.status_code in (
+                status.HTTP_200_OK,
+                status.HTTP_201_CREATED,
+            )
+
+            api_client.force_authenticate(user=user_b)
+            second = api_client.post(
+                orders_url,
+                {"date": "2099-01-06", "data": {}},
+                format="json",
+            )
+
+        assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert second.data["error"]["code"] == "rate_limit_exceeded"
+
+    def test_list_and_retrieve_are_not_throttled_by_order_submit_scope(
+        self, api_client
+    ):
+        """get_throttles() must scope the limiter to `create` only — list/
+        retrieve traffic (far more frequent) shouldn't share its budget."""
+        user = _user_with_profile(username="e@example.com", password="pw12345678")
+        orders_url = reverse("dailyorder-list")
+
+        with override_settings(**_low_throttle_settings()):
+            api_client.force_authenticate(user=user)
+            for _ in range(3):
+                resp = api_client.get(orders_url)
+                assert resp.status_code == status.HTTP_200_OK

--- a/backend/tests/test_import_real_gram_distributions.py
+++ b/backend/tests/test_import_real_gram_distributions.py
@@ -12,6 +12,7 @@ pytestmark = pytest.mark.django_db
 def _write_workbook(path, target_date, row_values):
     workbook = openpyxl.Workbook()
     sheet = workbook.active
+    sheet.title = "Hárok1"
     sheet.append(
         [
             target_date,
@@ -65,6 +66,7 @@ def test_import_real_gram_distributions_keeps_piece_exception_idempotent(tmp_pat
     path = tmp_path / "6.7.2026_tabulka.xlsx"
     workbook = openpyxl.Workbook()
     sheet = workbook.active
+    sheet.title = "Hárok1"
     sheet.append(
         [
             "6.7.2026",
@@ -113,6 +115,7 @@ def test_import_real_gram_distributions_covers_week_28_snack_split(tmp_path):
     path = tmp_path / "7.7.2026_tabulka.xlsx"
     workbook = openpyxl.Workbook()
     sheet = workbook.active
+    sheet.title = "Hárok1"
     sheet.append(
         [
             "7.7.2026",

--- a/backend/tests/test_legacy_contract_migration.py
+++ b/backend/tests/test_legacy_contract_migration.py
@@ -66,6 +66,17 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         migrated_prevadzka = new_apps.get_model("api", "Prevadzka").objects.get(
             pk=prevadzka.pk
         )
+        migrated_user = new_apps.get_model("auth", "User").objects.create(
+            username="post-contract",
+            email="post-contract@example.com",
+        )
+        migrated_profile = new_apps.get_model("api", "UserProfile").objects.create(
+            user=migrated_user,
+            company_name="Post-contract login",
+        )
+        post_contract_celok = new_apps.get_model("api", "Celok").objects.create(
+            nazov="Post-contract celok",
+        )
 
         assert migrated_celok.billing_name == "Fresh billing"
         assert migrated_celok.ico == "12345678"
@@ -76,6 +87,8 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         assert list(
             migrated_prevadzka.visible_diets.values_list("name", flat=True)
         ) == ["Legacy diet"]
+        assert migrated_profile.pk is not None
+        assert post_contract_celok.pk is not None
         with pytest.raises(LookupError):
             new_apps.get_model("api", "EdupageUpload")
 
@@ -105,6 +118,25 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
                     "api_edupageupload",
                 )
             }
+            cursor.execute(
+                """
+                SELECT api_identifier, billing_name, dic, ico, is_edupage,
+                       mealsguest_url
+                FROM api_userprofile
+                WHERE id = %s
+                """,
+                [migrated_profile.pk],
+            )
+            profile_legacy_values = cursor.fetchone()
+            cursor.execute(
+                """
+                SELECT edupage_api_identifier, mealsguest_url
+                FROM api_celok
+                WHERE id = %s
+                """,
+                [post_contract_celok.pk],
+            )
+            celok_legacy_values = cursor.fetchone()
 
         assert {
             "api_identifier",
@@ -117,6 +149,8 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         } <= profile_columns
         assert {"edupage_api_identifier", "mealsguest_url"} <= celok_columns
         assert "operation_id" in upload_columns
+        assert profile_legacy_values == ("", "", "", "", False, "")
+        assert celok_legacy_values == ("", "")
     finally:
         executor = MigrationExecutor(connection)
         executor.migrate(executor.loader.graph.leaf_nodes())

--- a/backend/tests/test_legacy_contract_migration.py
+++ b/backend/tests/test_legacy_contract_migration.py
@@ -78,6 +78,54 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         ) == ["Legacy diet"]
         with pytest.raises(LookupError):
             new_apps.get_model("api", "EdupageUpload")
+
+        table_names = connection.introspection.table_names()
+        assert "api_clientsettings" in table_names
+        assert "api_edupageupload" in table_names
+
+        with connection.cursor() as cursor:
+            profile_columns = {
+                column.name
+                for column in connection.introspection.get_table_description(
+                    cursor,
+                    "api_userprofile",
+                )
+            }
+            celok_columns = {
+                column.name
+                for column in connection.introspection.get_table_description(
+                    cursor,
+                    "api_celok",
+                )
+            }
+            upload_columns = {
+                column.name
+                for column in connection.introspection.get_table_description(
+                    cursor,
+                    "api_edupageupload",
+                )
+            }
+
+        assert {
+            "api_identifier",
+            "billing_name",
+            "celok_id",
+            "dic",
+            "ico",
+            "is_edupage",
+            "mealsguest_url",
+        } <= profile_columns
+        assert {"edupage_api_identifier", "mealsguest_url"} <= celok_columns
+        assert "operation_id" in upload_columns
     finally:
         executor = MigrationExecutor(connection)
         executor.migrate(executor.loader.graph.leaf_nodes())
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                DROP TABLE IF EXISTS api_edupageupload CASCADE;
+                DROP TABLE IF EXISTS api_clientsettings_visible_diets CASCADE;
+                DROP TABLE IF EXISTS api_clientsettings CASCADE;
+                DROP TABLE IF EXISTS api_userprofile_prevadzky CASCADE;
+                """
+            )

--- a/backend/tests/test_legacy_contract_migration.py
+++ b/backend/tests/test_legacy_contract_migration.py
@@ -5,9 +5,9 @@ from django.db.migrations.executor import MigrationExecutor
 
 @pytest.mark.migration
 @pytest.mark.django_db(transaction=True)
-def test_contract_migration_preserves_latest_legacy_facility_data():
+def test_contract_migration_preserves_data_and_allows_current_model_deletes():
     migrate_from = [("api", "0056_explicit_profile_access")]
-    migrate_to = [("api", "0058_delete_edupageupload")]
+    migrate_to = [("api", "0059_fix_legacy_contract_delete_constraints")]
     executor = MigrationExecutor(connection)
 
     try:
@@ -17,6 +17,7 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         Celok = old_apps.get_model("api", "Celok")
         ClientSettings = old_apps.get_model("api", "ClientSettings")
         Diet = old_apps.get_model("api", "Diet")
+        EdupageConnection = old_apps.get_model("api", "EdupageConnection")
         EdupageUpload = old_apps.get_model("api", "EdupageUpload")
         Prevadzka = old_apps.get_model("api", "Prevadzka")
         UserProfile = old_apps.get_model("api", "UserProfile")
@@ -52,11 +53,17 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
             admin_order_note="Fresh note",
         )
         settings.visible_diets.add(diet)
+        edupage_connection = EdupageConnection.objects.create(
+            name="Legacy connection",
+            mealsguest_url="https://legacy.edupage.org/menu/mealsGuest?id=test",
+        )
         EdupageUpload.objects.create(
             date="2026-07-24",
             filename="legacy.xlsx",
             file="edupage_uploads/legacy.xlsx",
             uploaded_by=user,
+            operation=profile,
+            connection=edupage_connection,
         )
 
         executor = MigrationExecutor(connection)
@@ -151,6 +158,59 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
         assert "operation_id" in upload_columns
         assert profile_legacy_values == ("", "", "", "", False, "")
         assert celok_legacy_values == ("", "")
+
+        migrated_prevadzka.delete()
+        migrated_celok.delete()
+        new_apps.get_model("api", "Diet").objects.get(pk=diet.pk).delete()
+        new_apps.get_model("api", "EdupageConnection").objects.get(
+            pk=edupage_connection.pk
+        ).delete()
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT celok_id FROM api_userprofile WHERE id = %s",
+                [profile.pk],
+            )
+            assert cursor.fetchone() == (None,)
+            cursor.execute(
+                "SELECT operation_id, connection_id "
+                "FROM api_edupageupload "
+                "WHERE filename = 'legacy.xlsx'"
+            )
+            assert cursor.fetchone() == (profile.pk, None)
+            cursor.execute(
+                """
+                SELECT COUNT(*)
+                FROM api_userprofile_prevadzky
+                WHERE userprofile_id = %s
+                """,
+                [profile.pk],
+            )
+            assert cursor.fetchone() == (0,)
+            cursor.execute(
+                """
+                SELECT COUNT(*)
+                FROM api_clientsettings_visible_diets
+                WHERE clientsettings_id = %s
+                """,
+                [settings.pk],
+            )
+            assert cursor.fetchone() == (0,)
+
+        new_apps.get_model("auth", "User").objects.get(pk=user.pk).delete()
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT COUNT(*) FROM api_clientsettings WHERE id = %s",
+                [settings.pk],
+            )
+            assert cursor.fetchone() == (0,)
+            cursor.execute(
+                "SELECT operation_id, uploaded_by_id "
+                "FROM api_edupageupload "
+                "WHERE filename = 'legacy.xlsx'"
+            )
+            assert cursor.fetchone() == (None, None)
     finally:
         executor = MigrationExecutor(connection)
         executor.migrate(executor.loader.graph.leaf_nodes())

--- a/backend/tests/test_legacy_contract_migration.py
+++ b/backend/tests/test_legacy_contract_migration.py
@@ -154,12 +154,11 @@ def test_contract_migration_preserves_latest_legacy_facility_data():
     finally:
         executor = MigrationExecutor(connection)
         executor.migrate(executor.loader.graph.leaf_nodes())
+        cleanup_sql = """
+            DROP TABLE IF EXISTS api_edupageupload CASCADE;
+            DROP TABLE IF EXISTS api_clientsettings_visible_diets CASCADE;
+            DROP TABLE IF EXISTS api_clientsettings CASCADE;
+            DROP TABLE IF EXISTS api_userprofile_prevadzky CASCADE;
+        """
         with connection.cursor() as cursor:
-            cursor.execute(
-                """
-                DROP TABLE IF EXISTS api_edupageupload CASCADE;
-                DROP TABLE IF EXISTS api_clientsettings_visible_diets CASCADE;
-                DROP TABLE IF EXISTS api_clientsettings CASCADE;
-                DROP TABLE IF EXISTS api_userprofile_prevadzky CASCADE;
-                """
-            )
+            cursor.execute(cleanup_sql)

--- a/backend/tests/test_push_notifications.py
+++ b/backend/tests/test_push_notifications.py
@@ -115,20 +115,20 @@ class TestSyncPushReminderSchedule:
         expected_name = _push_reminder_task_name(["breakfast", "lunch", "olovrant"])
         assert tasks.first().name == expected_name
 
-    def test_reminder_fires_15_min_before_each_deadline(self):
+    def test_reminder_fires_30_min_before_each_deadline(self):
         """Each task crontab is PUSH_REMINDER_OFFSET_MINUTES before the deadline."""
-        assert PUSH_REMINDER_OFFSET_MINUTES == 15
+        assert PUSH_REMINDER_OFFSET_MINUTES == 30
 
         _make_settings(
-            deadline_breakfast=datetime.time(8, 30),  # reminder → 08:15
-            deadline_lunch=datetime.time(11, 0),  # reminder → 10:45
-            deadline_olovrant=datetime.time(9, 30),  # reminder → 09:15
+            deadline_breakfast=datetime.time(8, 30),  # reminder → 08:00
+            deadline_lunch=datetime.time(11, 0),  # reminder → 10:30
+            deadline_olovrant=datetime.time(9, 30),  # reminder → 09:00
         )
 
         expectations = {
-            _push_reminder_task_name(["breakfast"]): (8, 15),
-            _push_reminder_task_name(["lunch"]): (10, 45),
-            _push_reminder_task_name(["olovrant"]): (9, 15),
+            _push_reminder_task_name(["breakfast"]): (8, 0),
+            _push_reminder_task_name(["lunch"]): (10, 30),
+            _push_reminder_task_name(["olovrant"]): (9, 0),
         }
         for task_name, (exp_hour, exp_min) in expectations.items():
             task = PeriodicTask.objects.get(name=task_name)
@@ -197,14 +197,14 @@ class TestSyncPushReminderSchedule:
         task_name = _push_reminder_task_name(["lunch"])
         task_before = PeriodicTask.objects.get(name=task_name)
         assert task_before.crontab.hour == "10"
-        assert task_before.crontab.minute == "45"
+        assert task_before.crontab.minute == "30"
 
         settings.deadline_lunch = datetime.time(12, 0)
         settings.save()
 
         task_after = PeriodicTask.objects.get(name=task_name)
         assert task_after.crontab.hour == "11"
-        assert task_after.crontab.minute == "45"
+        assert task_after.crontab.minute == "30"
 
     def test_orphaned_tasks_deleted_when_deadlines_merge(self):
         """When two previously separate deadlines merge, the old tasks are deleted."""

--- a/compose/README.md
+++ b/compose/README.md
@@ -19,7 +19,6 @@ Prometheus metrics at `/metrics/`; any future Alloy/Grafana setup should run as 
 separate compose stack and scrape the app over the Dokploy network.
 
 The observability stack expects Grafana Loki and Prometheus/Mimir remote-write
-credentials through environment variables. Set `ALLOY_METRICS_TARGET` to the
-backend address reachable from `dokploy-network`, for example `backend:8000` for
-a single app stack or the explicit Dokploy service DNS if multiple app stacks are
-on the same network.
+credentials through environment variables. Alloy discovers backend containers
+itself over the Docker socket (see `observability/alloy/config.alloy`), scraping
+one target per replica — no backend address needs to be configured.

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -131,7 +131,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      VITE_API_URL: http://localhost:8000/api
+      VITE_API_URL: /api
       VITE_DEV_PROXY_TARGET: http://backend:8000
     depends_on:
       - backend

--- a/compose/observability.yml
+++ b/compose/observability.yml
@@ -21,7 +21,6 @@ services:
       GRAFANA_PROM_USER: ${GRAFANA_PROM_USER:?Set GRAFANA_PROM_USER}
       GRAFANA_PROM_API_KEY: ${GRAFANA_PROM_API_KEY:?Set GRAFANA_PROM_API_KEY}
       ALLOY_ENVIRONMENT: ${ALLOY_ENVIRONMENT:-production}
-      ALLOY_METRICS_TARGET: ${ALLOY_METRICS_TARGET:-backend:8000}
     networks:
       - default
       - dokploy-network

--- a/env/observability.example
+++ b/env/observability.example
@@ -10,11 +10,7 @@ GRAFANA_PROM_API_KEY=grafana-prom-api-key
 
 # Alloy metadata / scrape targets
 ALLOY_ENVIRONMENT=production
-# Use "backend" (Compose's implicit alias, i.e. the service name in
-# compose/prod.yml / compose/staging.yml), not the raw Swarm-generated task
-# name — that one contains underscores, which Django's Host-header
-# validation rejects. A custom network alias was tried and abandoned:
-# Swarm's embedded DNS didn't reliably resolve it for this multi-network
-# service. "backend" is allow-listed in ALLOWED_HOSTS for exactly this.
-ALLOY_METRICS_TARGET=backend:8000
+# Alloy discovers backend replicas itself via the Docker socket (containers
+# labeled prometheus.io/scrape=true), one target per replica — no static
+# target env var needed. See observability/alloy/config.alloy.
 DOKPLOY_NETWORK=dokploy-network

--- a/env/prod.example
+++ b/env/prod.example
@@ -42,11 +42,30 @@ REGISTRY_USERNAME=dockerhub-username
 PROD_IMAGE_TAG=prod-<full-git-sha>
 
 # Runtime limits / Swarm rolling update controls
-BACKEND_REPLICAS=2
-BACKEND_CPU_LIMIT=1.00
+# Prod currently runs on a single 2-CPU / 3.82GB host (kept as 1 replica for
+# simplicity — a 2nd replica on the SAME host adds no physical capacity, only
+# revisit if/when a second node exists). 1.50 leaves ~0.5 core of headroom
+# for celery/celery-beat/frontend/Traefik/Dokploy on that same host instead
+# of letting a backend burst starve everything else. See
+# load-tests/README.md "Measured Capacity" for how these numbers were chosen.
+BACKEND_REPLICAS=1
+BACKEND_CPU_LIMIT=1.50
 BACKEND_MEMORY_LIMIT=768M
 BACKEND_CPU_RESERVATION=0.25
 BACKEND_MEMORY_RESERVATION=256M
+GUNICORN_WORKERS=3
+
+# Global throttles on the endpoints that saturate first under load (login,
+# order submit) — caps aggregate throughput across ALL callers, not
+# per-user/IP, since the overload risk is many different legitimate users
+# arriving at once. Keep below the measured-healthy ceiling with margin;
+# re-tune if BACKEND_CPU_LIMIT changes. See api/throttles.py.
+LOGIN_GLOBAL_THROTTLE_RATE=150/min
+ORDER_SUBMIT_GLOBAL_THROTTLE_RATE=150/min
+
+# Spreads push-deadline-reminder delivery across batches instead of waking
+# every subscriber in the same instant. See api/tasks.py.
+PUSH_REMINDER_BATCH_STAGGER_SECONDS=15
 CELERY_REPLICAS=1
 CELERY_CPU_LIMIT=1.00
 CELERY_MEMORY_LIMIT=768M

--- a/env/staging.example
+++ b/env/staging.example
@@ -45,6 +45,18 @@ BACKEND_CPU_LIMIT=1.00
 BACKEND_MEMORY_LIMIT=768M
 BACKEND_CPU_RESERVATION=0.25
 BACKEND_MEMORY_RESERVATION=256M
+
+# Global throttles on the endpoints that saturate first under load (login,
+# order submit) — caps aggregate throughput across ALL callers, not
+# per-user/IP. Keep below the measured-healthy ceiling with margin; re-tune
+# if BACKEND_CPU_LIMIT changes. See api/throttles.py and
+# load-tests/README.md "Measured Capacity".
+LOGIN_GLOBAL_THROTTLE_RATE=100/min
+ORDER_SUBMIT_GLOBAL_THROTTLE_RATE=100/min
+
+# Spreads push-deadline-reminder delivery across batches instead of waking
+# every subscriber in the same instant. See api/tasks.py.
+PUSH_REMINDER_BATCH_STAGGER_SECONDS=15
 CELERY_REPLICAS=1
 CELERY_CPU_LIMIT=1.00
 CELERY_MEMORY_LIMIT=768M

--- a/frontend/src/pages/admin/PushNotifications.tsx
+++ b/frontend/src/pages/admin/PushNotifications.tsx
@@ -142,7 +142,7 @@ const PushNotifications: React.FC = () => {
                     </div>
                     <ul style={{ margin: 0, paddingLeft: 20, display: 'flex', flexDirection: 'column', gap: 4 }}>
                         <li>Notifikácie sa odosielajú iba používateľom, ktorí si nainštalovali aplikáciu a povolili notifikácie.</li>
-                        <li>Automatické pripomienky sa odosielajú 15 minút pred uzávierkou objednávky (nakonfigurujte v Nastaveniach).</li>
+                        <li>Automatické pripomienky sa odosielajú 30 minút pred uzávierkou objednávky (nakonfigurujte v Nastaveniach).</li>
                         <li>Neplatné subscriptions (napr. po odinštalovaní) sú automaticky odstraňované pri odosielaní.</li>
                     </ul>
                 </div>

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -164,6 +164,113 @@ python manage.py seed_load_test_users \
   --email-domain "$LOAD_TEST_DOMAIN"
 ```
 
+## Measured Capacity (2026-07-28)
+
+Ran locally against a backend container built and started exactly like prod
+(`start-backend.sh` → gunicorn, `app.settings.staging`, real PBKDF2 password
+hashing — not the dev MD5 hasher). Prod is a **single** backend replica (no
+autoscaling), so a resource-capped local container is a faithful proxy for
+its ceiling. Prod's actual host: 2 CPU cores, 3.82 GB RAM (Dokploy).
+
+**1 CPU (initial, before the host spec was confirmed):**
+
+| Rate (iterations/min) | Iterations/sec | Result |
+|---|---|---|
+| 30 (documented CI/staging profile) | 0.5 | 100% success, p95=383ms |
+| 100 | 1.67 | 100% success, p95=385ms |
+| 120 | 2.0 | **45% failed**, login p95=57s |
+| 180 | 3.0 | 100% failed, all requests hang to the 60s client timeout |
+| 1200 | 20 | 76% failed, 1559 iterations dropped entirely |
+
+**2 CPU, `GUNICORN_WORKERS=5` (`2*cores+1`) — the real prod spec:**
+
+| Rate (iterations/min) | Iterations/sec | Result |
+|---|---|---|
+| 180 | 3.0 | 100% success, p95=386ms (collapsed at 1 CPU) |
+| 360 | 6.0 | 100% success, **but p95≈11s** — queueing, not failing |
+
+Root cause: every login runs Django's default PBKDF2 password hasher, which
+is CPU-bound. With sync gunicorn workers pinned to N cores, concurrent
+logins fully occupy those cores, and past that point gunicorn's `backlog`
+(2048) queues everything else behind them instead of rejecting it — so
+without a throttle in front, requests don't fail fast, they hang until the
+client's own timeout fires (60s in this test). This scaled roughly linearly
+with CPU (1→2 cores roughly doubled the healthy ceiling), and going from 1
+CPU to 2 CPU also changed *how* it fails past the ceiling: at 1 CPU it was
+outright request failures; at 2 CPU it degrades to very bad latency before
+failing, which is a meaningfully safer failure mode.
+
+30/min in production is comfortably under the 2-CPU ceiling (~6x margin to
+180/min). The real risk isn't sustained daily volume, it's **simultaneity**:
+a burst where many different users hit the API in the same short window
+(e.g. everyone opening the app right after a push reminder). See Overload
+Plan below for what's now in place for that.
+
+## Overload Plan
+
+**Phase 1 — implemented (2026-07-28):**
+- **Global throttles** on `/api/token/` (login) and `/api/orders/` create
+  (`api/throttles.py`, `LOGIN_GLOBAL_THROTTLE_RATE` /
+  `ORDER_SUBMIT_GLOBAL_THROTTLE_RATE` env vars, default 150/min each — under
+  the measured-healthy 180/min on the real 2-CPU host, with margin). These
+  are deliberately **global**, not per-user/per-IP like DRF's built-in
+  throttles: the overload risk here is many *different* legitimate users
+  arriving at once, which a per-user limit does nothing to catch. Past the
+  limit, callers get a fast `429` with `Retry-After` (in the project's
+  standard `error.details.retry_after_seconds` shape) instead of a request
+  that hangs until it times out.
+- **Push-reminder delivery staggering** (`api/tasks.py`,
+  `PUSH_REMINDER_BATCH_STAGGER_SECONDS`, default 15s in staging/prod, 0 in
+  dev/test): the 09:45 deadline reminder and the Sunday weekly reminder used
+  to push to every subscriber in one tight loop, which tends to make
+  everyone open the app within the same few seconds — exactly the
+  simultaneity risk above. Sends are now batched (batch count capped so
+  total spread stays well under the weekly task's 290s soft time limit
+  regardless of subscriber count) and spaced out.
+- **Per-replica Prometheus scraping** (`observability/alloy/config.alloy`):
+  the old static `backend:8000` scrape target round-robins across replicas
+  via Swarm's service DNS, so with more than one replica each scrape sampled
+  a random container and per-container multiprocess counters looked like
+  they kept resetting. Alloy now discovers each backend container
+  individually (`prometheus.io/scrape=true` label, same pattern already
+  used for log shipping) and scrapes it directly, keeping each replica's
+  series continuous. **Not yet verified against a live multi-replica Swarm
+  deployment** — see the checklist in `observability/README.md`.
+- Migrations/seeds already handle multiple replicas starting concurrently:
+  `deploy_bootstrap` (run by every container on startup) wraps them in a
+  Postgres advisory lock, so a second replica starting mid-deploy blocks
+  until the first finishes rather than racing it; since seeds are
+  idempotent, its own run afterwards is a no-op. Health checks are already
+  per-container and need no cross-replica coordination. JWT auth is
+  stateless and Redis-backed cache/celery state is already shared across
+  replicas, so neither needed changes for going to >1 replica.
+
+**Still open (not done in this pass):**
+- **No fast-fail / queueing for order writes.** They run synchronously in
+  the request/response cycle. Not a priority right now — order submit
+  itself was never the bottleneck in testing (~130ms), login was. Worth
+  revisiting only if DB write contention shows up as the limit at higher
+  scale.
+- **No alerting rule** tied to the Prometheus metrics already being scraped
+  (e.g. p95 latency or 5xx rate crossing a threshold) that would notify
+  before users report an outage.
+- **BACKEND_CPU_LIMIT is still 1.00 in `env/prod.example`**, below the real
+  2-CPU host it now runs on. Recommended Dokploy change (not applied here —
+  no Dokploy access from this environment):
+  ```
+  BACKEND_CPU_LIMIT=1.50
+  GUNICORN_WORKERS=3
+  ```
+  Leaving ~0.5 core of headroom for celery/celery-beat/frontend/Traefik/
+  Dokploy itself running on the same 2-core host, rather than capping
+  backend at the full 2.00 and letting it starve everything else during a
+  burst. Re-run this load test against the real host after applying, to
+  confirm the ceiling matches the 2-CPU numbers measured here.
+- Adding a **second backend replica** was considered and deliberately not
+  done: this is a single 2-CPU host, so a second replica doesn't add
+  physical capacity — it only helps if it's on separate hardware, or purely
+  for restart-resilience. Revisit if/when a second node is available.
+
 ## What To Watch
 
 In Grafana, watch:

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -245,27 +245,30 @@ Plan below for what's now in place for that.
   stateless and Redis-backed cache/celery state is already shared across
   replicas, so neither needed changes for going to >1 replica.
 
+**Phase 1 addendum (2026-07-28):**
+- `BACKEND_CPU_LIMIT=1.50` / `GUNICORN_WORKERS=3` applied on the real Dokploy
+  prod host (confirmed 2 CPU / 3.82GB), matching this document's
+  recommendation. Re-run this load test against the live host when
+  convenient to confirm the ceiling matches the 2-CPU numbers measured here.
+- `PUSH_REMINDER_OFFSET_MINUTES` widened from 15 to 30 min
+  (`api/signals.py`) — more lead time before the deadline for arrivals to
+  spread out, on top of the send-side batching above.
+- **A Grafana alert rule set already existed** in
+  `observability/terraform/grafana-alerts/` (Terraform-managed, incl. "High
+  p95 latency" at 3s and 5xx-rate alerts) — this doc previously and
+  incorrectly said no alerting existed. It was missed on the first pass;
+  now corrected. `high_backend_cpu_cores` (was 0.9, tuned for the old 1.00
+  CPU limit) has been bumped to 1.2 to match the new 1.50 limit. The 3s p95
+  threshold sits comfortably between the measured-healthy p95 (~386ms) and
+  the measured-degraded p95 (~11s at 2x over ceiling), so no change needed
+  there.
+
 **Still open (not done in this pass):**
 - **No fast-fail / queueing for order writes.** They run synchronously in
   the request/response cycle. Not a priority right now — order submit
   itself was never the bottleneck in testing (~130ms), login was. Worth
   revisiting only if DB write contention shows up as the limit at higher
   scale.
-- **No alerting rule** tied to the Prometheus metrics already being scraped
-  (e.g. p95 latency or 5xx rate crossing a threshold) that would notify
-  before users report an outage.
-- **BACKEND_CPU_LIMIT is still 1.00 in `env/prod.example`**, below the real
-  2-CPU host it now runs on. Recommended Dokploy change (not applied here —
-  no Dokploy access from this environment):
-  ```
-  BACKEND_CPU_LIMIT=1.50
-  GUNICORN_WORKERS=3
-  ```
-  Leaving ~0.5 core of headroom for celery/celery-beat/frontend/Traefik/
-  Dokploy itself running on the same 2-core host, rather than capping
-  backend at the full 2.00 and letting it starve everything else during a
-  burst. Re-run this load test against the real host after applying, to
-  confirm the ceiling matches the 2-CPU numbers measured here.
 - Adding a **second backend replica** was considered and deliberately not
   done: this is a single 2-CPU host, so a second replica doesn't add
   physical capacity — it only helps if it's on separate hardware, or purely

--- a/observability/README.md
+++ b/observability/README.md
@@ -56,24 +56,34 @@ frontend, Postgres, Redis, and the observability container.
    - `GRAFANA_LOKI_URL`, `GRAFANA_LOKI_USER`, `GRAFANA_LOKI_API_KEY`
    - `GRAFANA_PROM_URL`, `GRAFANA_PROM_USER`, `GRAFANA_PROM_API_KEY`
    - `ALLOY_ENVIRONMENT` (`production` / `staging`)
-   - `ALLOY_METRICS_TARGET` — use **`backend:8000`**. Don't use the
-     Swarm-generated task/service name Dokploy shows in `docker ps` (e.g.
-     `zdravy-projekt-appstack-<id>_backend`) — it contains underscores, and
-     Django's Host-header validation rejects any Host value that fails
-     RFC 1034/1035 (`400 DisallowedHost`, silently swallowed as scrape
-     failures with no metrics in Grafana).
-     `backend` is the alias Compose implicitly assigns from the service name
-     in `compose/prod.yml`/`compose/staging.yml` (no config needed — it's
-     automatic), and it's allow-listed in `ALLOWED_HOSTS` in both settings
-     files for exactly this reason. A custom, more descriptive alias
-     (`zdravy-prod-backend`) was tried first but abandoned: this service is
-     attached to 3 networks (`app`, `dokploy-network`, plus the implicit
-     compose default) and Swarm's embedded DNS did not reliably register a
-     custom `TaskTemplate` alias for it — only the implicit service-name
-     alias (`backend`) resolved. Verified by exec-ing into a throwaway
-     container on `dokploy-network` and running `getent hosts backend` vs.
-     `getent hosts zdravy-prod-backend`.
    - `DOKPLOY_NETWORK` if it differs from `dokploy-network`
+
+   Alloy discovers backend containers itself via the Docker socket
+   (`discovery.docker` in `config.alloy`), filtered to containers carrying
+   the `prometheus.io/scrape=true` label already set on the backend service
+   in `compose/prod.yml`/`compose/staging.yml` — one scrape target per
+   replica, so metrics stay correct when `BACKEND_REPLICAS` is more than 1.
+   There's no static target env var to set.
+
+   This replaced an earlier static `backend:8000` target: with only one
+   replica a static target was fine, but a Swarm service DNS name
+   round-robins per connection across replicas, so with more than one
+   replica each scrape sampled a random container and Prometheus's
+   per-container multiprocess counters looked like they kept resetting.
+
+   One gotcha carries over from the old setup: Django's `ALLOWED_HOSTS` only
+   allow-lists the literal `"backend"` (Compose's implicit service alias) —
+   raw container IPs and Swarm task names both fail RFC 1034/1035 validation
+   (`400 DisallowedHost`, which silently shows up as "no metrics" in
+   Grafana, not as an obvious error). Discovery now dials each replica by
+   its container IP but still sends `Host: backend` via `http_headers` in
+   the scrape config, so `ALLOWED_HOSTS` doesn't need to change.
+
+   **Not yet verified against a live multi-replica Swarm deployment** —
+   validate after the first `BACKEND_REPLICAS > 1` deploy by checking the
+   Grafana Explore view for the `django` job: expect one `instance` series
+   per replica with a steady request rate, not gaps or 400s in the backend
+   container logs around `/metrics/` requests.
 3. **Deploy the Alloy stack** (once per host, not per app stack):
    ```bash
    docker compose --env-file <your prod env file> -f compose/observability.yml up -d

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -82,17 +82,65 @@ prometheus.scrape "alloy" {
 	forward_to = [prometheus.remote_write.grafana.receiver]
 }
 
-prometheus.scrape "django" {
-	targets = [
-		{
-			"__address__" = sys.env("ALLOY_METRICS_TARGET"),
-			"job"         = "django",
-			"environment" = sys.env("ALLOY_ENVIRONMENT"),
-		},
-	]
+// Per-container discovery instead of a static `backend:8000` Swarm service
+// DNS target: with more than one backend replica, the service DNS
+// round-robins per connection, so a static target samples a random replica
+// each scrape. Prometheus multiprocess counters are per-container, so that
+// looked like the counters kept resetting. Scraping every replica by its own
+// container IP keeps each one's series continuous, and Grafana sums across
+// the `instance` label same as it already does for cAdvisor.
+discovery.relabel "django_metrics" {
+	targets = discovery.docker.containers.targets
 
+	// Only containers that opt in via the prometheus.io/scrape=true compose
+	// label (currently just backend; celery/celery-beat/frontend don't set it).
+	rule {
+		source_labels = ["__meta_docker_container_label_prometheus_io_scrape"]
+		regex         = "true"
+		action        = "keep"
+	}
+
+	// Backend is attached to both `app` and `dokploy-network`; docker SD emits
+	// one target per attached network, which would otherwise double-scrape
+	// each replica. Alloy only shares `dokploy-network` with backend, so keep
+	// that one.
+	rule {
+		source_labels = ["__meta_docker_network_name"]
+		regex         = "dokploy-network"
+		action        = "keep"
+	}
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.+)"
+		target_label  = "instance"
+	}
+
+	rule {
+		target_label = "job"
+		replacement  = "django"
+	}
+
+	rule {
+		target_label = "environment"
+		replacement  = sys.env("ALLOY_ENVIRONMENT")
+	}
+}
+
+prometheus.scrape "django" {
+	targets      = discovery.relabel.django_metrics.output
 	metrics_path = "/metrics/"
-	forward_to   = [prometheus.remote_write.grafana.receiver]
+
+	// Django's ALLOWED_HOSTS only accepts the literal "backend" (see
+	// app/settings/prod.py) — arbitrary Swarm task names and raw container
+	// IPs get rejected as 400 DisallowedHost. Dialing happens by container
+	// IP (from __address__ above) but the Host header must still say
+	// "backend" or every scrape silently 400s and Grafana shows no data.
+	http_headers = {
+		"Host" = ["backend"],
+	}
+
+	forward_to = [prometheus.remote_write.grafana.receiver]
 }
 
 prometheus.exporter.cadvisor "docker" {

--- a/observability/terraform/grafana-alerts/main.tf
+++ b/observability/terraform/grafana-alerts/main.tf
@@ -42,7 +42,7 @@ locals {
       no_data_state   = "Alerting"
       severity        = "critical"
       summary         = "Alloy cannot scrape the Django backend"
-      description     = "The django scrape target is down in ${var.environment}. Check the Alloy stack, ALLOY_METRICS_TARGET, container networking, and backend health."
+      description     = "The django scrape target is down in ${var.environment}. Check the Alloy stack, per-container discovery in observability/alloy/config.alloy, container networking, and backend health."
     }
 
     alloy_scrape_down = {

--- a/observability/terraform/grafana-alerts/variables.tf
+++ b/observability/terraform/grafana-alerts/variables.tf
@@ -51,9 +51,9 @@ variable "high_p95_latency_seconds" {
 }
 
 variable "high_backend_cpu_cores" {
-  description = "Warning threshold for sustained backend container CPU usage, in CPU cores."
+  description = "Warning threshold for sustained backend container CPU usage, in CPU cores. Set to ~80% of BACKEND_CPU_LIMIT (env/prod.example) — re-tune together if that changes."
   type        = number
-  default     = 0.9
+  default     = 1.2
 }
 
 variable "backend_recent_restart_seconds" {


### PR DESCRIPTION
## Summary
- fix(db): contract-migration rolling safety, retained legacy columns, stabilized migration test formatting
- fix(backend): unblock deletes from legacy relations
- fix(reports): apply client billing overrides to olovrant reporting
- feat(overload): global request throttling on `/api/token/` and `/api/orders/`, staggered push-reminder delivery, per-replica Prometheus scraping, prod capacity tuned to the real 2-CPU host (see `load-tests/README.md` "Measured Capacity")
- feat(overload): push-reminder lead time widened 15→30 min, Grafana CPU alert threshold retuned for the new capacity

## Test plan
- [x] Backend test suite green (875 passed) via `docker compose -f compose/dev.yml exec backend python -m pytest`
- [x] `python manage.py check` clean
- [x] Load-tested the throttle/capacity changes locally against a prod-resource-capped container (documented in `load-tests/README.md`)
- [ ] Confirm Grafana shows per-replica `instance` series after next multi-replica deploy (Alloy discovery change not yet verified live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1AvkiwidjRWwGMuRZWJDm