### PR TITLE
fix: resolve number 420 review findings

### DIFF
--- a/backend/api/services/meal_plan_service.py
+++ b/backend/api/services/meal_plan_service.py
@@ -29,22 +29,37 @@ from ..utils import (
 def resolve_diet_menu_variants(date: datetime.date) -> dict[str, str]:
     """Resolve each active diet's main-course menu variant for a given day.
 
-    Explicit diet-specific meal-plan variants override the default Menu A. This
-    is a read-only projection of kitchen-planning data and does not affect order
-    counts, billing, or gramage calculations.
+    Explicit diet-specific meal-plan variants override the default Menu A. When a
+    diet has more than one explicit main-course row on the same day (different
+    menu_variant values), the row tagged "A" wins — matching the priority
+    _col_grams_diet uses for the equivalent gramage computation (see that function
+    in this module; keep this in sync if its tie-break logic ever changes).
+    Otherwise resolution is deterministic by MealPlanItem id (lowest id wins) since
+    MealPlanItem has no declared ordering.
+
+    This is a read-only projection of kitchen-planning data and does not affect
+    order counts, billing, or gramage calculations.
     """
     meal_plan = (
         DailyMealPlan.objects.filter(date=date).prefetch_related("items__diet").first()
     )
     overrides: dict[int, str] = {}
     if meal_plan:
-        overrides = {
-            item.diet_id: item.menu_variant
-            for item in meal_plan.items.all()
-            if item.category == MealCategory.MAIN_COURSE
-            and item.diet_id
-            and item.menu_variant
-        }
+        main_course_items = sorted(
+            (
+                item
+                for item in meal_plan.items.all()
+                if item.category == MealCategory.MAIN_COURSE
+                and item.diet_id
+                and item.menu_variant
+            ),
+            key=lambda item: item.id,
+        )
+        for item in main_course_items:
+            if item.diet_id not in overrides:
+                overrides[item.diet_id] = item.menu_variant
+            elif item.menu_variant.strip().upper() == "A":
+                overrides[item.diet_id] = item.menu_variant
 
     return {
         diet.name: overrides.get(diet.id, "A")

--- a/backend/api/tests/integration/test_diet_api.py
+++ b/backend/api/tests/integration/test_diet_api.py
@@ -81,12 +81,46 @@ def test_menu_variant_map_uses_explicit_main_course_override(api_client):
 
 
 @pytest.mark.django_db
+def test_menu_variant_map_prefers_a_for_multiple_explicit_rows(api_client):
+    api_client.force_authenticate(user=AdminUserFactory())
+    vegetarian = Diet.objects.create(name="Vegetariánska")
+    meal_plan = DailyMealPlan.objects.create(date=datetime.date(2026, 8, 10))
+    template = MealTemplate.objects.create(
+        category=MealCategory.MAIN_COURSE,
+        name="Vegetariánsky obed",
+        base_weight_grams="250.00",
+        menu_variant="V",
+        diet=vegetarian,
+    )
+    MealPlanItem.objects.create(
+        meal_plan=meal_plan,
+        template=template,
+        category=MealCategory.MAIN_COURSE,
+        menu_variant="V",
+        diet=vegetarian,
+    )
+    MealPlanItem.objects.create(
+        meal_plan=meal_plan,
+        template=template,
+        category=MealCategory.MAIN_COURSE,
+        menu_variant="A",
+        diet=vegetarian,
+    )
+
+    response = api_client.get("/api/diets/menu-variant-map/?date=2026-08-10")
+
+    assert response.status_code == 200
+    assert response.json() == {vegetarian.name: "A"}
+
+
+@pytest.mark.django_db
 def test_menu_variant_map_requires_date(api_client):
     api_client.force_authenticate(user=AdminUserFactory())
 
     response = api_client.get("/api/diets/menu-variant-map/")
 
     assert response.status_code == 400
+    assert response.json() == {"error": "date query param required"}
 
 
 @pytest.mark.django_db
@@ -96,6 +130,13 @@ def test_menu_variant_map_rejects_invalid_date(api_client):
     response = api_client.get("/api/diets/menu-variant-map/?date=10-08-2026")
 
     assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "validation_error",
+            "message": "Validation failed.",
+            "details": {"date": "Invalid date format, use YYYY-MM-DD"},
+        }
+    }
 
 
 @pytest.mark.django_db

--- a/backend/api/views/diet_views.py
+++ b/backend/api/views/diet_views.py
@@ -1,10 +1,7 @@
-import datetime
-
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework import permissions, viewsets
+from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.status import HTTP_400_BAD_REQUEST
 
 from ..cache_service import (
     DIET_LIST_TIMEOUT,
@@ -15,6 +12,7 @@ from ..cache_service import (
 from ..models import Diet
 from ..serializers_user import DietSerializer
 from ..services.meal_plan_service import resolve_diet_menu_variants
+from ..utils import parse_date_param
 
 
 @extend_schema_view(
@@ -49,17 +47,10 @@ class DietViewSet(viewsets.ModelViewSet):
         date_str = request.query_params.get("date")
         if not date_str:
             return Response(
-                {"detail": "The date query parameter is required."},
-                status=HTTP_400_BAD_REQUEST,
+                {"error": "date query param required"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-        try:
-            target_date = datetime.date.fromisoformat(date_str)
-        except ValueError:
-            return Response(
-                {"detail": "The date query parameter must use YYYY-MM-DD format."},
-                status=HTTP_400_BAD_REQUEST,
-            )
-
+        target_date = parse_date_param(date_str)
         return Response(resolve_diet_menu_variants(target_date))
 
     def list(self, request, *args, **kwargs):

--- a/frontend/src/pages/admin/DietManager.tsx
+++ b/frontend/src/pages/admin/DietManager.tsx
@@ -184,7 +184,7 @@ const DietManager: React.FC = () => {
                 onChange={(e) => setNewDietSortOrder(Number(e.target.value) || 0)}
               />
             </Field>
-            <Field label="Farba">
+            <Field label="Farba" as="div">
               <ColorSwatchPicker
                 value={newDietColor}
                 onChange={setNewDietColor}
@@ -326,7 +326,7 @@ const DietManager: React.FC = () => {
               rows={4}
             />
           </Field>
-          <Field label="Farba">
+          <Field label="Farba" as="div">
             <ColorSwatchPicker
               value={renameModal.color}
               onChange={(color) => setRenameModal((prev) => (prev ? { ...prev, color } : prev))}

--- a/frontend/src/pages/admin/ui.tsx
+++ b/frontend/src/pages/admin/ui.tsx
@@ -86,8 +86,9 @@ export const Field: React.FC<{
     req?: boolean;
     hint?: React.ReactNode;
     children: React.ReactNode;
-}> = ({ label, req, hint, children }) => (
-    <label className="zpa-field">
+    as?: 'label' | 'div';
+}> = ({ label, req, hint, children, as: Component = 'label' }) => (
+    <Component className="zpa-field">
         {label && (
             <span className="zpa-label">
                 {label}
@@ -96,7 +97,7 @@ export const Field: React.FC<{
             </span>
         )}
         {children}
-    </label>
+    </Component>
 );
 
 export const Input: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({ className = '', ...rest }) => (
@@ -113,7 +114,9 @@ export const ColorSwatchPicker: React.FC<{
     onChange: (value: string) => void;
     ariaLabel: string;
 }> = ({ value, onChange, ariaLabel }) => {
-    const [showCustomColor, setShowCustomColor] = React.useState(false);
+    const [showCustomColor, setShowCustomColor] = React.useState(
+        () => !!value && !DIET_COLORS.includes(value.toUpperCase())
+    );
     const [focusedColor, setFocusedColor] = React.useState<string | null>(null);
 
     return (

--- a/frontend/src/pages/client/components/order/DietVariantHint.tsx
+++ b/frontend/src/pages/client/components/order/DietVariantHint.tsx
@@ -1,0 +1,10 @@
+const DietVariantHint = ({ kind, menuVariant }: { kind: string; menuVariant?: string }) => {
+    if (kind !== "diets" || !menuVariant) return null;
+    return (
+        <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 4 }}>
+            (pripravuje sa ako Menu {menuVariant})
+        </span>
+    );
+};
+
+export default DietVariantHint;

--- a/frontend/src/pages/client/components/order/OrderFormBody.tsx
+++ b/frontend/src/pages/client/components/order/OrderFormBody.tsx
@@ -2,6 +2,7 @@ import type { ComponentType, CSSProperties, ReactNode } from "react";
 import { CalendarDays, Minus, PackagePlus, Plus, Trash2 } from "lucide-react";
 import type { DailyOrder, MealData } from "../../services/OrderService";
 import CategoryRow from "./CategoryRow";
+import DietVariantHint from "./DietVariantHint";
 import MealCard from "./MealCard";
 
 type MealKey = "breakfast" | "lunch" | "olovrant";
@@ -235,11 +236,7 @@ const OrderFormBody = ({
                       <div>
                         <span className="zp-diet-label">
                           {item.category} · {item.kind === "menus" ? `Menu ${item.keyName}` : item.keyName}
-                          {item.kind === "diets" && item.menuVariant && (
-                            <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 4 }}>
-                              (pripravuje sa ako Menu {item.menuVariant})
-                            </span>
-                          )}
+                          <DietVariantHint kind={item.kind} menuVariant={item.menuVariant} />
                         </span>
                         <div style={{ fontSize: 12, opacity: 0.7, marginTop: 2 }}>
                           Limit objednávky: {item.orderedCount}

--- a/frontend/src/pages/client/components/order/PackSeparatelySelector.tsx
+++ b/frontend/src/pages/client/components/order/PackSeparatelySelector.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { X, Check, Minus, Plus } from 'lucide-react';
 import { useScrollLock } from '../../../../hooks/useScrollLock';
+import DietVariantHint from './DietVariantHint';
 import NumericCountInput from './NumericCountInput';
 
 // 'fullDay' je celodenná objednávka — drží dáta mimo currentOrder, ale UI je rovnaké.
@@ -77,11 +78,7 @@ const PackSeparatelySelector = ({
                                         <div>
                                             <span className="zp-diet-label">
                                                 {item.category} · {item.kind === 'menus' ? `Menu ${item.keyName}` : item.keyName}
-                                                {item.kind === 'diets' && item.menuVariant && (
-                                                    <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 4 }}>
-                                                        (pripravuje sa ako Menu {item.menuVariant})
-                                                    </span>
-                                                )}
+                                                <DietVariantHint kind={item.kind} menuVariant={item.menuVariant} />
                                             </span>
                                             <div style={{ fontSize: 12, opacity: 0.7, marginTop: 2 }}>
                                                 Objednané: {item.orderedCount}

--- a/frontend/src/pages/client/hooks/useOrder.ts
+++ b/frontend/src/pages/client/hooks/useOrder.ts
@@ -325,8 +325,8 @@ export const useOrder = (activePrevadzkaId?: number, waitForPrevadzkaChoice = fa
                 logger.error("Failed to fetch diet menu variant map", e);
             }
         };
-        if (user) fetchDietMenuVariantMap();
-    }, [selectedDate, apiFetch, user]);
+        if (user && packSeparatelyEnabled) fetchDietMenuVariantMap();
+    }, [selectedDate, apiFetch, user, packSeparatelyEnabled]);
 
     useEffect(() => {
         const fetchMealPlanAvailability = async () => {

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -235,6 +235,7 @@ const OrderPage = () => {
           keyName: dietKey,
           orderedCount,
           count: categoryData.packSeparately?.diets?.[dietKey] || 0,
+          // Keyed by current diet name; a renamed diet's hint silently disappears on older orders — acceptable, cosmetic only.
           menuVariant: dietMenuVariantMap[dietKey],
         }));
 


### PR DESCRIPTION
## Summary
Následná oprava po veľmi dôkladnom multi-angle code review (8 nezávislých review uhlov + samostatná verifikácia) dnešných zmien (diet color swatch picker, "Zabaliť zvlášť" muted box, #420 diet→menu-variant link). 7 z 7 kandidátov bolo potvrdených ako reálne problémy.

- **Label-click bug** (`Field`/`ColorSwatchPicker`) — klik na text labelu "Farba" ticho aktivoval prvý (červený) swatch a prepísal vybranú farbu diéty. `Field` teraz vie renderovať `div` namiesto `label` pre compound widgety (`as="div"` prop), ktoré si spravujú prístupnosť samé.
- **Nedeterministický tie-break v #420** (`resolve_diet_menu_variants`) — pri viacerých `MealPlanItem` riadkoch pre tú istú diétu na ten istý deň mohol vrátiť iný variant než gramážová logika (`_col_grams_diet`), nedeterministicky naprieč requestami. Teraz deterministicky preferuje variant `"A"`, s regresným testom dokazujúcim, že poradie vloženia nehrá rolu.
- **Neviditeľná existujúca farba** (`ColorSwatchPicker`) — farba diéty mimo 16 vzoriek (napr. presne `#F97316` z model help textu) sa v edit modale javila ako nevybraná. Vlastná farba sa teraz automaticky odkryje pri otvorení.
- **Duplicitná date-param validácia** (`menu_variant_map` endpoint) — teraz znovupoužíva `parse_date_param`, rovnaký tvar chyby ako sesterský `by_date` endpoint.
- **Zbytočný fetch** (`useOrder.ts`) — `dietMenuVariantMap` sa teraz sťahuje len keď je `pack_separately_enabled` zapnuté, nie pre každú prevádzku pri každej zmene dňa.
- **Duplicitný JSX** — hint "(pripravuje sa ako Menu X)" vytiahnutý do zdieľanej `DietVariantHint` komponenty, použitej v oboch "zvlášť" zobrazeniach.
- Kozmetický nález (premenovanie diéty ticho stratí hint na starých objednávkach) zdokumentovaný komentárom — nedá sa opraviť bez sledovania histórie premenovaní, mimo rozsahu.

## Test plan
- [x] `docker compose -f compose/dev.yml exec -T backend python -m pytest --no-cov -q` — 897 passed (vrátane nového regresného testu pre tie-break)
- [x] `docker compose -f compose/dev.yml exec -T backend python manage.py check` — OK
- [x] `cd frontend && npx tsc --noEmit && npm run lint` — čisté
- [x] `npx vitest run` — 121 passed
- [x] `/compare-real 2026-08-05` spustené pred aj po opravách (cez git worktree) — **bit-pre-bit identický výsledok**, potvrdzuje nulový dopad na reálne gramážové/count výsledky

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFFhJKdjadnxuL9fXECvFK