### PR TITLE
fix(admin): improve diet colors and combinations

### DIFF
--- a/backend/api/serializers_user.py
+++ b/backend/api/serializers_user.py
@@ -29,7 +29,7 @@ class DietSerializer(serializers.ModelSerializer):
     base_colors = serializers.SerializerMethodField()
 
     def get_base_colors(self, obj: Diet) -> List[str]:
-        return [diet.color for diet in obj.base_diets.all() if diet.color]
+        return [diet.color or "#FDE68A" for diet in obj.base_diets.all()]
 
     def validate_base_diets(self, value: List[Diet]) -> List[Diet]:
         if self.instance and any(diet.pk == self.instance.pk for diet in value):

--- a/backend/api/services/meal_plan_service.py
+++ b/backend/api/services/meal_plan_service.py
@@ -415,9 +415,20 @@ class MealPlanService:
             "Histamín": "#0EA5E9",
             "DIA": "#64748B",
         }
+        active_diets = list(
+            Diet.objects.filter(is_active=True).prefetch_related("base_diets")
+        )
         diet_color_map = {
             diet.name: (diet.color or DEFAULT_DIET_COLORS.get(diet.name, "#FDE68A"))
-            for diet in Diet.objects.filter(is_active=True)
+            for diet in active_diets
+        }
+        diet_base_color_map = {
+            diet.name: [
+                base.color or DEFAULT_DIET_COLORS.get(base.name, "#FDE68A")
+                for base in diet.base_diets.all()
+            ]
+            for diet in active_diets
+            if diet.base_diets.exists()
         }
 
         def _normalize_variant(value: object) -> str:
@@ -949,6 +960,9 @@ class MealPlanService:
                                     "diet_color": diet_color_map.get(
                                         diet_name, "#FDE68A"
                                     ),
+                                    "diet_base_colors": diet_base_color_map.get(
+                                        diet_name, []
+                                    ),
                                     "count": billed_diet_count,
                                     "col_grams": diet_grams,
                                 }
@@ -1063,6 +1077,8 @@ class MealPlanService:
                 diet_summary_rows = [
                     {
                         "name": name,
+                        "color": diet_color_map.get(name, "#FDE68A"),
+                        "base_colors": diet_base_color_map.get(name, []),
                         "count": _tidy_count(diet_summary_counts[name]),
                         "col_grams": _serialize_group_totals(diet_summary_totals[name]),
                     }
@@ -1278,4 +1294,5 @@ class MealPlanService:
             "totals": totals_serialized,
             "count_summary": count_summary,
             "diet_colors": diet_color_map,
+            "diet_base_colors": diet_base_color_map,
         }

--- a/backend/api/tests/integration/test_admin_api.py
+++ b/backend/api/tests/integration/test_admin_api.py
@@ -1007,6 +1007,10 @@ class AdminMealPlanApiTest(APITestCase):
 
     def test_diet_summary_and_gramage_dashboard_return_expected_contract(self):
         self._create_plan()
+        milk_free = Diet.objects.create(name="Bez mlieka", color="#31D885")
+        gluten_free = Diet.objects.create(name="Bez lepku", color="#315BD8")
+        composite = Diet.objects.create(name="Bezlepková", color="#31D885")
+        composite.base_diets.add(milk_free, gluten_free)
         prevadzka = self.client_user.profile.dostupne_prevadzky().first()
         prevadzka.admin_order_note = "Bez cibule v pondelok"
         prevadzka.save(update_fields=["admin_order_note"])
@@ -1050,6 +1054,14 @@ class AdminMealPlanApiTest(APITestCase):
         self.assertEqual(len(dashboard_payload["rows"]), 1)
         self.assertEqual(
             dashboard_payload["rows"][0]["diet_summary_rows"][0]["name"], "Bezlepková"
+        )
+        self.assertEqual(
+            dashboard_payload["rows"][0]["diet_summary_rows"][0]["base_colors"],
+            ["#315BD8", "#31D885"],
+        )
+        self.assertEqual(
+            dashboard_payload["diet_base_colors"]["Bezlepková"],
+            ["#315BD8", "#31D885"],
         )
         self.assertEqual(
             dashboard_payload["rows"][0]["admin_order_note"],

--- a/backend/api/tests/integration/test_diet_api.py
+++ b/backend/api/tests/integration/test_diet_api.py
@@ -128,7 +128,7 @@ def test_diet_serializer_exposes_base_diet_ids_and_colors(api_client):
         gluten_free.id,
         colorless.id,
     }
-    assert payload["base_colors"] == ["#F59E0B", "#2563EB"]
+    assert payload["base_colors"] == ["#FDE68A", "#F59E0B", "#2563EB"]
 
 
 @pytest.mark.django_db

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -5,6 +5,7 @@ import { useToast } from "../../context/ToastContext";
 import { logger } from '../../lib/logger';
 import ConfirmationModal from "../client/components/ui/ConfirmationModal";
 import { PageHead, Button, Card, Badge, Empty } from "./ui";
+import { DietColorSwatch } from "./DietColorSwatch";
 
 const API = import.meta.env.VITE_API_URL || "/api";
 
@@ -34,6 +35,7 @@ interface SubRow {
   variant?: string;
   label: string;
   diet_color?: string;
+  diet_base_colors?: string[];
   count: number;
   col_grams: string[][];
 }
@@ -41,6 +43,7 @@ interface SubRow {
 interface DietSummaryRow {
   name: string;
   color?: string;
+  base_colors?: string[];
   count: number;
   col_grams: string[][];
 }
@@ -109,6 +112,7 @@ interface GramageDashboard {
   totals: string[][];
   count_summary: CountSection[];
   diet_colors?: Record<string, string>;
+  diet_base_colors?: Record<string, string[]>;
 }
 
 type OrderMealKey = "breakfast" | "lunch" | "olovrant";
@@ -750,14 +754,14 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
     <span className="count-badge">{count > 0 ? count : "—"}</span>
   );
 
-  const SummaryRow = ({ label, count, col_grams, kind, color }: {
-    label: string; count: number; col_grams: string[][]; kind: "std" | "diet"; color?: string;
+  const SummaryRow = ({ label, count, col_grams, kind, color, baseColors }: {
+    label: string; count: number; col_grams: string[][]; kind: "std" | "diet"; color?: string; baseColors?: string[];
   }) => (
     <tr className={kind === "std" ? "summ-std" : "summ-diet"} style={kind === "diet" && color ? { background: `${color}22` } : undefined}>
       <td>
         <span className="lbl-line">
           <span>
-            {kind === "diet" && color && <span style={{ display: "inline-block", width: 10, height: 10, borderRadius: 999, background: color, marginRight: 8 }} />}
+            {kind === "diet" && color && <span style={{ display: "inline-flex", marginRight: 8 }}><DietColorSwatch color={color} baseColors={baseColors} size={10} /></span>}
             {label}
           </span>
           <CountBadge count={count} />
@@ -812,7 +816,7 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
             <td className="lbl">
               <span className="lbl-line">
                 <span>
-                  {sr.type === "diet" && sr.diet_color && <span style={{ display: "inline-block", width: 9, height: 9, borderRadius: 999, background: sr.diet_color, marginRight: 8 }} />}
+                  {sr.type === "diet" && sr.diet_color && <span style={{ display: "inline-flex", marginRight: 8 }}><DietColorSwatch color={sr.diet_color} baseColors={sr.diet_base_colors} size={9} /></span>}
                   {sr.type === "diet" ? `↳ ${sr.label}` : sr.label}
                 </span>
                 <CountBadge count={sr.count} />
@@ -842,7 +846,7 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
 
         <SummaryRow label="Súčet bez diét" count={row.standard_total_count} col_grams={row.standard_col_grams} kind="std" />
         {row.diet_summary_rows.map((diet) => (
-          <SummaryRow key={diet.name} label={diet.name} count={diet.count} col_grams={diet.col_grams} kind="diet" color={diet.color || data.diet_colors?.[diet.name]} />
+          <SummaryRow key={diet.name} label={diet.name} count={diet.count} col_grams={diet.col_grams} kind="diet" color={diet.color || data.diet_colors?.[diet.name]} baseColors={diet.base_colors || data.diet_base_colors?.[diet.name]} />
         ))}
       </React.Fragment>
     );

--- a/frontend/src/pages/admin/DietColorSwatch.tsx
+++ b/frontend/src/pages/admin/DietColorSwatch.tsx
@@ -3,6 +3,7 @@ import React from "react";
 interface DietColorSwatchProps {
   color?: string;
   baseColors?: string[];
+  size?: number;
 }
 
 const dietSwatchBackground = (color?: string, baseColors: string[] = []): string => {
@@ -19,18 +20,18 @@ const dietSwatchBackground = (color?: string, baseColors: string[] = []): string
   return `conic-gradient(${segments.join(", ")})`;
 };
 
-export const DietColorSwatch: React.FC<DietColorSwatchProps> = ({ color, baseColors = [] }) => (
+export const DietColorSwatch: React.FC<DietColorSwatchProps> = ({ color, baseColors = [], size = 18 }) => (
   <span
     data-testid="diet-color-swatch"
     aria-hidden="true"
     style={{
-      width: 18,
-      height: 18,
+      display: "inline-block",
+      width: size,
+      height: size,
       borderRadius: 999,
       background: dietSwatchBackground(color, baseColors),
       boxShadow: "inset 0 0 0 1px rgba(39, 52, 34, 0.18)",
-      flex: "0 0 18px",
-      marginTop: 2,
+      flex: `0 0 ${size}px`,
     }}
   />
 );

--- a/frontend/src/pages/admin/DietManager.tsx
+++ b/frontend/src/pages/admin/DietManager.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { GripVertical, Plus, Pencil, Trash2 } from "lucide-react";
+import { GripVertical, Layers, Plus, Pencil, Trash2 } from "lucide-react";
 import { useAuth } from "../../context/auth";
 import { useToast } from "../../context/ToastContext";
 import { logger } from '../../lib/logger';
-import { PageHead, Card, Button, IconButton, Field, Input, Textarea, Modal, Empty, ColorSwatchPicker } from "./ui";
+import { PageHead, Card, Button, IconButton, Field, Input, Textarea, Modal, Empty, ColorSwatchPicker, Checkbox } from "./ui";
 import { DietColorSwatch } from "./DietColorSwatch";
 import { dietReorderPayload, moveDietBefore } from "./dietReorder";
 
@@ -31,6 +31,11 @@ interface RenameModal {
   description: string;
   color: string;
   baseDietIds: number[];
+  isComposite: boolean;
+}
+
+interface CompositeModal {
+  baseDietIds: number[];
 }
 
 interface DragState {
@@ -47,10 +52,11 @@ const DietManager: React.FC = () => {
   const [newDietName, setNewDietName] = useState("");
   const [newDietSortOrder, setNewDietSortOrder] = useState(0);
   const [newDietDescription, setNewDietDescription] = useState("");
-  const [newDietColor, setNewDietColor] = useState("#FDE68A");
-  const [newDietBaseIds, setNewDietBaseIds] = useState<number[]>([]);
+  const [newDietColor, setNewDietColor] = useState("#D83131");
   const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirm | null>(null);
   const [renameModal, setRenameModal] = useState<RenameModal | null>(null);
+  const [compositeModal, setCompositeModal] = useState<CompositeModal | null>(null);
+  const [creatingComposite, setCreatingComposite] = useState(false);
   const [renaming, setRenaming] = useState(false);
   const [dragging, setDragging] = useState<DragState | null>(null);
   const saveVersionRef = useRef(0);
@@ -88,7 +94,7 @@ const DietManager: React.FC = () => {
             sort_order: newDietSortOrder,
             description: newDietDescription.trim(),
             color: newDietColor,
-            base_diets: newDietBaseIds,
+            base_diets: [],
             is_active: true,
           }),
         },
@@ -102,8 +108,7 @@ const DietManager: React.FC = () => {
         setNewDietName("");
         setNewDietSortOrder(0);
         setNewDietDescription("");
-        setNewDietColor("#FDE68A");
-        setNewDietBaseIds([]);
+        setNewDietColor("#D83131");
         fetchDiets();
         success("Diéta bola úspešne pridaná");
       } else {
@@ -112,6 +117,55 @@ const DietManager: React.FC = () => {
     } catch (e) {
       logger.error(e);
       error("Chyba pri vytváraní diéty");
+    }
+  };
+
+  const toggleCompositeDiet = (dietId: number) => {
+    setCompositeModal((current) => {
+      if (!current) return current;
+      const selected = current.baseDietIds.includes(dietId)
+        ? current.baseDietIds.filter((id) => id !== dietId)
+        : [...current.baseDietIds, dietId];
+      return { baseDietIds: selected };
+    });
+  };
+
+  const handleAddCompositeDiet = async () => {
+    if (!compositeModal || compositeModal.baseDietIds.length < 2) return;
+    const selectedDiets = composableDiets.filter((diet) =>
+      compositeModal.baseDietIds.includes(diet.id),
+    );
+    if (selectedDiets.length < 2) return;
+
+    setCreatingComposite(true);
+    try {
+      const res = await apiFetch(
+        `${import.meta.env.VITE_API_URL || "/api"}/diets/`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: selectedDiets.map((diet) => diet.name).join(" – "),
+            sort_order: Math.max(0, ...diets.map((diet) => diet.sort_order || 0)) + 1,
+            description: `Kombinácia: ${selectedDiets.map((diet) => diet.name).join(", ")}`,
+            color: selectedDiets[0].color || "#D83131",
+            base_diets: selectedDiets.map((diet) => diet.id),
+            is_active: true,
+          }),
+        },
+      );
+      if (res.ok) {
+        setCompositeModal(null);
+        await fetchDiets();
+        success("Kombinovaná diéta bola vytvorená");
+      } else {
+        error("Nepodarilo sa vytvoriť kombinovanú diétu (možno už existuje)");
+      }
+    } catch (e) {
+      logger.error(e);
+      error("Chyba pri vytváraní kombinovanej diéty");
+    } finally {
+      setCreatingComposite(false);
     }
   };
 
@@ -223,6 +277,8 @@ const DietManager: React.FC = () => {
     void persistDietOrder(nextDiets);
   };
 
+  const composableDiets = diets.filter((diet) => (diet.base_diets || []).length === 0);
+
   return (
     <>
       <PageHead
@@ -263,23 +319,16 @@ const DietManager: React.FC = () => {
                 ariaLabel="Farba novej diéty"
               />
             </Field>
-            <Field label="Základné diéty" hint="(pre kombinovanú diétu)">
-              <select
-                className="zpa-select"
-                multiple
-                size={Math.min(Math.max(diets.length, 3), 6)}
-                value={newDietBaseIds.map(String)}
-                onChange={(e) =>
-                  setNewDietBaseIds(Array.from(e.currentTarget.selectedOptions, (option) => Number(option.value)))
-                }
-              >
-                {diets.map((diet) => (
-                  <option key={diet.id} value={diet.id}>{diet.name}</option>
-                ))}
-              </select>
-            </Field>
             <Button type="submit" disabled={!newDietName.trim()}>
               <Plus /> Pridať diétu
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={composableDiets.length < 2}
+              onClick={() => setCompositeModal({ baseDietIds: [] })}
+            >
+              <Layers /> Vytvoriť kombinovanú
             </Button>
           </form>
         </Card>
@@ -312,6 +361,11 @@ const DietManager: React.FC = () => {
                   {diet.description && (
                     <p style={{ fontSize: 13, color: "var(--ink-3)", margin: "4px 0 0" }}>{diet.description}</p>
                   )}
+                  {(diet.base_diets || []).length > 0 && (
+                    <p style={{ fontSize: 12, color: "var(--green-700)", margin: "4px 0 0" }}>
+                      Kombinácia: {(diet.base_diets || []).map((id) => diets.find((item) => item.id === id)?.name).filter(Boolean).join(" + ")}
+                    </p>
+                  )}
                   </div>
                 </div>
                 <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>
@@ -324,8 +378,9 @@ const DietManager: React.FC = () => {
                         newName: diet.name,
                         sortOrder: diet.sort_order ?? 0,
                         description: diet.description || "",
-                        color: diet.color || "#FDE68A",
+                        color: diet.color || "#D83131",
                         baseDietIds: diet.base_diets || [],
+                        isComposite: (diet.base_diets || []).length > 0,
                       })
                     }
                   >
@@ -340,6 +395,53 @@ const DietManager: React.FC = () => {
           </div>
         )}
       </div>
+
+      {compositeModal && (
+        <Modal
+          title="Vytvoriť kombinovanú diétu"
+          onClose={() => setCompositeModal(null)}
+          icon={<Layers />}
+          iconKind="ok"
+          foot={
+            <>
+              <Button variant="ghost" onClick={() => setCompositeModal(null)}>Zrušiť</Button>
+              <Button
+                onClick={handleAddCompositeDiet}
+                disabled={creatingComposite || compositeModal.baseDietIds.length < 2}
+              >
+                {creatingComposite ? "Vytváram…" : "Vytvoriť kombináciu"}
+              </Button>
+            </>
+          }
+        >
+          <p style={{ margin: 0, color: "var(--ink-2)" }}>
+            Vyberte aspoň dve existujúce diéty. Názov aj viacfarebné označenie sa vytvoria automaticky.
+          </p>
+          <div className="zpa-composite-options">
+            {composableDiets.map((diet) => (
+              <Checkbox
+                key={diet.id}
+                on={compositeModal.baseDietIds.includes(diet.id)}
+                onChange={() => toggleCompositeDiet(diet.id)}
+              >
+                <DietColorSwatch color={diet.color} size={14} />
+                <span>{diet.name}</span>
+              </Checkbox>
+            ))}
+          </div>
+          {compositeModal.baseDietIds.length > 0 && (
+            <div className="zpa-composite-preview">
+              <DietColorSwatch
+                baseColors={compositeModal.baseDietIds.map((id) => diets.find((diet) => diet.id === id)?.color || "")}
+                size={24}
+              />
+              <span>
+                {compositeModal.baseDietIds.map((id) => diets.find((diet) => diet.id === id)?.name).filter(Boolean).join(" – ")}
+              </span>
+            </div>
+          )}
+        </Modal>
+      )}
 
       {/* Delete confirmation modal */}
       {deleteConfirm && (
@@ -375,11 +477,12 @@ const DietManager: React.FC = () => {
                 disabled={
                   renaming ||
                   !renameModal.newName.trim() ||
+                  (renameModal.isComposite && renameModal.baseDietIds.length < 2) ||
                   (renameModal.newName.trim() === renameModal.currentName &&
                     renameModal.sortOrder === (diets.find((diet) => diet.id === renameModal.id)?.sort_order || 0) &&
                     renameModal.description.trim() ===
                       (diets.find((diet) => diet.id === renameModal.id)?.description || "").trim() &&
-                    renameModal.color === (diets.find((diet) => diet.id === renameModal.id)?.color || "#FDE68A"))
+                    renameModal.color === (diets.find((diet) => diet.id === renameModal.id)?.color || "#D83131"))
                     && sameDietIds(
                       renameModal.baseDietIds,
                       diets.find((diet) => diet.id === renameModal.id)?.base_diets || [],
@@ -421,31 +524,35 @@ const DietManager: React.FC = () => {
               rows={4}
             />
           </Field>
-          <Field label="Farba" as="div">
-            <ColorSwatchPicker
-              value={renameModal.color}
-              onChange={(color) => setRenameModal((prev) => (prev ? { ...prev, color } : prev))}
-              ariaLabel={`Farba diéty ${renameModal.currentName}`}
-            />
-          </Field>
-          <Field label="Základné diéty" hint="(pre kombinovanú diétu)">
-            <select
-              className="zpa-select"
-              multiple
-              size={Math.min(Math.max(diets.length - 1, 3), 6)}
-              value={renameModal.baseDietIds.map(String)}
-              onChange={(e) =>
-                setRenameModal((prev) => prev ? {
-                  ...prev,
-                  baseDietIds: Array.from(e.currentTarget.selectedOptions, (option) => Number(option.value)),
-                } : prev)
-              }
-            >
-              {diets.filter((diet) => diet.id !== renameModal.id).map((diet) => (
-                <option key={diet.id} value={diet.id}>{diet.name}</option>
-              ))}
-            </select>
-          </Field>
+          {!renameModal.isComposite ? (
+            <Field label="Farba" as="div">
+              <ColorSwatchPicker
+                value={renameModal.color}
+                onChange={(color) => setRenameModal((prev) => (prev ? { ...prev, color } : prev))}
+                ariaLabel={`Farba diéty ${renameModal.currentName}`}
+              />
+            </Field>
+          ) : (
+            <Field label="Zloženie kombinácie" as="div">
+              <div className="zpa-composite-options">
+                {composableDiets.filter((diet) => diet.id !== renameModal.id).map((diet) => (
+                  <Checkbox
+                    key={diet.id}
+                    on={renameModal.baseDietIds.includes(diet.id)}
+                    onChange={(selected) => setRenameModal((current) => current ? {
+                      ...current,
+                      baseDietIds: selected
+                        ? [...current.baseDietIds, diet.id]
+                        : current.baseDietIds.filter((id) => id !== diet.id),
+                    } : current)}
+                  >
+                    <DietColorSwatch color={diet.color} size={14} />
+                    <span>{diet.name}</span>
+                  </Checkbox>
+                ))}
+              </div>
+            </Field>
+          )}
         </Modal>
       )}
     </>

--- a/frontend/src/pages/admin/admin.css
+++ b/frontend/src/pages/admin/admin.css
@@ -23,6 +23,11 @@
 .zpa-formrow { display: grid; grid-template-columns: 1fr 1fr auto; gap: 16px; align-items: end; }
 @media (max-width: 700px) { .zpa-formrow { grid-template-columns: 1fr; } }
 .zpa-diet-card { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.zpa-composite-options { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px 16px; }
+.zpa-composite-options .zpa-check { border: 0; background: transparent; padding: 8px; border-radius: var(--radius-md); text-align: left; }
+.zpa-composite-options .zpa-check:hover { background: var(--bg-cream-soft); }
+.zpa-composite-preview { display: flex; align-items: center; gap: 10px; padding: 12px 14px; border-radius: var(--radius-md); background: rgba(114,136,75,0.09); color: var(--green-900); font-family: var(--font-display); font-weight: 600; }
+@media (max-width: 520px) { .zpa-composite-options { grid-template-columns: 1fr; } }
 
 /* Prevádzka overview */
 .zpa-statusdot { display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; border-radius: 50%; flex: 0 0 26px; }

--- a/frontend/src/pages/admin/ui.tsx
+++ b/frontend/src/pages/admin/ui.tsx
@@ -105,10 +105,13 @@ export const Input: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({ c
 );
 
 const DIET_COLORS = [
-    '#F87171', '#FB923C', '#FDE68A', '#86EFAC', '#5EEAD4', '#93C5FD', '#C4B5FD', '#F9A8D4',
-    '#DC2626', '#EA580C', '#F59E0B', '#16A34A', '#0D9488', '#2563EB', '#7C3AED', '#DB2777',
-    '#FDA4AF', '#FDBA74', '#FDE047', '#A3E635', '#34D399', '#22D3EE', '#818CF8', '#E879F9',
-    '#9F1239', '#9A3412', '#A16207', '#3F6212', '#047857', '#0E7490', '#4338CA', '#A21CAF',
+    // One consistent saturation/lightness level across the full hue wheel.
+    // This keeps every diet equally prominent without repeating light/dark
+    // variants of the same eight colours.
+    '#D83131', '#D85B31', '#D88531', '#D8AE31', '#D8D831', '#AED831',
+    '#85D831', '#5BD831', '#31D831', '#31D85B', '#31D885', '#31D8AE',
+    '#31D8D8', '#31AED8', '#3185D8', '#315BD8', '#3131D8', '#5B31D8',
+    '#8531D8', '#AE31D8', '#D831D8', '#D831AE', '#D83185', '#D8315B',
 ];
 
 export const ColorSwatchPicker: React.FC<{


### PR DESCRIPTION
## What changed

- replace repeated light/dark variants with 24 equally strong hues across the color wheel
- move composite-diet creation into a dedicated checkbox-based flow built from existing diets
- automatically derive the composite name, description, fallback color, and component links
- show every component color in the diet manager and gramage dashboard summary/detail rows
- preserve fallback colors for components without an explicitly assigned color

## Why

The previous palette repeated a small set of hues at different strengths, which made diets less distinct. Composite diets were also configured through an unclear base-diets multi-select embedded in the normal form, and their component colors did not reach the dashboard summary.

## Validation

- frontend production build
- TypeScript tsc --noEmit
- frontend ESLint
- focused Vitest suite for DietColorSwatch
- 14 relevant backend pytest tests
- Django system check
- migration dry run: no changes detected
- pre-commit: Black, isort, Flake8, mypy
