### PR TITLE
fix(frontend): login mgmt, mobile keyboard fix, tour cleanup

### DIFF
--- a/backend/api/serializers_user.py
+++ b/backend/api/serializers_user.py
@@ -499,6 +499,8 @@ class AdminUserSerializer(serializers.ModelSerializer):
         """
         settings_data = self.initial_data.get("settings", None)
         company_name = validated_data.pop("company_name", serializers.empty)
+        celok = validated_data.pop("celok", serializers.empty)
+        prevadzky = validated_data.pop("prevadzky", serializers.empty)
         settings_serializer = None
         if settings_data is not None:
             if not hasattr(instance, "profile"):
@@ -541,12 +543,39 @@ class AdminUserSerializer(serializers.ModelSerializer):
 
         instance = super().update(instance, validated_data)
 
-        profile_needs_update = company_name is not serializers.empty
+        profile_needs_update = (
+            company_name is not serializers.empty
+            or celok is not serializers.empty
+            or prevadzky is not serializers.empty
+        )
         if profile_needs_update:
-            profile, _ = UserProfile.objects.get_or_create(user=instance)
+            try:
+                profile = instance.profile
+            except UserProfile.DoesNotExist:
+                profile = UserProfile(user=instance)
+                profile._skip_default_facility = True
+                profile.save()
             if company_name is not serializers.empty:
                 profile.company_name = company_name or ""
-            profile.save()
+                profile.save(update_fields=["company_name"])
+
+            if celok is not serializers.empty or prevadzky is not serializers.empty:
+                ProfileCelokAccess.objects.filter(profile=profile).delete()
+                ProfilePrevadzkaAccess.objects.filter(profile=profile).delete()
+
+                selected_prevadzky = [] if prevadzky is serializers.empty else prevadzky
+                if selected_prevadzky:
+                    ProfilePrevadzkaAccess.objects.bulk_create(
+                        [
+                            ProfilePrevadzkaAccess(
+                                profile=profile,
+                                prevadzka=prevadzka,
+                            )
+                            for prevadzka in selected_prevadzky
+                        ]
+                    )
+                elif celok is not serializers.empty and celok is not None:
+                    ProfileCelokAccess.objects.create(profile=profile, celok=celok)
 
         if settings_serializer is not None:
             settings_serializer.save()

--- a/backend/api/tests/integration/test_admin_user_create.py
+++ b/backend/api/tests/integration/test_admin_user_create.py
@@ -22,6 +22,7 @@ from api.models import (
     PasswordResetToken,
     Prevadzka,
     ProfileCelokAccess,
+    ProfilePrevadzkaAccess,
     UserProfile,
 )
 from api.reference_data import DEFAULT_DIET_NAMES, DEFAULT_DIETS
@@ -338,3 +339,59 @@ class TestAdminUserCreate:
         assert res.status_code == status.HTTP_200_OK
         user.profile.refresh_from_db()
         assert user.profile.company_name == ""
+
+    def test_update_user_reassigns_prevadzka_access(self, admin_client):
+        user = User.objects.create_user(
+            username="reassign@example.com",
+            email="reassign@example.com",
+        )
+        profile = UserProfile(user=user)
+        profile._skip_default_facility = True
+        profile.save()
+        celok = Celok.objects.create(nazov="Reassignment celok")
+        first = Prevadzka.objects.create(celok=celok, nazov="First")
+        second = Prevadzka.objects.create(celok=celok, nazov="Second")
+        ProfileCelokAccess.objects.create(profile=profile, celok=celok)
+
+        res = admin_client.patch(
+            f"{API_URL}{user.pk}/",
+            {
+                "email": "reassigned@example.com",
+                "company_name": "Reassigned login",
+                "celok": celok.pk,
+                "prevadzky": [second.pk],
+            },
+            format="json",
+        )
+
+        assert res.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        profile.refresh_from_db()
+        assert user.email == "reassigned@example.com"
+        assert user.username == "reassigned@example.com"
+        assert profile.company_name == "Reassigned login"
+        assert not ProfileCelokAccess.objects.filter(profile=profile).exists()
+        assert list(
+            ProfilePrevadzkaAccess.objects.filter(profile=profile).values_list(
+                "prevadzka_id", flat=True
+            )
+        ) == [second.pk]
+        assert first.pk not in profile.dostupne_prevadzky().values_list("pk", flat=True)
+
+    def test_destroy_user_removes_profile_access(self, admin_client):
+        user = User.objects.create_user(
+            username="delete-login@example.com",
+            email="delete-login@example.com",
+        )
+        profile = UserProfile(user=user)
+        profile._skip_default_facility = True
+        profile.save()
+        celok = Celok.objects.create(nazov="Delete login celok")
+        ProfileCelokAccess.objects.create(profile=profile, celok=celok)
+
+        res = admin_client.delete(f"{API_URL}{user.pk}/")
+
+        assert res.status_code == status.HTTP_204_NO_CONTENT
+        assert not User.objects.filter(pk=user.pk).exists()
+        assert not UserProfile.objects.filter(pk=profile.pk).exists()
+        assert not ProfileCelokAccess.objects.filter(profile_id=profile.pk).exists()

--- a/frontend/src/context/OnboardingContext.tsx
+++ b/frontend/src/context/OnboardingContext.tsx
@@ -104,12 +104,14 @@ export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const completeTour = useCallback(async () => {
     setIsTourActive(false);
+    setCurrentStep(0);
     updateProfile({ onboarding_completed: true });
     await markOnServer(true);
   }, [updateProfile, markOnServer]);
 
   const skipTour = useCallback(async () => {
     setIsTourActive(false);
+    setCurrentStep(0);
     updateProfile({ onboarding_completed: true });
     await markOnServer(true);
   }, [updateProfile, markOnServer]);

--- a/frontend/src/pages/AuthViewportPages.test.tsx
+++ b/frontend/src/pages/AuthViewportPages.test.tsx
@@ -1,0 +1,33 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ForgotPasswordPage from "./ForgotPasswordPage";
+import ResetPasswordPage from "./ResetPasswordPage";
+import SetPasswordPage from "./SetPasswordPage";
+
+const mockUseStableViewportHeight = vi.fn();
+
+vi.mock("../hooks/useStableViewportHeight", () => ({
+  useStableViewportHeight: () => mockUseStableViewportHeight(),
+}));
+
+describe("authentication page viewport sizing", () => {
+  beforeEach(() => {
+    mockUseStableViewportHeight.mockClear();
+  });
+
+  it.each([
+    ["forgot password", ForgotPasswordPage, "/forgot-password"],
+    ["reset password", ResetPasswordPage, "/reset-password?token=test"],
+    ["set password", SetPasswordPage, "/set-password?token=test"],
+  ])("uses the stable app height on %s", (_name, Page, route) => {
+    const view = render(
+      <MemoryRouter initialEntries={[route]}>
+        <Page />
+      </MemoryRouter>,
+    );
+
+    expect(mockUseStableViewportHeight).toHaveBeenCalledOnce();
+    expect(view.container.firstElementChild).toHaveClass("zp-app--login");
+  });
+});

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import ConfirmationModal from "./client/components/ui/ConfirmationModal";
+import { useStableViewportHeight } from "../hooks/useStableViewportHeight";
 
 const API_URL = import.meta.env.VITE_API_URL || "/api";
 
 const ForgotPasswordPage: React.FC = () => {
+  useStableViewportHeight();
   const [email, setEmail] = useState("");
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState("");
@@ -51,7 +53,7 @@ const ForgotPasswordPage: React.FC = () => {
 
   if (submitted) {
     return (
-      <div className="zp-app" style={{ minHeight: "100vh" }}>
+      <div className="zp-app zp-app--login">
         <div className="zp-login">
           <div className="zp-login-brand">
             <img className="logoimg" src="/logo-zdravy-projekt.png" alt="Zdravý projekt" />
@@ -75,7 +77,7 @@ const ForgotPasswordPage: React.FC = () => {
   }
 
   return (
-    <div className="zp-app" style={{ minHeight: "100vh" }}>
+    <div className="zp-app zp-app--login">
       <div className="zp-login">
         <div className="zp-login-brand">
           <img className="logoimg" src="/logo-zdravy-projekt.png" alt="Zdravý projekt" />

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useSearchParams, Link } from "react-router-dom";
+import { useStableViewportHeight } from "../hooks/useStableViewportHeight";
 
 const API_URL = import.meta.env.VITE_API_URL || "/api";
 
 const ResetPasswordPage: React.FC = () => {
+  useStableViewportHeight();
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token") ?? "";
   const navigate = useNavigate();
@@ -60,7 +62,7 @@ const ResetPasswordPage: React.FC = () => {
 
   if (success) {
     return (
-      <div className="zp-app" style={{ minHeight: "100vh" }}>
+      <div className="zp-app zp-app--login">
         <div className="zp-login">
           <div className="zp-login-brand">
             <img className="logoimg" src="/logo-zdravy-projekt.png" alt="Zdravý projekt" />
@@ -80,7 +82,7 @@ const ResetPasswordPage: React.FC = () => {
   }
 
   return (
-    <div className="zp-app" style={{ minHeight: "100vh" }}>
+    <div className="zp-app zp-app--login">
       <div className="zp-login">
         <div className="zp-login-brand">
           <img className="logoimg" src="/logo-zdravy-projekt.png" alt="Zdravý projekt" />

--- a/frontend/src/pages/SetPasswordPage.tsx
+++ b/frontend/src/pages/SetPasswordPage.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useNavigate, useSearchParams, Link } from "react-router-dom";
+import { useStableViewportHeight } from "../hooks/useStableViewportHeight";
 
 const API_URL = import.meta.env.VITE_API_URL || "/api";
 
 const SetPasswordPage: React.FC = () => {
+  useStableViewportHeight();
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token") ?? "";
   const navigate = useNavigate();
@@ -65,7 +67,7 @@ const SetPasswordPage: React.FC = () => {
 
   if (success) {
     return (
-      <div className="zp-app" style={{ minHeight: "100vh" }}>
+      <div className="zp-app zp-app--login">
         <div className="zp-login">
           <div className="zp-login-brand">
             <img className="logoimg" src="/logo-zdravy-projekt.png" alt="Zdravý projekt" />
@@ -85,7 +87,7 @@ const SetPasswordPage: React.FC = () => {
   }
 
   return (
-    <div className="zp-app" style={{ minHeight: "100vh" }}>
+    <div className="zp-app zp-app--login">
       <div className="zp-login">
         <div className="zp-login-brand">
           <img className="logoimg" src="/logo-zdravy-projekt.png" alt="Zdravý projekt" />

--- a/frontend/src/pages/admin/FacilityManager.test.tsx
+++ b/frontend/src/pages/admin/FacilityManager.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import FacilityManager from "./FacilityManager";
+
+const mockApiFetch = vi.fn();
+
+vi.mock("../../context/auth", () => ({
+  useAuth: () => ({ apiFetch: mockApiFetch }),
+}));
+
+vi.mock("../../context/ToastContext", () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+const celok = {
+  id: 10,
+  nazov: "Centrálny celok",
+  billing_name: "",
+  adresa: "",
+  ico: "",
+  dic: "",
+  zdroj_objednavok: "app",
+  prevadzky_count: 2,
+  prevadzky: [
+    {
+      id: 101,
+      celok: 10,
+      celok_nazov: "Centrálny celok",
+      nazov: "Prvá prevádzka",
+      adresa: "Prvá 1",
+      edupage_connection: null,
+      edupage_connection_name: null,
+      edupage_match: "",
+      report_alias: "",
+      delivery_note: "",
+      sort_order: 0,
+      is_active: true,
+      billing_portion_coefficients: {},
+      orders_count: 0,
+      client_user_id: null,
+    },
+    {
+      id: 102,
+      celok: 10,
+      celok_nazov: "Centrálny celok",
+      nazov: "Druhá prevádzka",
+      adresa: "Druhá 2",
+      edupage_connection: null,
+      edupage_connection_name: null,
+      edupage_match: "",
+      report_alias: "",
+      delivery_note: "",
+      sort_order: 1,
+      is_active: true,
+      billing_portion_coefficients: {},
+      orders_count: 0,
+      client_user_id: null,
+    },
+  ],
+  logins: [
+    {
+      user_id: 501,
+      email: "celok@example.com",
+      company_name: "Celok login",
+      is_edupage: false,
+      prevadzka_ids: [],
+    },
+    {
+      user_id: 502,
+      email: "prevadzka@example.com",
+      company_name: "Prevádzka login",
+      is_edupage: false,
+      prevadzka_ids: [101],
+    },
+  ],
+};
+
+function renderManager() {
+  return render(
+    <MemoryRouter>
+      <FacilityManager />
+    </MemoryRouter>,
+  );
+}
+
+describe("FacilityManager login management", () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+    mockApiFetch.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (options?.method === "PATCH") return { ok: true, status: 200, json: async () => ({}) };
+      if (options?.method === "DELETE") return { ok: true, status: 204, json: async () => ({}) };
+      if (url.endsWith("/admin/edupage-connections/")) return { ok: true, json: async () => [] };
+      return { ok: true, json: async () => [celok] };
+    });
+  });
+
+  it("opens the complete login list from the celok badge", async () => {
+    const user = userEvent.setup();
+    renderManager();
+
+    await user.click(await screen.findByRole("button", { name: "Zobraziť loginy celku Centrálny celok" }));
+
+    expect(screen.getByText("Loginy — Centrálny celok")).toBeInTheDocument();
+    expect(screen.getByText("celok@example.com")).toBeInTheDocument();
+    expect(screen.getByText("prevadzka@example.com")).toBeInTheDocument();
+  });
+
+  it("opens a filtered login list from a prevádzka badge", async () => {
+    const user = userEvent.setup();
+    renderManager();
+
+    await user.click(await screen.findByRole("button", { name: "Centrálny celok 2 prevádzky" }));
+    await user.click(screen.getByRole("button", { name: "Zobraziť loginy prevádzky Prvá prevádzka" }));
+
+    expect(screen.getByText("Loginy — Prvá prevádzka")).toBeInTheDocument();
+    expect(screen.getByText("prevadzka@example.com")).toBeInTheDocument();
+    expect(screen.queryByText("celok@example.com")).not.toBeInTheDocument();
+  });
+
+  it("prefills and saves an edited login with PATCH", async () => {
+    const user = userEvent.setup();
+    renderManager();
+
+    await user.click(await screen.findByRole("button", { name: "Zobraziť loginy celku Centrálny celok" }));
+    await user.click(screen.getByRole("button", { name: "Upraviť login prevadzka@example.com" }));
+
+    const editor = screen.getByText("Upraviť login — prevadzka@example.com").closest<HTMLElement>(".zpa-modal")!;
+    const nameInput = within(editor).getByLabelText("Názov loginu *");
+    const emailInput = within(editor).getByLabelText("Email *");
+    expect(nameInput).toHaveValue("Prevádzka login");
+    expect(emailInput).toHaveValue("prevadzka@example.com");
+
+    await user.clear(nameInput);
+    await user.type(nameInput, "Upravený login");
+    await user.clear(emailInput);
+    await user.type(emailInput, "upraveny@example.com");
+    await user.click(within(editor).getByRole("button", { name: "Uložiť" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/api/admin/users/502/",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({
+            email: "upraveny@example.com",
+            company_name: "Upravený login",
+            is_staff: false,
+            is_active: true,
+            celok: 10,
+            prevadzky: [101],
+          }),
+        }),
+      );
+    });
+  });
+
+  it("deletes a login only after confirmation", async () => {
+    const user = userEvent.setup();
+    renderManager();
+
+    await user.click(await screen.findByRole("button", { name: "Zobraziť loginy celku Centrálny celok" }));
+    await user.click(screen.getByRole("button", { name: "Odstrániť login celok@example.com" }));
+
+    expect(screen.getByText("Naozaj odstrániť login", { exact: false })).toHaveTextContent("celok@example.com");
+    expect(mockApiFetch).not.toHaveBeenCalledWith(
+      "/api/admin/users/501/",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Odstrániť$/ }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith("/api/admin/users/501/", { method: "DELETE" });
+    });
+  });
+});

--- a/frontend/src/pages/admin/FacilityManager.tsx
+++ b/frontend/src/pages/admin/FacilityManager.tsx
@@ -232,10 +232,14 @@ const FacilityManager: React.FC = () => {
   });
   const [cSaving, setCSaving] = useState(false);
 
-  // Login add (target: celok, optional prevádzka)
+  // Login list/add/edit/delete (target: celok, optional prevádzka)
+  const [loginListTarget, setLoginListTarget] = useState<{ celok: Celok; prevadzka: Prevadzka | null } | null>(null);
   const [loginTarget, setLoginTarget] = useState<{ celok: Celok; prevadzka: Prevadzka | null } | null>(null);
+  const [loginEditTarget, setLoginEditTarget] = useState<Login | null>(null);
+  const [loginDeleteTarget, setLoginDeleteTarget] = useState<Login | null>(null);
   const [lForm, setLForm] = useState<LoginForm>(EMPTY_LOGIN);
   const [lSaving, setLSaving] = useState(false);
+  const [loginDeleting, setLoginDeleting] = useState(false);
 
   const fetchCelky = useCallback(async () => {
     try {
@@ -427,10 +431,21 @@ const FacilityManager: React.FC = () => {
     }
   };
 
-  // ── Login add ──
+  // ── Login ──
   const openAddLogin = (celok: Celok, prevadzka: Prevadzka | null) => {
+    setLoginEditTarget(null);
     setLoginTarget({ celok, prevadzka });
     setLForm({ ...EMPTY_LOGIN, company_name: prevadzka?.nazov || celok.nazov });
+  };
+  const openEditLogin = (celok: Celok, prevadzka: Prevadzka | null, login: Login) => {
+    setLoginListTarget(null);
+    setLoginEditTarget(login);
+    setLoginTarget({ celok, prevadzka });
+    setLForm({ email: login.email, company_name: login.company_name });
+  };
+  const closeLoginEditor = () => {
+    setLoginTarget(null);
+    setLoginEditTarget(null);
   };
   const saveLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -447,26 +462,54 @@ const FacilityManager: React.FC = () => {
         is_active: true,
         celok: loginTarget.celok.id,
       };
-      if (loginTarget.prevadzka) body.prevadzky = [loginTarget.prevadzka.id];
-      const res = await apiFetch(`${API}/admin/users/`, {
-        method: "POST",
+      if (loginEditTarget) {
+        body.prevadzky = loginEditTarget.prevadzka_ids;
+      } else if (loginTarget.prevadzka) {
+        body.prevadzky = [loginTarget.prevadzka.id];
+      }
+      const res = await apiFetch(
+        loginEditTarget ? `${API}/admin/users/${loginEditTarget.user_id}/` : `${API}/admin/users/`,
+        {
+        method: loginEditTarget ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
-      });
+        },
+      );
       if (res.ok) {
-        success("Login bol vytvorený.");
+        success(loginEditTarget ? "Login bol upravený." : "Login bol vytvorený.");
         setExpanded((prev) => new Set(prev).add(loginTarget.celok.id));
-        setLoginTarget(null);
+        closeLoginEditor();
         fetchCelky();
       } else {
         const data = await res.json().catch(() => ({}));
-        toastError(data?.error?.details?.email?.[0] || data?.email?.[0] || data?.error?.message || "Nepodarilo sa vytvoriť login.");
+        toastError(data?.error?.details?.email?.[0] || data?.email?.[0] || data?.error?.message || "Nepodarilo sa uložiť login.");
       }
     } catch (err) {
       logger.error(err);
-      toastError("Chyba pri vytváraní loginu.");
+      toastError("Chyba pri ukladaní loginu.");
     } finally {
       setLSaving(false);
+    }
+  };
+
+  const doDeleteLogin = async () => {
+    if (!loginDeleteTarget) return;
+    setLoginDeleting(true);
+    try {
+      const res = await apiFetch(`${API}/admin/users/${loginDeleteTarget.user_id}/`, { method: "DELETE" });
+      if (res.ok || res.status === 204) {
+        success(`Login „${loginDeleteTarget.email}“ bol odstránený.`);
+        setLoginDeleteTarget(null);
+        setLoginListTarget(null);
+        fetchCelky();
+      } else {
+        toastError("Nepodarilo sa odstrániť login.");
+      }
+    } catch (err) {
+      logger.error(err);
+      toastError("Chyba pri odstraňovaní loginu.");
+    } finally {
+      setLoginDeleting(false);
     }
   };
 
@@ -510,10 +553,25 @@ const FacilityManager: React.FC = () => {
                           {celok.prevadzky_count} {celok.prevadzky_count === 1 ? "prevádzka" : "prevádzky"}
                         </Badge>
                         {celok.zdroj_objednavok === "edupage" && <Badge tone="teal">Edupage</Badge>}
-                        {celok.logins.length > 0 && (
-                          <Badge tone="honey"><Users size={12} style={{ verticalAlign: "-2px" }} /> {celok.logins.length}</Badge>
-                        )}
                       </button>
+                      {celok.logins.length > 0 && (
+                        <Badge
+                          tone="honey"
+                          role="button"
+                          tabIndex={0}
+                          aria-label={`Zobraziť loginy celku ${celok.nazov}`}
+                          style={{ cursor: "pointer" }}
+                          onClick={() => setLoginListTarget({ celok, prevadzka: null })}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              setLoginListTarget({ celok, prevadzka: null });
+                            }
+                          }}
+                        >
+                          <Users size={12} style={{ verticalAlign: "-2px" }} /> {celok.logins.length}
+                        </Badge>
+                      )}
                       <div className="zpa-celok-actions">
                         <IconButton onClick={() => openEditCelok(celok)} title="Upraviť celok" aria-label="Upraviť celok"><Pencil /></IconButton>
                         <IconButton onClick={() => openAddLogin(celok, null)} title="Pridať login" aria-label="Pridať login"><UserPlus /></IconButton>
@@ -538,11 +596,30 @@ const FacilityManager: React.FC = () => {
                               <tr><td colSpan={5} className="c" style={{ color: "var(--ink-mute)", padding: 16 }}>Žiadne prevádzky</td></tr>
                             ) : (
                               celok.prevadzky.map((p) => {
+                                const prevadzkaLogins = celok.logins.filter((login) => login.prevadzka_ids.includes(p.id));
                                 return (
                                   <tr key={p.id} style={{ opacity: p.is_active ? 1 : 0.5 }}>
                                     <td>
                                       {p.nazov}
                                       {!p.is_active && <Badge tone="gray" style={{ marginLeft: 8 }}>neaktívna</Badge>}
+                                      {prevadzkaLogins.length > 0 && (
+                                        <Badge
+                                          tone="honey"
+                                          role="button"
+                                          tabIndex={0}
+                                          aria-label={`Zobraziť loginy prevádzky ${p.nazov}`}
+                                          style={{ marginLeft: 8, cursor: "pointer" }}
+                                          onClick={() => setLoginListTarget({ celok, prevadzka: p })}
+                                          onKeyDown={(event) => {
+                                            if (event.key === "Enter" || event.key === " ") {
+                                              event.preventDefault();
+                                              setLoginListTarget({ celok, prevadzka: p });
+                                            }
+                                          }}
+                                        >
+                                          <Users size={12} style={{ verticalAlign: "-2px" }} /> {prevadzkaLogins.length}
+                                        </Badge>
+                                      )}
                                     </td>
                                     <td style={{ fontSize: 12, color: "var(--ink-3)" }}>{p.adresa || "—"}</td>
                                     <td style={{ fontSize: 12, color: "var(--ink-3)" }}>{p.edupage_match || "—"}</td>
@@ -635,24 +712,94 @@ const FacilityManager: React.FC = () => {
         </Modal>
       )}
 
-      {/* Login add */}
+      {/* Login list */}
+      {loginListTarget && (() => {
+        const listedLogins = loginListTarget.prevadzka
+          ? loginListTarget.celok.logins.filter((login) => login.prevadzka_ids.includes(loginListTarget.prevadzka!.id))
+          : loginListTarget.celok.logins;
+        return (
+          <Modal
+            title={loginListTarget.prevadzka ? `Loginy — ${loginListTarget.prevadzka.nazov}` : `Loginy — ${loginListTarget.celok.nazov}`}
+            onClose={() => setLoginListTarget(null)}
+            wide
+            foot={<Button variant="ghost" onClick={() => setLoginListTarget(null)}>Zavrieť</Button>}
+          >
+            {listedLogins.map((login) => (
+              <div key={login.user_id} className="zpa-listrow" style={{ paddingInline: 0 }}>
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div className="lr-ttl" style={{ textTransform: "none" }}>{login.company_name || login.email}</div>
+                  <div className="lr-sub">{login.email}</div>
+                </div>
+                {login.is_edupage && <Badge tone="teal">EduPage</Badge>}
+                <IconButton
+                  onClick={() => openEditLogin(loginListTarget.celok, loginListTarget.prevadzka, login)}
+                  title="Upraviť login"
+                  aria-label={`Upraviť login ${login.email}`}
+                >
+                  <Pencil />
+                </IconButton>
+                <IconButton
+                  onClick={() => {
+                    setLoginListTarget(null);
+                    setLoginDeleteTarget(login);
+                  }}
+                  title="Odstrániť login"
+                  aria-label={`Odstrániť login ${login.email}`}
+                >
+                  <Trash2 />
+                </IconButton>
+              </div>
+            ))}
+          </Modal>
+        );
+      })()}
+
+      {/* Login add/edit */}
       {loginTarget && (
         <Modal
-          title={loginTarget.prevadzka ? `Pridať login — ${loginTarget.prevadzka.nazov}` : `Pridať login — ${loginTarget.celok.nazov}`}
-          onClose={() => setLoginTarget(null)}
+          title={loginEditTarget
+            ? `Upraviť login — ${loginEditTarget.email}`
+            : loginTarget.prevadzka
+              ? `Pridať login — ${loginTarget.prevadzka.nazov}`
+              : `Pridať login — ${loginTarget.celok.nazov}`}
+          onClose={closeLoginEditor}
           foot={<>
-            <Button variant="ghost" onClick={() => setLoginTarget(null)}>Zrušiť</Button>
-            <Button type="submit" form="login-form" disabled={lSaving}>{lSaving ? "Vytváram…" : "Vytvoriť login"}</Button>
+            <Button variant="ghost" onClick={closeLoginEditor}>Zrušiť</Button>
+            <Button type="submit" form="login-form" disabled={lSaving}>
+              {lSaving ? "Ukladám…" : loginEditTarget ? "Uložiť" : "Vytvoriť login"}
+            </Button>
           </>}
         >
-          <p style={{ margin: "0 0 4px", fontSize: 13, color: "var(--ink-3)" }}>
-            {loginTarget.prevadzka
-              ? `Login bude objednávať len za prevádzku „${loginTarget.prevadzka.nazov}“.`
-              : `Login bude objednávať za celý celok „${loginTarget.celok.nazov}“ (všetky prevádzky).`}
-          </p>
+          {!loginEditTarget && (
+            <p style={{ margin: "0 0 4px", fontSize: 13, color: "var(--ink-3)" }}>
+              {loginTarget.prevadzka
+                ? `Login bude objednávať len za prevádzku „${loginTarget.prevadzka.nazov}“.`
+                : `Login bude objednávať za celý celok „${loginTarget.celok.nazov}“ (všetky prevádzky).`}
+            </p>
+          )}
           <form id="login-form" onSubmit={saveLogin} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <LoginFields form={lForm} setForm={setLForm} />
           </form>
+        </Modal>
+      )}
+
+      {/* Login delete */}
+      {loginDeleteTarget && (
+        <Modal
+          title="Odstrániť login"
+          onClose={() => setLoginDeleteTarget(null)}
+          icon={<AlertTriangle />}
+          iconKind="danger"
+          foot={<>
+            <Button variant="ghost" onClick={() => setLoginDeleteTarget(null)} disabled={loginDeleting}>Zrušiť</Button>
+            <Button variant="danger" onClick={doDeleteLogin} disabled={loginDeleting}>
+              {loginDeleting ? "Odstraňujem…" : "Odstrániť"}
+            </Button>
+          </>}
+        >
+          <p style={{ margin: 0, color: "var(--ink-2)", lineHeight: 1.6 }}>
+            Naozaj odstrániť login <strong style={{ color: "var(--green-900)" }}>{loginDeleteTarget.email}</strong>?
+          </p>
         </Modal>
       )}
 

--- a/frontend/src/pages/client/components/onboarding/TourOverlay.test.tsx
+++ b/frontend/src/pages/client/components/onboarding/TourOverlay.test.tsx
@@ -1,0 +1,79 @@
+import { act, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useOnboarding } from "../../../../context/OnboardingContext";
+import TourOverlay from "./TourOverlay";
+
+vi.mock("../../../../context/OnboardingContext", () => ({
+  useOnboarding: vi.fn(),
+}));
+
+vi.mock("./TourTooltip", () => ({
+  default: () => <div data-testid="tour-tooltip" />,
+}));
+
+const mockUseOnboarding = vi.mocked(useOnboarding);
+
+function tourState(isTourActive: boolean) {
+  return {
+    isTourActive,
+    currentStep: 0,
+    totalSteps: 10,
+    startTour: vi.fn(),
+    nextStep: vi.fn(),
+    prevStep: vi.fn(),
+    completeTour: vi.fn(async () => undefined),
+    skipTour: vi.fn(async () => undefined),
+    resetTour: vi.fn(async () => undefined),
+  };
+}
+
+describe("TourOverlay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 20,
+      y: 20,
+      top: 20,
+      left: 20,
+      right: 140,
+      bottom: 60,
+      width: 120,
+      height: 40,
+      toJSON: () => ({}),
+    } as DOMRect);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("removes the target highlight immediately when the tour is skipped or cancelled", () => {
+    mockUseOnboarding.mockReturnValue(tourState(true));
+    const view = render(
+      <MemoryRouter initialEntries={["/home"]}>
+        <div data-tour-id="tour-new-order-btn">New order</div>
+        <TourOverlay />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+
+    const target = view.container.querySelector('[data-tour-id="tour-new-order-btn"]')!;
+    expect(target).toHaveClass("tour-highlight");
+
+    mockUseOnboarding.mockReturnValue(tourState(false));
+    view.rerender(
+      <MemoryRouter initialEntries={["/home"]}>
+        <div data-tour-id="tour-new-order-btn">New order</div>
+        <TourOverlay />
+      </MemoryRouter>,
+    );
+
+    expect(target).not.toHaveClass("tour-highlight");
+  });
+});

--- a/frontend/src/pages/client/components/onboarding/TourOverlay.tsx
+++ b/frontend/src/pages/client/components/onboarding/TourOverlay.tsx
@@ -89,6 +89,13 @@ const TourOverlay: React.FC = () => {
   useEffect(() => {
     hasRemeasured.current = false;
 
+    // Always clear the previous target first. The overlay stays mounted when
+    // the tour is skipped, so unmount cleanup alone is not sufficient.
+    if (highlightedEl.current) {
+      highlightedEl.current.classList.remove("tour-highlight");
+      highlightedEl.current = null;
+    }
+
     if (!isTourActive) {
       setTooltipPos(null);
       return;
@@ -100,12 +107,6 @@ const TourOverlay: React.FC = () => {
     if (!location.pathname.startsWith(step.page)) {
       setTooltipPos(null);
       return;
-    }
-
-    // Remove highlight from previous element
-    if (highlightedEl.current) {
-      highlightedEl.current.classList.remove("tour-highlight");
-      highlightedEl.current = null;
     }
 
     // The target element may not exist in the DOM yet — e.g. it lives inside


### PR DESCRIPTION
## Summary
- #424: celok/prevádzka login badges are now clickable → filtered login list with edit/delete actions (reusing the existing add-login modal + `AdminUserViewSet` CRUD, now with celok/prevádzka reassignment support on update).
- #425: password-related auth pages (`SetPasswordPage`, `ForgotPasswordPage`, `ResetPasswordPage`) switched from hardcoded `100vh` to the existing `useStableViewportHeight()` + `zp-app--login` pattern already used by `LoginPage`, fixing the empty colored box left behind when the mobile keyboard opens.
- #426: `TourOverlay` was only clearing the `.tour-highlight` DOM class on unmount; since the overlay stays mounted across skip/cancel, the highlight lingered. Now cleared on every `isTourActive` transition. `skipTour`/`completeTour` also reset `currentStep` for consistency with `resetTour`.

## Test plan
- [x] Backend: `pytest` — 921 passed
- [x] Frontend: `tsc --noEmit`, `eslint`, `vitest` — 146 passed (new tests cover login list/edit/delete, viewport hook usage on all three auth pages, and immediate highlight-class removal on tour skip)
- [ ] Manual mobile keyboard check (no browser automation available in this environment — covered by targeted tests instead)

Closes #424, #425, #426

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>