### PR TITLE
fix(ci): drop org_id from grafana_rule_group

### DIFF
--- a/observability/terraform/grafana-alerts/main.tf
+++ b/observability/terraform/grafana-alerts/main.tf
@@ -136,7 +136,6 @@ resource "grafana_rule_group" "backend" {
   name             = var.alert_group_name
   folder_uid       = grafana_folder.zdravy_project.uid
   interval_seconds = 60
-  org_id           = 1
 
   dynamic "rule" {
     for_each = local.alert_rules


### PR DESCRIPTION
## Summary
- Terraform's `Apply Grafana alerts` job has failed on every push to main since 2026-07-19 with `Error: org_id is only supported with basic auth. API keys are already org-scoped`.
- `grafana_rule_group.backend` in `observability/terraform/grafana-alerts/main.tf` set `org_id = 1`, which the Grafana provider rejects when auth is an API key/service account token (already org-scoped).
- Removed the `org_id` attribute so apply can actually create/update the rule group in Grafana. No functional change to the alert rules themselves.

## Test plan
- [x] `grep` confirms no other `org_id` usage in the terraform module
- [ ] `Validate Grafana alerts` (plan) passes on this PR
- [ ] `Apply Grafana alerts` succeeds after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1AvkiwidjRWwGMuRZWJDm