### PR TITLE
fix(backend): fix Edulienka seed split name mismatch

### DIFF
--- a/backend/api/management/commands/seed_prevadzky_edupage.py
+++ b/backend/api/management/commands/seed_prevadzky_edupage.py
@@ -38,8 +38,10 @@ SPLITS: dict[str, list[tuple[str, str]]] = {
         ("Jolly 3", "J3"),
     ],
     # Názvy sú krátke, lebo v reportoch sa prefixujú celkom:
-    # "Edulienka – Palisády".
-    "Edulienka": [
+    # "MŠ Edulienka – Palisády".
+    # Kľúč musí sedieť na presný `Celok.nazov` ("MŠ Edulienka", nie holé
+    # "Edulienka") — inak filter nič nenájde a split sa ticho preskočí.
+    "MŠ Edulienka": [
         ("Palisády", "Palisády"),
         ("Stupava", "Stupava"),
     ],

--- a/backend/api/tests/test_seed_prevadzky_edupage.py
+++ b/backend/api/tests/test_seed_prevadzky_edupage.py
@@ -1,0 +1,42 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from api.models import Celok, Prevadzka
+
+
+@pytest.mark.django_db
+def test_seed_splits_ms_edulienka_into_palisady_and_stupava():
+    """Regression test: SPLITS previously keyed on the bare "Edulienka" name,
+    which never matches the real Celok.nazov ("MŠ Edulienka") and caused the
+    split to be silently skipped (see command module docstring: this split is
+    verified against live data and expected to run cleanly)."""
+    celok = Celok.objects.create(nazov="MŠ Edulienka")
+    Prevadzka.objects.create(
+        celok=celok,
+        nazov="MŠ Edulienka",
+        billing_portion_coefficients={"Predškolák": "1.25"},
+    )
+
+    out = StringIO()
+    err = StringIO()
+    call_command("seed_prevadzky_edupage", stdout=out, stderr=err)
+
+    # Jolly Homeschool / Škôlka MS legitimately don't exist in this isolated
+    # test DB — only assert the Edulienka split itself wasn't skipped.
+    assert "celok neexistuje: MŠ Edulienka" not in err.getvalue()
+
+    sub_prevadzky = {
+        p.nazov: p for p in Prevadzka.objects.filter(celok=celok, is_active=True)
+    }
+    assert set(sub_prevadzky) == {"Palisády", "Stupava"}
+    assert sub_prevadzky["Palisády"].edupage_match == "Palisády"
+    assert sub_prevadzky["Stupava"].edupage_match == "Stupava"
+    # Billing coefficient must survive the split, not silently drop to {}.
+    assert sub_prevadzky["Palisády"].billing_portion_coefficients == {
+        "Predškolák": "1.25"
+    }
+
+    original_default = Prevadzka.objects.get(celok=celok, nazov="MŠ Edulienka")
+    assert original_default.is_active is False


### PR DESCRIPTION
## Summary
`SPLITS` in `seed_prevadzky_edupage.py` was keyed on the bare `"Edulienka"`, but the celok is actually named `"MŠ Edulienka"` — the module's own docstring even confirms this is the verified name (`MŠ Edulienka → Palisády/Stupava  0 nezaradených ✓`). The exact-match `Celok.objects.filter(nazov=celok_nazov)` lookup never found it, so the split into `Palisády`/`Stupava` sub-prevádzky was silently skipped on every reseed.

Found by doing a from-scratch `./rebuild-dev.sh` (fresh volumes) and checking the seed logs, which printed `✗ celok neexistuje: Edulienka`. Confirmed in the DB that `MŠ Edulienka` was never split, unlike `Jolly Homeschool`/`Škôlka MS` (whose `SPLITS` keys match exactly).

Confirmed with the user this is **not** manually patched on production, so this fix is needed for the next deploy's seed chain to split it as intended.

**Heads up for deploy**: the command's existing (and intentional, already-documented) cleanup logic deletes today-and-later orders on the retired parent prevádzka once it's replaced by sub-prevádzky — they get re-scraped and recreated under the new split. History before today is preserved. This is pre-existing behavior in the command, just newly triggered for this celok because the split will actually run now.

## Test plan
- [x] Backend: `pytest` — 927 passed (added `test_seed_prevadzky_edupage.py` regression test asserting the split runs and the billing coefficient survives)
- [x] Manually re-ran `manage.py seed_prevadzky_edupage` against the dev DB — confirmed `MŠ Edulienka: Palisády/Stupava — vytvorená`, no more `celok neexistuje` for Edulienka

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>