### PR TITLE
fix(backend): fix Edulienka delivery seed reactivation

### DIFF
--- a/backend/api/management/commands/seed_real_delivery_layout.py
+++ b/backend/api/management/commands/seed_real_delivery_layout.py
@@ -279,8 +279,22 @@ DELIVERY_ROWS = [
         "Školička 2. stupeň",
         address="Panenská 4, BA",
     ),
+    # MŠ Edulienka splits into Palisády/Stupava sub-prevádzky (see
+    # seed_prevadzky_edupage.SPLITS) — target them directly, same as the
+    # Jolly Homeschool / Škôlka MS multi-prevádzka rows above/below.
+    # Targeting the pre-split default name here would resurrect it
+    # (is_active=True) every time this command reseeds, undoing the split.
     DeliverySeedRow(
-        "TRASA EXTRA 2 - MIŠO a IGOR 9:15", "MŠ Edulienka", alias="Edulienka"
+        "TRASA EXTRA 2 - MIŠO a IGOR 9:15",
+        "Palisády",
+        alias="Edulienka - Palisády",
+        is_edupage=True,
+    ),
+    DeliverySeedRow(
+        "TRASA EXTRA 2 - MIŠO a IGOR 9:15",
+        "Stupava",
+        alias="Edulienka - Stupava",
+        is_edupage=True,
     ),
     DeliverySeedRow(
         "TRASA EXTRA 2 - MIŠO a IGOR 9:15",

--- a/backend/api/tests/test_seed_real_delivery_layout_edulienka.py
+++ b/backend/api/tests/test_seed_real_delivery_layout_edulienka.py
@@ -1,0 +1,33 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from api.models import Celok, Prevadzka
+
+
+@pytest.mark.django_db
+def test_delivery_layout_does_not_resurrect_retired_edulienka_default():
+    """Regression test: seed_real_delivery_layout previously targeted the
+    pre-split "MŠ Edulienka" name and unconditionally set is_active=True on
+    whatever prevádzka it matched. Once seed_prevadzky_edupage.SPLITS started
+    actually splitting Edulienka (see test_seed_prevadzky_edupage.py), this
+    resurrected the retired default prevádzka on every reseed, leaving 3
+    active prevádzky under the celok instead of 2 and breaking the
+    single-active-prevádzka assumption the scrape task relies on."""
+    celok = Celok.objects.create(nazov="MŠ Edulienka")
+    Prevadzka.objects.create(
+        celok=celok,
+        nazov="MŠ Edulienka",
+        billing_portion_coefficients={"Predškolák": "1.25"},
+    )
+
+    call_command("seed_prevadzky_edupage", stdout=StringIO(), stderr=StringIO())
+    call_command("seed_real_delivery_layout", stdout=StringIO())
+
+    prevadzky = {p.nazov: p for p in Prevadzka.objects.filter(celok=celok)}
+    assert prevadzky["MŠ Edulienka"].is_active is False
+    assert prevadzky["Palisády"].is_active is True
+    assert prevadzky["Stupava"].is_active is True
+    assert prevadzky["Palisády"].delivery_route is not None
+    assert prevadzky["Stupava"].delivery_route is not None


### PR DESCRIPTION
## Summary
Found while verifying the earlier Edulienka split fix with a from-scratch \`./rebuild-dev.sh\`.

\`seed_real_delivery_layout\`'s \`DELIVERY_ROWS\` still targeted the pre-split \"MŠ Edulienka\" name (unlike the equivalent Jolly Homeschool / Škôlka MS multi-prevádzka rows, which already target their sub-prevádzky directly — \`\"Jolly 1\"\`, \`\"Jolly 2\"\`, \`\"Jolly 3\"\`, \`\"Les\"\`, \`\"Lúka\"\`). \`_upsert_prevadzka\` unconditionally sets \`is_active=True\` on whatever prevádzka it name-matches. Once the split actually runs (after the earlier fix), this resurrects the retired default prevádzka on every reseed — leaving 3 active prevádzky under the celok instead of 2, and tripping the scrape task's single-active-prevádzka guard: \`MŠ Edulienka má 3 prevádzok, ale MŠ Edulienka nemá edupage_match — preskakujem\`.

## Fix
Split the single \`DeliverySeedRow\` into \`Palisády\`/\`Stupava\` rows, matching the established pattern already used for Jolly/Škôlka MS.

## Test plan
- [x] Backend: \`pytest\` — 928 passed (added a regression test running \`seed_prevadzky_edupage\` then \`seed_real_delivery_layout\` together, asserting the default stays inactive and both sub-prevádzky get the delivery route)
- [x] Full from-scratch \`./rebuild-dev.sh\` (fresh volumes) — confirmed no more reactivation, no scrape warning, both sub-prevádzky correctly have \`delivery_route\` set

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>