### PR TITLE
fix: show all admins in production UI

### DIFF
--- a/backend/api/tests/integration/test_admin_user_create.py
+++ b/backend/api/tests/integration/test_admin_user_create.py
@@ -37,6 +37,32 @@ _SETUP_EMAIL = "api.email_utils.send_account_setup_email"
 class TestAdminUserCreate:
     """Test admin user creation endpoint and onboarding emails."""
 
+    def test_list_can_filter_and_return_up_to_100_admins(self, admin_client):
+        User.objects.bulk_create(
+            [
+                User(
+                    username=f"admin-{index}@example.com",
+                    email=f"admin-{index}@example.com",
+                    is_staff=True,
+                )
+                for index in range(25)
+            ]
+            + [
+                User(
+                    username=f"client-{index}@example.com",
+                    email=f"client-{index}@example.com",
+                    is_staff=False,
+                )
+                for index in range(25)
+            ]
+        )
+
+        res = admin_client.get(f"{API_URL}?is_staff=true&page_size=100")
+
+        assert res.status_code == status.HTTP_200_OK
+        assert len(res.data["results"]) == 26  # 25 created + authenticated admin
+        assert all(user["is_staff"] for user in res.data["results"])
+
     def test_create_app_user_sends_setup_email(self, admin_client):
         """Creating a regular user triggers send_account_setup_email."""
         with patch(_SETUP_EMAIL) as mock_email:

--- a/backend/api/views/admin_views.py
+++ b/backend/api/views/admin_views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from django.db.models import Exists, OuterRef, Q, Subquery
 from django.utils.dateparse import parse_date
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework import permissions, serializers, viewsets
+from rest_framework import pagination, permissions, serializers, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
@@ -13,6 +13,14 @@ from ..models import Celok, EventLog, Prevadzka
 from ..serializers_user import AdminUserSerializer
 
 logger = logging.getLogger(__name__)
+
+
+class AdminUserPagination(pagination.PageNumberPagination):
+    """Allow admin screens to request a larger, bounded user page."""
+
+    page_size = 100
+    page_size_query_param = "page_size"
+    max_page_size = 500
 
 
 class AdminEventLogSerializer(serializers.ModelSerializer):
@@ -59,6 +67,7 @@ class AdminUserViewSet(viewsets.ModelViewSet):
 
     serializer_class = AdminUserSerializer
     permission_classes = [permissions.IsAdminUser]
+    pagination_class = AdminUserPagination
 
     def get_queryset(self):
         accessible_prevadzky = Prevadzka.objects.filter(
@@ -105,6 +114,12 @@ class AdminUserViewSet(viewsets.ModelViewSet):
             qs = qs.filter(_has_access=True, _has_app_access=False)
         elif is_edupage == "false":
             qs = qs.filter(_has_app_access=True)
+
+        is_staff = self.request.query_params.get("is_staff")
+        if is_staff == "true":
+            qs = qs.filter(is_staff=True)
+        elif is_staff == "false":
+            qs = qs.filter(is_staff=False)
         return qs
 
     def perform_create(self, serializer):

--- a/frontend/src/pages/admin/AdminUserList.test.tsx
+++ b/frontend/src/pages/admin/AdminUserList.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AdminUserList from "./AdminUserList";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("../../context/auth", () => ({
+  useAuth: () => ({ apiFetch: mockApiFetch }),
+}));
+
+vi.mock("../../context/ToastContext", () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+describe("AdminUserList", () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        count: 1,
+        results: [
+          {
+            id: 42,
+            email: "admin@example.com",
+            first_name: "Prod",
+            last_name: "Admin",
+            is_active: true,
+            is_staff: true,
+          },
+        ],
+      }),
+    });
+  });
+
+  it("requests up to 100 admin users from the server", async () => {
+    render(
+      <MemoryRouter>
+        <AdminUserList />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Prod Admin")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/api/admin/users/?is_staff=true&page_size=100",
+      );
+    });
+  });
+});

--- a/frontend/src/pages/admin/AdminUserList.tsx
+++ b/frontend/src/pages/admin/AdminUserList.tsx
@@ -46,7 +46,7 @@ const AdminUserList: React.FC = () => {
   const fetchUsers = useCallback(async () => {
     try {
       const res = await apiFetch(
-        `${import.meta.env.VITE_API_URL || "/api"}/admin/users/`,
+        `${import.meta.env.VITE_API_URL || "/api"}/admin/users/?is_staff=true&page_size=100`,
       );
       if (res.ok) {
         const data = await res.json();


### PR DESCRIPTION
## Čo sa mení

- endpoint admin používateľov podporuje filtrovanie podľa `is_staff` a stránku s 100 záznamami (max. 500)

- obrazovka Správa adminov načítava priamo prvých 100 adminov namiesto filtrovania prvej 20-člennej stránky všetkých používateľov

## Overenie
- backend integračný test: passed

- frontend test: passed

- frontend ESLint: passed


