### PR TITLE
fix: show all diets in admin UI

### DIFF
--- a/backend/api/cache_service.py
+++ b/backend/api/cache_service.py
@@ -119,7 +119,7 @@ def clear_global_settings_cache() -> None:
 
 
 def clear_diet_list_cache() -> None:
-    """Clear the Diet list cache (all paginated variants)."""
+    """Clear the Diet list cache, including keys from older paginated releases."""
     base_key = get_diet_list_cache_key()
 
     # django-redis supports wildcard invalidation via delete_pattern.

--- a/backend/api/tests/integration/test_diet_api.py
+++ b/backend/api/tests/integration/test_diet_api.py
@@ -16,13 +16,28 @@ def test_diet_list_respects_sort_order_then_name(api_client):
     response = api_client.get("/api/diets/")
 
     assert response.status_code == 200
-    # Odpoveď je stránkovaná, takže položky sú pod "results".
     payload = response.json()
-    items = payload["results"] if isinstance(payload, dict) else payload
-    names = [item["name"] for item in items]
+    names = [item["name"] for item in payload]
 
     # Zulu a Beta majú sort_order 0 → idú pred Alpha (5), medzi sebou podľa názvu.
     assert names.index("Beta") < names.index("Zulu") < names.index("Alpha")
+
+
+@pytest.mark.django_db
+def test_diet_list_returns_all_items_without_pagination(api_client):
+    """Admin screens must see diets beyond the former 20-item first page."""
+    admin = AdminUserFactory()
+    api_client.force_authenticate(user=admin)
+    Diet.objects.bulk_create(
+        [Diet(name=f"Diet {index:02d}", sort_order=index) for index in range(25)]
+    )
+
+    response = api_client.get("/api/diets/")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 25
 
 
 @pytest.mark.django_db

--- a/backend/api/views/diet_views.py
+++ b/backend/api/views/diet_views.py
@@ -31,6 +31,10 @@ class DietViewSet(viewsets.ModelViewSet):
     queryset = Diet.objects.all()
     serializer_class = DietSerializer
     permission_classes = [permissions.IsAuthenticated]
+    # Diets are reference data consumed as one complete set by the management
+    # and facility-assignment screens. Paginating this endpoint made diets after
+    # the first 20 invisible and could hide an already assigned diet.
+    pagination_class = None
 
     def get_permissions(self):
         if self.action in ["create", "update", "partial_update", "destroy"]:
@@ -44,12 +48,10 @@ class DietViewSet(viewsets.ModelViewSet):
         Cache is automatically invalidated when Diet instances are
         created/updated/deleted via signal handlers (clear_diet_list_cache).
 
-        Note: Caching is per-page via pagination aware keys. This avoids returning
-        stale pages when filtering/sorting query params change.
+        The complete list is cached under one key because this endpoint is
+        intentionally not paginated.
         """
-        # Build cache key including pagination params to handle different pages
-        page_num = request.query_params.get("page", "1")
-        cache_key = f"{get_diet_list_cache_key()}:page={page_num}"
+        cache_key = get_diet_list_cache_key()
 
         # Try to get cached serialized data
         cached_data = get_cached(cache_key)
@@ -61,7 +63,7 @@ class DietViewSet(viewsets.ModelViewSet):
         # Generate response via parent list() method
         response = super().list(request, *args, **kwargs)
 
-        # Cache the serialized data (response.data is already paginated dict)
+        # Cache the complete serialized list.
         if response.status_code == 200:
             set_cached(cache_key, response.data, timeout=DIET_LIST_TIMEOUT)
 


### PR DESCRIPTION
## Čo sa mení

- endpoint `/api/diets/` vracia kompletný ne stránkovaný zoznam diét

- správca diét aj priraďovanie diét k prevádzke tak uvidia všetky položky vrátane už priradených

## Príčina
- globálne DRF stránkovanie orezalo odpoveď na prvých 20 diét, no frontend ďalšie stránky nenačítaval

## Overenie

- 7 relevantných backend testov prešlo

- Black a Flake8 prešli
