### PR TITLE
feat(): celok CRUD + cascade delete + auth hardening

### DIFF
--- a/backend/api/password_reset_service.py
+++ b/backend/api/password_reset_service.py
@@ -141,10 +141,18 @@ def confirm_password_reset(token: str, new_password: str) -> None:
     try:
         reset_token = PasswordResetToken.objects.select_related("user").get(token=token)
     except PasswordResetToken.DoesNotExist:
-        raise ValueError("Neplatný alebo expirovaný odkaz na obnovu hesla.")
+        # Token neexistuje vôbec (napr. účet bol medzitým zmazaný/nahradený) —
+        # nerozlišujeme prečo, aby sme neprezradili nič o existencii účtu.
+        raise ValueError("Neplatný odkaz.")
 
-    if not reset_token.is_valid:
-        raise ValueError("Neplatný alebo expirovaný odkaz na obnovu hesla.")
+    # Rozlíšené hlášky pre "už použitý" vs. "skutočne expiroval" — obe sú bezpečné
+    # na zobrazenie (neprezrádzajú nič o cieľovom účte), ale pomáhajú admin/klient
+    # diagnostike namiesto jednej generickej hlášky pre všetko (issue #461).
+    if reset_token.used:
+        raise ValueError("Tento odkaz už bol použitý, požiadajte o nový.")
+
+    if reset_token.is_expired:
+        raise ValueError("Odkaz vypršal, požiadajte o nový.")
 
     user = reset_token.user
 

--- a/backend/api/tests/integration/test_admin_user_create.py
+++ b/backend/api/tests/integration/test_admin_user_create.py
@@ -428,3 +428,110 @@ class TestAdminUserCreate:
         assert not User.objects.filter(pk=user.pk).exists()
         assert not UserProfile.objects.filter(pk=profile.pk).exists()
         assert not ProfileCelokAccess.objects.filter(profile_id=profile.pk).exists()
+
+    def test_update_email_change_invalidates_password_and_resends_setup(
+        self, admin_client
+    ):
+        """Issue #460: changing a login's email forces a new password (setup
+        link resent) instead of leaving the old password usable under a mail
+        the admin can no longer reach the user at."""
+        user = User.objects.create_user(
+            username="old@example.com",
+            email="old@example.com",
+            password="StrongPass123",
+        )
+        profile = UserProfile(user=user)
+        profile._skip_default_facility = True
+        profile.save()
+        celok = Celok.objects.create(nazov="Email change celok")
+        ProfileCelokAccess.objects.create(profile=profile, celok=celok)
+        assert user.has_usable_password()
+
+        with patch(_SETUP_EMAIL) as mock_email:
+            res = admin_client.patch(
+                f"{API_URL}{user.pk}/",
+                {"email": "new@example.com"},
+                format="json",
+            )
+
+        assert res.status_code == status.HTTP_200_OK
+        mock_email.assert_called_once()
+        user.refresh_from_db()
+        assert user.email == "new@example.com"
+        assert user.username == "new@example.com"
+        assert not user.has_usable_password()
+
+    def test_update_without_email_change_keeps_password(self, admin_client):
+        """Updating unrelated fields must not touch the password or resend
+        a setup email — only an actual email change should (issue #460)."""
+        user = User.objects.create_user(
+            username="stable@example.com",
+            email="stable@example.com",
+            password="StrongPass123",
+        )
+        UserProfile.objects.create(user=user)
+
+        with patch(_SETUP_EMAIL) as mock_email:
+            res = admin_client.patch(
+                f"{API_URL}{user.pk}/",
+                {"first_name": "Stable"},
+                format="json",
+            )
+
+        assert res.status_code == status.HTTP_200_OK
+        mock_email.assert_not_called()
+        user.refresh_from_db()
+        assert user.has_usable_password()
+
+    def test_update_email_change_case_only_keeps_password(self, admin_client):
+        """A same-address case change (Foo@x.sk -> foo@x.sk) is not a real
+        email change and must not force a password reset."""
+        user = User.objects.create_user(
+            username="case@example.com",
+            email="case@example.com",
+            password="StrongPass123",
+        )
+        UserProfile.objects.create(user=user)
+
+        with patch(_SETUP_EMAIL) as mock_email:
+            res = admin_client.patch(
+                f"{API_URL}{user.pk}/",
+                {"email": "CASE@example.com"},
+                format="json",
+            )
+
+        assert res.status_code == status.HTTP_200_OK
+        mock_email.assert_not_called()
+        user.refresh_from_db()
+        assert user.has_usable_password()
+
+    def test_update_email_change_for_edupage_only_login_skips_resend(
+        self, admin_client
+    ):
+        """Edupage-only logins never get a setup email on create either — an
+        email change for them must not suddenly send one."""
+        user = User.objects.create_user(
+            username="edu-old@example.com",
+            email="edu-old@example.com",
+            password="StrongPass123",
+        )
+        profile = UserProfile(user=user)
+        profile._skip_default_facility = True
+        profile.save()
+        celok = Celok.objects.create(
+            nazov="Edupage change celok", zdroj_objednavok=Celok.ZdrojObjednavok.EDUPAGE
+        )
+        Prevadzka.objects.create(celok=celok, nazov="Edupage prevádzka")
+        ProfileCelokAccess.objects.create(profile=profile, celok=celok)
+
+        with patch(_SETUP_EMAIL) as mock_email:
+            res = admin_client.patch(
+                f"{API_URL}{user.pk}/",
+                {"email": "edu-new@example.com"},
+                format="json",
+            )
+
+        assert res.status_code == status.HTTP_200_OK
+        mock_email.assert_not_called()
+        user.refresh_from_db()
+        assert user.has_usable_password()

--- a/backend/api/tests/integration/test_auth_api.py
+++ b/backend/api/tests/integration/test_auth_api.py
@@ -409,6 +409,9 @@ class TestPasswordResetFlow:
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # Issue #461: token neexistuje vôbec → generická hláška (nemá čo
+        # rozlišovať, iba potvrdiť, že odkaz nie je platný).
+        assert response.data["detail"] == "Neplatný odkaz."
 
     def test_password_reset_confirm_with_expired_token(self, api_client, user):
         PasswordResetToken.objects.create(
@@ -424,6 +427,8 @@ class TestPasswordResetFlow:
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # Issue #461: token skutočne expiroval → odlišná hláška od "neplatný".
+        assert response.data["detail"] == "Odkaz vypršal, požiadajte o nový."
 
     def test_password_reset_confirm_with_already_used_token(self, api_client, user):
         PasswordResetToken.objects.create(
@@ -439,6 +444,41 @@ class TestPasswordResetFlow:
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # Issue #461: token bol už použitý → odlišná hláška od "expiroval"/"neplatný".
+        assert (
+            response.data["detail"] == "Tento odkaz už bol použitý, požiadajte o nový."
+        )
+
+    def test_password_reset_confirm_error_messages_are_distinguishable(
+        self, api_client, user
+    ):
+        """The three failure causes (issue #461) must not collapse into the
+        same generic string — that was the whole point of the bug report."""
+        PasswordResetToken.objects.create(
+            user=user,
+            token="used-token-distinct",
+            expires_at=timezone.now() + timedelta(hours=1),
+            used=True,
+        )
+        PasswordResetToken.objects.create(
+            user=user,
+            token="expired-token-distinct",
+            expires_at=timezone.now() - timedelta(hours=1),
+            used=False,
+        )
+
+        def confirm(token):
+            return api_client.post(
+                reverse("password_reset_confirm"),
+                {"token": token, "new_password": "NewPassword123"},
+                format="json",
+            ).data["detail"]
+
+        invalid_msg = confirm("does-not-exist-at-all")
+        used_msg = confirm("used-token-distinct")
+        expired_msg = confirm("expired-token-distinct")
+
+        assert len({invalid_msg, used_msg, expired_msg}) == 3
 
     def test_password_reset_confirm_weak_password(self, api_client, user):
         PasswordResetToken.objects.create(

--- a/backend/api/tests/integration/test_facility_api.py
+++ b/backend/api/tests/integration/test_facility_api.py
@@ -2,7 +2,14 @@ from datetime import date
 
 import pytest
 
-from api.models import Celok, DailyOrder, Prevadzka
+from api.models import (
+    Celok,
+    DailyOrder,
+    Prevadzka,
+    ProfileCelokAccess,
+    ProfilePrevadzkaAccess,
+    UserProfile,
+)
 
 
 @pytest.mark.django_db
@@ -43,21 +50,121 @@ def test_delete_celok_without_prevadzky_succeeds(admin_client):
 
 
 @pytest.mark.django_db
-def test_delete_celok_with_prevadzky_returns_protected_error(admin_client):
-    celok = Celok.objects.create(nazov="Chránený celok")
-    Prevadzka.objects.create(celok=celok, nazov="Prevádzka pod celkom")
+def test_delete_celok_with_prevadzky_cascades(admin_client, admin_user):
+    """Issue #462: deleting a Celok cascades to its Prevádzky and their orders
+    instead of being blocked by the PROTECT FKs."""
+    celok = Celok.objects.create(nazov="Celok na zmazanie")
+    prevadzka = Prevadzka.objects.create(celok=celok, nazov="Prevádzka pod celkom")
+    other_prevadzka = Prevadzka.objects.create(celok=celok, nazov="Druhá prevádzka")
+    order = DailyOrder.objects.create(
+        user=admin_user,
+        prevadzka=prevadzka,
+        date=date.today(),
+        data={},
+    )
+    profile = UserProfile.objects.create(user=admin_user)
+    celok_access = ProfileCelokAccess.objects.create(profile=profile, celok=celok)
+    prevadzka_access = ProfilePrevadzkaAccess.objects.create(
+        profile=profile, prevadzka=other_prevadzka
+    )
 
     response = admin_client.delete(f"/api/admin/celky/{celok.pk}/")
 
-    assert response.status_code == 409
-    assert response.json() == {
-        "error": {
-            "code": "protected_error",
-            "message": (
-                "Túto položku nie je možné odstrániť, pretože sú na ňu naviazané "
-                "ďalšie záznamy."
-            ),
-            "details": {},
-        }
-    }
-    assert Celok.objects.filter(pk=celok.pk).exists()
+    assert response.status_code == 204
+    assert not Celok.objects.filter(pk=celok.pk).exists()
+    assert not Prevadzka.objects.filter(
+        pk__in=[prevadzka.pk, other_prevadzka.pk]
+    ).exists()
+    assert not DailyOrder.objects.filter(pk=order.pk).exists()
+    assert not ProfileCelokAccess.objects.filter(pk=celok_access.pk).exists()
+    assert not ProfilePrevadzkaAccess.objects.filter(pk=prevadzka_access.pk).exists()
+    # Login itself survives — it just lost access, per issue #462.
+    assert UserProfile.objects.filter(pk=profile.pk).exists()
+
+
+@pytest.mark.django_db
+def test_delete_celok_cascade_logs_event(admin_client):
+    celok = Celok.objects.create(nazov="Auditovaný celok")
+    Prevadzka.objects.create(celok=celok, nazov="Prevádzka")
+
+    from api.models import EventLog
+
+    response = admin_client.delete(f"/api/admin/celky/{celok.pk}/")
+
+    assert response.status_code == 204
+    event = EventLog.objects.filter(
+        event_type=EventLog.EventType.SETTINGS_CHANGE
+    ).latest("created_at")
+    assert "Auditovaný celok" in event.summary
+    assert event.payload["cascade"]["prevadzky_count"] == 1
+
+
+@pytest.mark.django_db
+def test_create_celok_via_admin_api(admin_client):
+    """Issue #463: a new Celok can be created directly through the admin API
+    (the endpoint already supported it; only the frontend lacked a button)."""
+    response = admin_client.post(
+        "/api/admin/celky/",
+        {"nazov": "Nová škôlka s.r.o."},
+        format="json",
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["nazov"] == "Nová škôlka s.r.o."
+    assert data["prevadzky"] == []
+    assert data["prevadzky_count"] == 0
+    assert data["logins"] == []
+    celok = Celok.objects.get(pk=data["id"])
+    assert celok.zdroj_objednavok == Celok.ZdrojObjednavok.APP
+
+
+@pytest.mark.django_db
+def test_create_celok_rejects_duplicate_nazov(admin_client):
+    Celok.objects.create(nazov="Existujúci celok")
+
+    response = admin_client.post(
+        "/api/admin/celky/",
+        {"nazov": "Existujúci celok"},
+        format="json",
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_onboard_new_celok_with_prevadzka_and_login(admin_client):
+    """End-to-end onboarding path issue #463 is meant to unblock: create celok →
+    add its first prevádzka → add its first login, all through admin endpoints."""
+    celok_res = admin_client.post(
+        "/api/admin/celky/", {"nazov": "Onboard Škôlka"}, format="json"
+    )
+    assert celok_res.status_code == 201
+    celok_id = celok_res.json()["id"]
+
+    prevadzka_res = admin_client.post(
+        "/api/admin/facility-prevadzky/",
+        {"celok": celok_id, "nazov": "Onboard Škôlka — hlavná budova"},
+        format="json",
+    )
+    assert prevadzka_res.status_code == 201
+    prevadzka_id = prevadzka_res.json()["id"]
+
+    from unittest.mock import patch
+
+    with patch("api.email_utils.send_account_setup_email"):
+        login_res = admin_client.post(
+            "/api/admin/users/",
+            {
+                "email": "onboard@example.com",
+                "company_name": "Onboard Škôlka",
+                "celok": celok_id,
+                "prevadzky": [prevadzka_id],
+            },
+            format="json",
+        )
+    assert login_res.status_code == 201
+
+    celok = Celok.objects.get(pk=celok_id)
+    assert celok.prevadzky.count() == 1
+    assert ProfilePrevadzkaAccess.objects.filter(prevadzka_id=prevadzka_id).exists()

--- a/backend/api/views/admin_views.py
+++ b/backend/api/views/admin_views.py
@@ -136,6 +136,32 @@ class AdminUserViewSet(viewsets.ModelViewSet):
                 "Failed to send onboarding email for new user %s", user.email
             )
 
+    def perform_update(self, serializer):
+        old_email = serializer.instance.email
+        user = serializer.save()
+
+        # Email zmenený → starý setup/reset odkaz smeruje na účet pod inou
+        # adresou a heslo bolo zvolené (alebo naposledy obnovené) s vedomím
+        # pôvodného mailu. Radšej vynútime nové heslo a rovno pošleme nový
+        # setup e-mail, než aby si to admin musel domýšľať/riešiť ručne
+        # (issue #460 — zistené pri onboardingu, keď sa login preklikol na
+        # iný mail a pôvodný setup-link zostal mŕtvy).
+        if old_email and user.email and old_email.lower() != user.email.lower():
+            try:
+                profile = user.profile
+                if not profile.is_edupage_only():
+                    from ..email_utils import send_account_setup_email
+
+                    user.set_unusable_password()
+                    user.save(update_fields=["password"])
+                    send_account_setup_email(user=user)
+            except Exception:
+                logger.exception(
+                    "Failed to invalidate password / resend setup email after "
+                    "email change for user %s",
+                    user.email,
+                )
+
 
 @extend_schema_view(
     list=extend_schema(tags=["admin"]),

--- a/backend/api/views/auth_views.py
+++ b/backend/api/views/auth_views.py
@@ -362,8 +362,12 @@ class PasswordResetConfirmView(APIView):
             confirm_password_reset(token=token, new_password=new_password)
         except ValueError as exc:
             logger.info("Password reset confirmation failed: %s", exc)
+            # `confirm_password_reset` already crafts a message that is safe to
+            # show (does not leak whether an account exists) but distinguishes
+            # *why* it failed — used / expired / invalid — instead of a single
+            # generic string for every case (issue #461).
             return Response(
-                {"detail": PASSWORD_RESET_CONFIRM_ERROR},
+                {"detail": str(exc) or PASSWORD_RESET_CONFIRM_ERROR},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/backend/api/views/facility_views.py
+++ b/backend/api/views/facility_views.py
@@ -1,17 +1,28 @@
 """Admin správa celkov a prevádzok — celok sa rozbalí na svoje prevádzky.
 
-`AdminCelokViewSet` je read-only zdroj pre rozbaliteľný zoznam; písanie ide cez
+`AdminCelokViewSet` nesie plný CRUD nad `Celok` (vrátane vytvorenia nového celku
+z admin UI, issue #463); prevádzkové polia sa menia cez
 `AdminFacilityPrevadzkaViewSet` (plný CRUD nad `Prevadzka`). Presun prevádzky medzi
 celkami sa nepodporuje — celok je pri vytvorení fixný (viď serializer).
+
+Zmazanie celku je **kaskádové** (issue #462): zmažú sa aj jeho prevádzky a ich
+objednávky (`Prevadzka.celok`/`DailyOrder.prevadzka` sú `PROTECT`, takže bez
+explicitného manuálneho zmazania v správnom poradí by DELETE skončil na
+`ProtectedError`). Prístupy (`ProfileCelokAccess`/`ProfilePrevadzkaAccess`) sa
+zmažú automaticky (`CASCADE`) — samotné loginy (`User`/`UserProfile`) ostávajú,
+len prídu o prístup. Frontend pred zavolaním DELETE zobrazí potvrdzovací dialóg
+s rozsahom dopadu (počet prevádzok/objednávok/loginov).
 """
 
 from __future__ import annotations
 
+from django.db import transaction
 from django.db.models import Count, Prefetch, Q, QuerySet
 from rest_framework import permissions, viewsets
 
 from ..models import (
     Celok,
+    DailyOrder,
     EventLog,
     Prevadzka,
     ProfileCelokAccess,
@@ -58,6 +69,53 @@ class AdminCelokViewSet(viewsets.ModelViewSet):
         instance = serializer.save()
         _log_settings_change(self.request, instance, changes, "upravil")
 
+    def perform_destroy(self, instance):
+        """Kaskádovo zmaže celok aj jeho prevádzky a ich objednávky.
+
+        `Prevadzka.celok` a `DailyOrder.prevadzka` sú `on_delete=PROTECT`, takže
+        `instance.delete()` by inak zlyhal na `ProtectedError`, ak má celok čo len
+        jednu prevádzku. Poradie mazania: objednávky → prevádzky (uvoľní PROTECT
+        z Celok) → celok. Prístupy (`ProfileCelokAccess`/`ProfilePrevadzkaAccess`)
+        sú `CASCADE`, zmažú sa samy; loginy (`User`) ostávajú, len prídu o prístup.
+        """
+        with transaction.atomic():
+            prevadzka_ids = list(instance.prevadzky.values_list("id", flat=True))
+            orders_count = DailyOrder.objects.filter(
+                prevadzka_id__in=prevadzka_ids
+            ).count()
+            logins_count = (
+                ProfileCelokAccess.objects.filter(celok=instance).count()
+                + ProfilePrevadzkaAccess.objects.filter(
+                    prevadzka_id__in=prevadzka_ids
+                ).count()
+            )
+            prevadzky_count = len(prevadzka_ids)
+            label = str(instance)
+            instance_pk = instance.pk
+
+            DailyOrder.objects.filter(prevadzka_id__in=prevadzka_ids).delete()
+            Prevadzka.objects.filter(id__in=prevadzka_ids).delete()
+            instance.delete()
+
+            log_event(
+                EventLog.EventType.SETTINGS_CHANGE,
+                actor=self.request.user,
+                summary=(
+                    f"Admin vymazal celok „{label}“ vrátane {prevadzky_count} "
+                    f"prevádzok, {orders_count} objednávok a {logins_count} "
+                    "prístupov (loginy ostávajú, len prišli o prístup)."
+                ),
+                payload={
+                    "model": "api.celok",
+                    "object_id": instance_pk,
+                    "cascade": {
+                        "prevadzky_count": prevadzky_count,
+                        "orders_count": orders_count,
+                        "logins_count": logins_count,
+                    },
+                },
+            )
+
     def get_queryset(self) -> QuerySet:
         prevadzka_accesses = ProfilePrevadzkaAccess.objects.select_related(
             "profile__user"
@@ -67,6 +125,7 @@ class AdminCelokViewSet(viewsets.ModelViewSet):
         ).order_by("pk")
         prevadzky = (
             Prevadzka.objects.select_related("celok", "edupage_connection")
+            .annotate(orders_count=Count("orders", distinct=True))
             .prefetch_related(
                 "visible_diets",
                 "visible_portion_types",

--- a/frontend/src/pages/admin/FacilityManager.test.tsx
+++ b/frontend/src/pages/admin/FacilityManager.test.tsx
@@ -252,4 +252,153 @@ describe("FacilityManager celok delete", () => {
     );
     expect(screen.getByText("Naozaj odstrániť celok", { exact: false })).toBeInTheDocument();
   });
+
+  it("warns about cascade impact (prevádzky/objednávky/loginy) before deleting a non-empty celok", async () => {
+    const withOrders = {
+      ...celok,
+      prevadzky: celok.prevadzky.map((p) => (p.id === 101 ? { ...p, orders_count: 5 } : p)),
+    };
+    mockApiFetch.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (options?.method === "DELETE") return { ok: true, status: 204, json: async () => ({}) };
+      if (url.endsWith("/admin/edupage-connections/")) return { ok: true, json: async () => [] };
+      return { ok: true, json: async () => [withOrders] };
+    });
+
+    const user = userEvent.setup();
+    renderManager();
+
+    await user.click(await screen.findByRole("button", { name: "Vymazať celok Centrálny celok" }));
+
+    expect(screen.getByText("Zmažú sa aj:", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("2 prevádzok")).toBeInTheDocument();
+    expect(screen.getByText("5 objednávok")).toBeInTheDocument();
+    expect(screen.getByText(/prístup pre 2/)).toBeInTheDocument();
+  });
+});
+
+describe("FacilityManager celok create (onboarding)", () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+  });
+
+  it("creates a celok, then chains straight into add-prevádzka and add-login", async () => {
+    const newCelok = {
+      id: 30,
+      nazov: "Nová škôlka",
+      billing_name: "",
+      adresa: "",
+      ico: "",
+      dic: "",
+      zdroj_objednavok: "app",
+      prevadzky_count: 0,
+      prevadzky: [],
+      logins: [],
+    };
+    const newPrevadzka = { id: 301, celok: 30, nazov: "Hlavná budova" };
+    let celkyState = [celok];
+
+    mockApiFetch.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.endsWith("/admin/edupage-connections/")) return { ok: true, json: async () => [] };
+      if (url === "/api/admin/celky/" && options?.method === "POST") {
+        celkyState = [...celkyState, newCelok];
+        return { ok: true, status: 201, json: async () => newCelok };
+      }
+      if (url === "/api/admin/facility-prevadzky/" && options?.method === "POST") {
+        return { ok: true, status: 201, json: async () => newPrevadzka };
+      }
+      if (url === "/api/admin/users/" && options?.method === "POST") {
+        return { ok: true, status: 201, json: async () => ({ id: 601 }) };
+      }
+      return { ok: true, json: async () => celkyState };
+    });
+
+    const user = userEvent.setup();
+    renderManager();
+
+    await user.click(await screen.findByRole("button", { name: "Nový celok" }));
+    expect(screen.getByRole("heading", { name: "Nový celok" })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Názov celku *"), "Nová škôlka");
+    await user.click(screen.getByRole("button", { name: "Vytvoriť celok" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/api/admin/celky/",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    // Chained straight into "add prevádzka" for the freshly created celok.
+    expect(await screen.findByText("Pridať prevádzku — Nová škôlka")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Názov prevádzky *"), "Hlavná budova");
+    await user.click(screen.getByRole("button", { name: "Pridať" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/api/admin/facility-prevadzky/",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    // Chained straight into "add login" for the same celok.
+    expect(await screen.findByText("Pridať login — Nová škôlka")).toBeInTheDocument();
+  });
+
+  it("does not resume onboarding after cancelling the add-prevádzka step", async () => {
+    const newCelok = {
+      id: 31,
+      nazov: "Zrušená škôlka",
+      billing_name: "",
+      adresa: "",
+      ico: "",
+      dic: "",
+      zdroj_objednavok: "app",
+      prevadzky_count: 0,
+      prevadzky: [],
+      logins: [],
+    };
+    let celkyState = [celok];
+
+    mockApiFetch.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.endsWith("/admin/edupage-connections/")) return { ok: true, json: async () => [] };
+      if (url === "/api/admin/celky/" && options?.method === "POST") {
+        celkyState = [...celkyState, newCelok];
+        return { ok: true, status: 201, json: async () => newCelok };
+      }
+      if (url === "/api/admin/facility-prevadzky/" && options?.method === "POST") {
+        return { ok: true, status: 201, json: async () => ({ id: 311, celok: 31, nazov: "Neskorá budova" }) };
+      }
+      return { ok: true, json: async () => celkyState };
+    });
+
+    const user = userEvent.setup();
+    renderManager();
+
+    await user.click(await screen.findByRole("button", { name: "Nový celok" }));
+    await user.type(screen.getByLabelText("Názov celku *"), "Zrušená škôlka");
+    await user.click(screen.getByRole("button", { name: "Vytvoriť celok" }));
+
+    expect(await screen.findByText("Pridať prevádzku — Zrušená škôlka")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Zrušiť" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Pridať prevádzku — Zrušená škôlka")).not.toBeInTheDocument();
+    });
+
+    // Manually adding a prevádzka to that celok afterwards must NOT chain into add-login.
+    const row = (await screen.findByText("Zrušená škôlka")).closest<HTMLElement>(".zpa-celok")!;
+    await user.click(within(row).getAllByRole("button", { name: "Pridať prevádzku" })[0]);
+    expect(screen.getByText("Pridať prevádzku — Zrušená škôlka")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Názov prevádzky *"), "Neskorá budova");
+    await user.click(screen.getByRole("button", { name: "Pridať" }));
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        "/api/admin/facility-prevadzky/",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    expect(screen.queryByText("Pridať login — Zrušená škôlka")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/admin/FacilityManager.tsx
+++ b/frontend/src/pages/admin/FacilityManager.tsx
@@ -98,8 +98,9 @@ const FacilityManager: React.FC = () => {
   const [pForm, setPForm] = useState<PrevadzkaForm>(EMPTY_PREVADZKA);
   const [pSaving, setPSaving] = useState(false);
 
-  // Celok edit
+  // Celok create/edit — rovnaký formulár (cForm), rozlíšené cez celokCreateOpen.
   const [celokEdit, setCelokEdit] = useState<Celok | null>(null);
+  const [celokCreateOpen, setCelokCreateOpen] = useState(false);
   const [cForm, setCForm] = useState<CelokForm>({
     nazov: "",
     billing_name: "",
@@ -109,6 +110,10 @@ const FacilityManager: React.FC = () => {
     zdroj_objednavok: "app",
   });
   const [cSaving, setCSaving] = useState(false);
+  // Onboarding nového celku (issue #463): po vytvorení celku rovno navedieme
+  // admina cez existujúce "pridať prevádzku" a "pridať login" modály, aby
+  // založenie novej škôlky nevyžadovalo prepínanie do django shellu.
+  const [onboardingCelokId, setOnboardingCelokId] = useState<number | null>(null);
 
   // Celok delete
   const [celokDeleteTarget, setCelokDeleteTarget] = useState<Celok | null>(null);
@@ -207,6 +212,10 @@ const FacilityManager: React.FC = () => {
     setModalCelok(celok);
     setPForm({ ...EMPTY_PREVADZKA });
   };
+  const closeAddPrevadzka = () => {
+    if (modalCelok && onboardingCelokId === modalCelok.id) setOnboardingCelokId(null);
+    setModalCelok(null);
+  };
   const savePrevadzka = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!modalCelok || !pForm.nazov.trim()) {
@@ -223,8 +232,15 @@ const FacilityManager: React.FC = () => {
       if (res.ok) {
         success("Prevádzka pridaná.");
         setExpanded((prev) => new Set(prev).add(modalCelok.id));
+        const onboardingTarget = onboardingCelokId === modalCelok.id ? modalCelok : null;
         setModalCelok(null);
-        fetchCelky();
+        await fetchCelky();
+        if (onboardingTarget) {
+          // Onboarding nového celku (issue #463) pokračuje pridaním prvého loginu.
+          openAddLogin(onboardingTarget);
+        } else {
+          setOnboardingCelokId(null);
+        }
       } else {
         const data = await res.json().catch(() => ({}));
         toastError(data?.nazov?.[0] || data?.error?.message || "Nepodarilo sa uložiť prevádzku.");
@@ -236,7 +252,7 @@ const FacilityManager: React.FC = () => {
       setPSaving(false);
     }
   };
-  // ── Celok edit ──
+  // ── Celok create/edit ──
   const openEditCelok = (celok: Celok) => {
     setCelokEdit(celok);
     setCForm({
@@ -248,23 +264,40 @@ const FacilityManager: React.FC = () => {
       zdroj_objednavok: celok.zdroj_objednavok || "app",
     });
   };
+  const openCreateCelok = () => {
+    setCForm({ nazov: "", billing_name: "", adresa: "", ico: "", dic: "", zdroj_objednavok: "app" });
+    setCelokCreateOpen(true);
+  };
+  const closeCelokModal = () => {
+    setCelokEdit(null);
+    setCelokCreateOpen(false);
+  };
   const saveCelok = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!celokEdit || !cForm.nazov.trim()) {
+    if (!cForm.nazov.trim()) {
       toastError("Názov celku je povinný.");
       return;
     }
     setCSaving(true);
     try {
-      const res = await apiFetch(`${API}/admin/celky/${celokEdit.id}/`, {
-        method: "PATCH",
+      const url = celokCreateOpen ? `${API}/admin/celky/` : `${API}/admin/celky/${celokEdit!.id}/`;
+      const res = await apiFetch(url, {
+        method: celokCreateOpen ? "POST" : "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(cForm),
       });
       if (res.ok) {
-        success("Celok upravený.");
-        setCelokEdit(null);
-        fetchCelky();
+        const data: Celok = await res.json();
+        closeCelokModal();
+        await fetchCelky();
+        if (celokCreateOpen) {
+          success(`Celok „${data.nazov}“ bol vytvorený. Pridajte prvú prevádzku.`);
+          setExpanded((prev) => new Set(prev).add(data.id));
+          setOnboardingCelokId(data.id);
+          openAddPrevadzka(data);
+        } else {
+          success("Celok upravený.");
+        }
       } else {
         const data = await res.json().catch(() => ({}));
         toastError(data?.nazov?.[0] || data?.error?.message || "Nepodarilo sa uložiť celok.");
@@ -311,6 +344,10 @@ const FacilityManager: React.FC = () => {
     setLForm({ email: login.email, company_name: login.company_name });
   };
   const closeLoginEditor = () => {
+    // Zrušenie posledného kroku onboardingu nesmie nechať "zaseknutý" stav —
+    // ďalšie bežné pridanie prevádzky do toho istého celku by inak omylom
+    // znova otvorilo krok "pridať login".
+    if (loginTarget && onboardingCelokId === loginTarget.id) setOnboardingCelokId(null);
     setLoginTarget(null);
     setLoginEditTarget(null);
   };
@@ -341,8 +378,16 @@ const FacilityManager: React.FC = () => {
         },
       );
       if (res.ok) {
-        success(loginEditTarget ? "Login bol upravený." : "Login bol vytvorený.");
+        const wasOnboarding = onboardingCelokId === loginTarget.id;
+        success(
+          wasOnboarding
+            ? "Hotovo — celok, prevádzka aj login sú založené."
+            : loginEditTarget
+              ? "Login bol upravený."
+              : "Login bol vytvorený.",
+        );
         setExpanded((prev) => new Set(prev).add(loginTarget.id));
+        if (wasOnboarding) setOnboardingCelokId(null);
         closeLoginEditor();
         fetchCelky();
       } else {
@@ -392,7 +437,10 @@ const FacilityManager: React.FC = () => {
         eyebrow="Prevádzky"
         title="Správa prevádzok"
         desc="Celky a ich prevádzky — rozbaľte celok pre správu prevádzok"
-        actions={<Button variant="secondary" onClick={() => setConnectionsOpen(true)}>EduPage spojenia</Button>}
+        actions={<>
+          <Button variant="secondary" onClick={() => setConnectionsOpen(true)}>EduPage spojenia</Button>
+          <Button onClick={openCreateCelok}><Plus /> Nový celok</Button>
+        </>}
       />
 
       <div className="zpa-stack">
@@ -508,9 +556,9 @@ const FacilityManager: React.FC = () => {
       {modalCelok && (
         <Modal
           title={`Pridať prevádzku — ${modalCelok.nazov}`}
-          onClose={() => setModalCelok(null)}
+          onClose={closeAddPrevadzka}
           foot={<>
-            <Button variant="ghost" onClick={() => setModalCelok(null)}>Zrušiť</Button>
+            <Button variant="ghost" onClick={closeAddPrevadzka}>Zrušiť</Button>
             <Button type="submit" form="prevadzka-form" disabled={pSaving}>{pSaving ? "Ukladám…" : "Pridať"}</Button>
           </>}
         >
@@ -525,17 +573,24 @@ const FacilityManager: React.FC = () => {
         </Modal>
       )}
 
-      {/* Celok edit */}
-      {celokEdit && (
+      {/* Celok create/edit */}
+      {(celokEdit || celokCreateOpen) && (
         <Modal
-          title={`Upraviť celok — ${celokEdit.nazov}`}
-          onClose={() => setCelokEdit(null)}
+          title={celokCreateOpen ? "Nový celok" : `Upraviť celok — ${celokEdit!.nazov}`}
+          onClose={closeCelokModal}
           foot={<>
-            <Button variant="ghost" onClick={() => setCelokEdit(null)}>Zrušiť</Button>
-            <Button type="submit" form="celok-form" disabled={cSaving}>{cSaving ? "Ukladám…" : "Uložiť"}</Button>
+            <Button variant="ghost" onClick={closeCelokModal}>Zrušiť</Button>
+            <Button type="submit" form="celok-form" disabled={cSaving}>
+              {cSaving ? "Ukladám…" : celokCreateOpen ? "Vytvoriť celok" : "Uložiť"}
+            </Button>
           </>}
         >
           <form id="celok-form" onSubmit={saveCelok} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            {celokCreateOpen && (
+              <p style={{ margin: 0, fontSize: 13, color: "var(--ink-mute)" }}>
+                Po vytvorení celku vás rovno prevedieme založením prvej prevádzky a loginu.
+              </p>
+            )}
             <Field label="Názov celku" req>
               <Input required value={cForm.nazov} onChange={(e) => setCForm((f) => ({ ...f, nazov: e.target.value }))} />
             </Field>
@@ -593,12 +648,36 @@ const FacilityManager: React.FC = () => {
               Naozaj odstrániť celok „<strong style={{ color: "var(--green-900)" }}>{celokDeleteTarget.nazov}</strong>“?
               Táto akcia je nevratná.
             </p>
-            {celokDeleteTarget.prevadzky_count > 0 && (
-              <p style={{ margin: 0, color: "var(--coral-700)", lineHeight: 1.6 }}>
-                Celok má {celokDeleteTarget.prevadzky_count}{" "}
-                {celokDeleteTarget.prevadzky_count === 1 ? "prevádzku" : "prevádzok"}, ktoré zablokujú jeho odstránenie —
-                najprv ich treba vymazať alebo presunúť.
-              </p>
+            {celokDeleteTarget.prevadzky.length > 0 && (
+              <div
+                style={{
+                  margin: 0,
+                  padding: "10px 12px",
+                  borderRadius: 8,
+                  background: "var(--coral-50, #fef2f2)",
+                  border: "1px solid var(--coral-200, #fecaca)",
+                  color: "var(--coral-700)",
+                  lineHeight: 1.6,
+                }}
+              >
+                <strong>Zmažú sa aj:</strong>
+                <ul style={{ margin: "4px 0 0", paddingLeft: 18 }}>
+                  <li>
+                    {celokDeleteTarget.prevadzky.length}{" "}
+                    {celokDeleteTarget.prevadzky.length === 1 ? "prevádzka" : "prevádzok"}
+                  </li>
+                  <li>
+                    {celokDeleteTarget.prevadzky.reduce((sum, p) => sum + (p.orders_count || 0), 0)} objednávok
+                  </li>
+                  {celokDeleteTarget.logins.length > 0 && (
+                    <li>
+                      prístup pre {celokDeleteTarget.logins.length}{" "}
+                      {celokDeleteTarget.logins.length === 1 ? "login" : "loginy/loginov"} (samotné loginy ostanú,
+                      len prídu o prístup k tomuto celku)
+                    </li>
+                  )}
+                </ul>
+              </div>
             )}
             {celokDeleteError && (
               <p role="alert" style={{ margin: 0, color: "var(--coral-700)", lineHeight: 1.6 }}>


### PR DESCRIPTION
Closes #460, closes #461, closes #462, closes #463.

## #460 — Zmena e-mailu loginu musí vynútiť nové heslo
`AdminUserViewSet.perform_update` teraz detekuje skutočnú zmenu e-mailu (case-insensitive) a pri nej:
- `set_unusable_password()` na starý login,
- rovno pošle nový setup e-mail (`send_account_setup_email`) na nový e-mail.

Preskočí sa pre EduPage-only loginy (rovnaká podmienka ako pri `perform_create`) a pri zmene len veľkosti písmen v e-maile (nie je to reálna zmena).

## #461 — Rozlíšené chybové hlášky pri set-password odkaze
`confirm_password_reset` v `password_reset_service.py` teraz rozlišuje:
- token neexistuje → „Neplatný odkaz.“
- token bol už použitý → „Tento odkaz už bol použitý, požiadajte o nový.“
- token skutočne expiroval (`expires_at`) → „Odkaz vypršal, požiadajte o nový.“

`PasswordResetConfirmView` posiela túto reálnu hlášku namiesto jednej univerzálnej konštanty pre všetky prípady.

## #462 — Cascade delete Celku s potvrdzovacím dialógom
`AdminCelokViewSet.perform_destroy` teraz zmaže celok aj so všetkými prevádzkami a ich objednávkami (predtým `Prevadzka.celok`/`DailyOrder.prevadzka` sú `PROTECT`, takže DELETE skončil 409). Prístupy (`ProfileCelokAccess`/`ProfilePrevadzkaAccess`) sa zmažú automaticky (CASCADE) — **loginy samotné ostávajú**, len prídu o prístup. Akcia sa loguje do `EventLog`.

Admin UI (`FacilityManager.tsx`) pred zmazaním explicitne ukáže dopad: počet prevádzok, objednávok aj loginov, ktoré prídu o prístup.

## #463 — Vytvorenie nového Celku priamo v admin UI
Pridané tlačidlo **„Nový celok“**, ktoré po vytvorení celku rovno prevedie admina existujúcimi modálmi „Pridať prevádzku“ → „Pridať login“ (bez potreby django shellu). Zrušenie kroku onboarding korektne ukončí (nezostane „zaseknutý“ stav).

## Testovanie
- Backend: `pytest` — **939 passed** (celá suita), vrátane nových testov pre všetky 4 issues.
- Frontend: `tsc --noEmit`, `eslint`, `vitest run` — **32/32 test files, 185/185 testov**.
- Reálna E2E verifikácia cez Playwright proti bežiacemu dev stacku (`compose/dev.yml`): prihlásenie, plný onboarding flow (celok → prevádzka → login), cascade delete s impact-preview, 3 rôzne set-password chybové hlášky, a Mailhog kontrola, že resend e-mail naozaj príde na novú adresu. **18/18 kontrol prešlo.** Testovacie dáta po sebe upratané.

🤖 Generated with [Claude Code](https://claude.com/claude-code)