### PR TITLE
fix: sub-prevádzky dedia EduPage pripojenie po splite

### DIFF
--- a/.claude/skills/compare-real/facility_aliases.json
+++ b/.claude/skills/compare-real/facility_aliases.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "App (EduPage) facility label -> real workbook 'Zariadenie' label. Value may be a single string, or a LIST of real labels meaning 'sum these real rows for this one app facility' (used when the app scrapes a celok as one bucket but the real sheet bills its sub-units on separate rows, e.g. Rozmanitá = Škôlka + Škola). Keys/values are ASCII-folded before matching, so human spelling is fine. Add only CONFIDENT mappings; leave ambiguous ones out and note them in the report. NOTE (2026-07-17 update): the real workbook renamed most facilities with an 'ms ' prefix and the app dropped its 'MŠ' prefix; list values below carry both spellings so old and new workbooks both reconcile.",
+  "_comment": "App (EduPage) facility label -> real workbook 'Zariadenie' label. Value may be a single string, or a LIST of real labels meaning 'sum these real rows for this one app facility' (used when the app scrapes a celok as one bucket but the real sheet bills its sub-units on separate rows). Keys/values are ASCII-folded before matching, so human spelling is fine. Add only CONFIDENT mappings; leave ambiguous ones out and note them in the report. NOTE (2026-07-17 update): the real workbook renamed most facilities with an 'ms ' prefix and the app dropped its 'MŠ' prefix; list values below carry both spellings so old and new workbooks both reconcile. NOTE (2026-08-04 Rozmanita split, d5892019): 'Rozmanita Škola' is now its own app-managed prevadzka (edupage_connection=None, own real row) — it must NOT be summed into 'Rozmanita Škôlka' here, or its counts vanish from its own real_only/app_only comparison and get silently folded into the kindergarten's total.",
 
   "Fantastická": ["fantasticka skolka", "fantasticka"],
   "Edulienka": ["ms edulienka", "edulienka"],
@@ -8,7 +8,7 @@
   "Krasňanko": ["ms krasnanko", "krasnanko"],
   "Libellus": ["ms libellus", "libellus"],
   "Pramienok": ["ms pramen", "pramienok"],
-  "Rozmanita Škôlka": ["ms rozmanita", "rozmanita skolka", "rozmanita skola"],
+  "Rozmanita Škôlka": ["ms rozmanita", "rozmanita skolka"],
   "Jolly Homeschool – Jolly 1": "Jolly 1",
   "Jolly Homeschool – Jolly 2": "Jolly 2",
   "Jolly Homeschool – Jolly 3": "Jolly 3",

--- a/backend/api/management/commands/reconcile_real.py
+++ b/backend/api/management/commands/reconcile_real.py
@@ -216,6 +216,26 @@ def _component_names(col_groups: list[dict]) -> list[str]:
     return [c["label"] for g in col_groups for c in g["components"]]
 
 
+def _component_meal_types(col_groups: list[dict]) -> list[str | None]:
+    return [
+        _APP_MEAL_TO_TYPE.get(group["meal"])
+        for group in col_groups
+        for _component in group["components"]
+    ]
+
+
+def _component_base_grams(col_groups: list[dict]) -> list[Decimal | None]:
+    return [
+        (
+            _decimal(component["base_grams"])
+            if component.get("base_grams") not in (None, "")
+            else None
+        )
+        for group in col_groups
+        for component in group["components"]
+    ]
+
+
 def _empty_totals(col_groups: list[dict]) -> list[list[Decimal]]:
     return [[Decimal("0")] * len(g["components"]) for g in col_groups]
 
@@ -609,6 +629,8 @@ class Command(BaseCommand):
         app_rows = dashboard.get("rows", [])
         col_groups = dashboard.get("col_groups", [])
         labels = _component_labels(col_groups)
+        component_meal_types = _component_meal_types(col_groups)
+        component_base_grams = _component_base_grams(col_groups)
         width = len(labels)
 
         # read_only=False: this command does random cell access per facility,
@@ -656,6 +678,14 @@ class Command(BaseCommand):
         )
         real_only = sorted(set(real_counts) - matched_keys)
 
+        count_diff_by_key_meal = {}
+        for key, (row, app_buckets) in app_counts.items():
+            real_buckets = real_counts.get(key, {})
+            for meal_type in MEAL_TYPES:
+                app_val = app_buckets.get(meal_type) or Decimal("0")
+                real_val = real_buckets.get(meal_type) or Decimal("0")
+                count_diff_by_key_meal[(key, meal_type)] = app_val - real_val
+
         # ── Tier 2: gramage ───────────────────────────────────────────────────
         gram_findings = []
         if width:
@@ -680,13 +710,26 @@ class Command(BaseCommand):
                 real_values = _real_gram_values_by_name(
                     har_sheet, block_rows, component_names, header_columns
                 )
-                for label, real_v, app_v in zip(labels, real_values, app_values):
+                for label, real_v, app_v, meal_type, base_grams in zip(
+                    labels,
+                    real_values,
+                    app_values,
+                    component_meal_types,
+                    component_base_grams,
+                ):
                     # Dish not in this day's header → can't compare, don't fake a diff.
                     if real_v is None:
                         continue
                     diff = app_v - real_v
                     if abs(diff) <= gram_tol:
                         continue
+                    if meal_type is not None and base_grams is not None:
+                        count_diff = count_diff_by_key_meal.get((key, meal_type))
+                        if (
+                            count_diff is not None
+                            and abs(diff - (count_diff * base_grams)) <= gram_tol
+                        ):
+                            continue  # Fully explained by the Tier 1 count diff.
                     gram_findings.append(
                         {
                             "facility": client,

--- a/backend/api/management/commands/seed_prevadzky_edupage.py
+++ b/backend/api/management/commands/seed_prevadzky_edupage.py
@@ -94,6 +94,18 @@ class Command(BaseCommand):
                 {},
             )
 
+            # EduPage pripojenie historicky visí na prevádzke, ktorú split nižšie
+            # deaktivuje. Aktívne sub-prevádzky ho musia zdediť, inak ich scraper
+            # pre dané pripojenie vôbec nenájde a celý celok ticho preskočí.
+            zdedene_pripojenie = next(
+                (
+                    p.edupage_connection
+                    for p in Prevadzka.objects.filter(celok=celok)
+                    if p.edupage_connection_id
+                ),
+                None,
+            )
+
             for sort_order, (nazov, match) in enumerate(prevadzky, start=1):
                 obj, created = Prevadzka.objects.update_or_create(
                     celok=celok,
@@ -105,6 +117,7 @@ class Command(BaseCommand):
                         "visible_menus": DEFAULT_VISIBLE_MENUS,
                         "visible_meals": DEFAULT_VISIBLE_MEALS,
                         "billing_portion_coefficients": zdedeny_koeficient,
+                        "edupage_connection": zdedene_pripojenie,
                     },
                 )
                 if not dry_run:

--- a/feedback.md
+++ b/feedback.md
@@ -292,3 +292,98 @@ Staré `MŠ …` kľúče prestali sadať a navyše aktívne rozbíjali párovan
 prepísaný na aktuálne app labely s list-hodnotami nesúcimi staré aj nové pravopisy.
 
 **Fantastická +1** (obed aj olovrant 8→9) je pre tento týždeň **akceptované** (potvrdené klientom).
+
+---
+
+## 🔴 Jolly Homeschool / Škôlka MS — EduPage split znova rozbité (regresia, CHYBA APPKY)
+
+**Toto JE chyba appky** — na rozdiel od všetkého ostatného v tomto súbore. Presne ten istý
+problém bol raz už opravený (viď „17.7.2026 — bod 2" vyššie: „Škôlka MS – Les/Lúka mali 0
+objednaných"), ale vrátil sa — niekedy medzi 17.7. a 4.8. sa `seed_prevadzky_edupage.py`
+alebo nadväzujúci seed znova rozbehol do rovnakého stavu.
+
+**Zistené 5.8.2026 pri reconcile 3.–5.8.:** scrape hlási pri každom behu (každý deň v týždni)
+
+```
+Jolly Homeschool nemá žiadnu prevádzku — preskakujem
+Škôlka MS nemá žiadnu prevádzku — preskakujem
+```
+
+**Príčina (overené v DB):** `seed_prevadzky_edupage.py` rozdelí celok na aktívne
+sub-prevádzky (`Jolly 1/2/3` s `edupage_match='J1'/'J2'/'J3'`; `Les`/`Lúka` s vlastným
+matchom) a starú "default" prevádzku **deaktivuje** (`is_active=False`) — ale
+**nepresunie na sub-prevádzky jej `edupage_connection`**. Tá ostáva visieť na
+deaktivovanej default prevádzke:
+
+```
+'Jolly Homeschool' active=False edupage_connection=6   edupage_match=''
+'Jolly 1'           active=True  edupage_connection=None edupage_match='J1'
+'Jolly 2'           active=True  edupage_connection=None edupage_match='J2'
+'Jolly 3'           active=True  edupage_connection=None edupage_match='J3'
+
+'Škôlka MS' active=False edupage_connection=12  edupage_match=''
+'Lúka'      active=True  edupage_connection=None edupage_match='Lúka'
+'Les'       active=True  edupage_connection=None edupage_match='Les'
+```
+
+`edupage_operations()` (`api/services/edupage_connection_service.py`) berie z pripojenia
+len **aktívne** prevádzky (`Prevadzka.objects.filter(is_active=True)`) — keďže pripojenie
+visí na neaktívnom placeholderi, vyjde pre neho prázdny zoznam prevádzok → scraper
+zariadenie preskočí. **Dôsledok: Jolly 1/2/3 aj Les/Lúka sa nescrapujú vôbec, každý deň,
+odkedy sa split takto rozbil znova** (presný dátum regresie neznámy — treba pozrieť git
+históriu `seed_prevadzky_edupage.py`).
+
+**Fix (navrhnutý, ešte NEaplikovaný):** v tej istej sekcii kde sa dnes dedí
+`billing_portion_coefficients` zo starej default prevádzky (komentár „Fakturačný
+koeficient visí na prevádzke..."), treba rovnako zdediť `edupage_connection` a priradiť
+ho každej novej sub-prevádzke — presne ako to dnes robí `real_initial_seed_prevadzky.py`
+pri Rozmanite (opačným smerom: tam sa connection naopak **odoberá** zo `školy`, tu sa má
+**preniesť** na sub-prevádzky).
+
+**Stav: 🔴 čaká na implementáciu.** (Návrh: Codex cez `codex:rescue`, tak ako
+`reconcile_real.py` Tier2 zmena.)
+
+---
+
+## 🟢 `facility_aliases.json` — stará alias skladala Rozmanitá Škôlka + Škola dokopy (opravené)
+
+Alias `"Rozmanita Škôlka": [..., "rozmanita skola"]` (skill `compare-real`, nie appka)
+ešte z čias pred splitom `Rozmanita Škôlka` / `Rozmanita Škola` (commit `d589201`,
+4.8.2026) sčítaval real-riadok školy do škôlky. Po splite má škola vlastnú `Prevadzka`
+(`edupage_connection=None`, app-managed) aj vlastný real riadok — starý alias by ju ticho
+vynuloval z `app_only`/`real_only` porovnania a napumpoval jej počty do škôlky.
+
+**Opravené 5.8.2026:** `"rozmanita skola"` odstránené zo zoznamu, doplnená poznámka do
+komentára súboru. Netýka sa produkčnej appky, len reconcile tooling.
+
+---
+
+## 🔴 Reconcile 3.–5.8.2026 (Po/Ut/St) — nič z tohto nie je chyba appky, potrebuje odpoveď klienta
+
+Meal plan doseedovaný z Week 32 Klasik PDF (predtým chýbal, appka mala pre celý týždeň
+`meal_plan_id=null`). Po doseedovaní: counts sedia takmer všade (Po 10/12, Ut 11/12, St
+8/9); zvyšné nezrovnalosti sú tieto štyri, opakujúce sa/konzistentné cez viac dní:
+
+**1. „Kuracie v krémovej" — rozpor v receptúre, streda 5.8.** Week 32 Klasik PDF: hlavný
+chod `225g (90g/110g/25g)` → Kuracie=90g. Real tabuľka má vo svojom base-gramáž riadku
+(KLASIK, row 2) `Kuracie v krémovej = 185g` (Ryža 110g aj Šalát 25g sedia s PDF). Real
+sheet je self-consistent (počet × base gramáž = riadkové gramy sedí presne na
+Cvernička/Deutsche schule/MŠ Heyrovského 4 — 9×185=1665, 75×185=13875, 2×185=370).
+Appka počítala presne to, čo je v PDF menu. → **Otázka: ktoré číslo je správne, 90 alebo
+185g?**
+
+**2. MŠ Heyrovského 4 — olovrant chýba v appke, KAŽDÝ deň (Po/Ut/St).** Real tabuľka: 1–2
+olovranty denne. Appka: vždy 0. `visible_meals` má olovrant povolený (nie je to appkové
+nastavenie), takže títo ľudia sa objednávajú **mimo appky**. → **Otázka: kade, nech to
+vieme dohľadať/pokryť appkou.**
+
+**3. Fantastická — 1 obed v appke, real tabuľka celý blok nula, streda 5.8.** Appka len
+zobrazila objednávku, ktorú má; real tabuľka hovorí že zariadenie ten deň neobjednávalo
+vôbec (možno zatvorené). → **Otázka: prišlo dieťa?**
+
+**4. „Grahamové pečivo" base gramáž = 1g namiesto 50g, pondelok 3.8.** V real tabuľke
+(KLASIK base row) — zjavný preklep, spôsobuje umelo veľký gram-diff pre
+Cvernička/Fantastická (real vychádza rádovo nižšie, lebo sa násobí 1g namiesto 50g). →
+**Otázka: môže klient bunku opraviť?**
+
+**Stav: 🔴 čaká na odpoveď klienta** (všetky 4 body).


### PR DESCRIPTION
## Čo je vnútri

**1. `fix(edupage): inherit edupage_connection when splitting a celok`** — skutočná appková chyba.
`seed_prevadzky_edupage` pri splite celku (Jolly Homeschool → Jolly 1/2/3, Škôlka MS → Les/Lúka) deaktivuje starú default prevádzku, ale nikdy nepresunul jej `edupage_connection` na nové aktívne sub-prevádzky. Keďže `edupage_operations()` berie z pripojenia len aktívne prevádzky, connection ostal visieť na neaktívnom placeholderi a celý celok sa ticho preskakoval **každý deň** ("nemá žiadnu prevádzku"). Overené naživo: pred fixom `scrape_edupage_orders` hlásil `skipped=2`, po fixe + reseede `skipped=0` (scraped 21→26).

**2. `fix(reconcile): don't double-report count-driven gram diffs`** — tooling.
`reconcile_real.py` Tier 2 teraz potlačí gram diff, ak je presne (v rámci tolerancie) vysvetlený už nahláseným Tier 1 count diffom pre rovnaké zariadenie+typ jedla. Plus oprava zastaranej `facility_aliases.json` aliasy, ktorá po splite Rozmanitej ticho sčítavala školu do škôlky.

**3. `docs: log reconcile 3.-5.8.2026 findings`** — zápis otázok pre klienta z tohtotýždňového reconcile do `feedback.md` (Kuracie v krémovej gramáž, MŠ Heyrovského 4 olovrant, Fantastická zatvorená, preklep v base gramáži).

## Testy

- `python manage.py check` — OK
- `pytest tests/test_deploy_bootstrap.py api/tests/test_reconcile_real.py` — 43 passed
- celá suita: `pytest` — **890 passed, 1 deselected**

🤖 Generated with [Claude Code](https://claude.com/claude-code)