### PR TITLE
chore(ci): relax PR title lint rules

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -21,29 +21,13 @@
     "type-case": [2, "always", "lower-case"],
     "type-empty": [2, "never"],
     "scope-case": [2, "always", "lower-case"],
-    "scope-enum": [
-      2,
-      "always",
-      [
-        "backend",
-        "frontend",
-        "ci",
-        "docker",
-        "docs",
-        "auth",
-        "api",
-        "tests",
-        "config",
-        "deps"
-      ]
-    ],
     "subject-empty": [2, "never"],
     "subject-case": [0, "always", "lower-case"],
     "subject-full-stop": [2, "never", "."],
-    "subject-max-length": [2, "always", 50],
-    "header-max-length": [2, "always", 72],
+    "subject-max-length": [0],
+    "header-max-length": [0],
+    "body-max-line-length": [0],
     "body-leading-blank": [2, "always"],
-    "body-max-line-length": [2, "always", 72],
     "footer-leading-blank": [2, "always"]
   }
 }

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -64,8 +64,7 @@ jobs:
             ### Valid types:
             \`feat\`, \`fix\`, \`docs\`, \`style\`, \`refactor\`, \`test\`, \`chore\`, \`perf\`, \`ci\`, \`build\`, \`revert\`
 
-            ### Valid scopes:
-            \`backend\`, \`frontend\`, \`ci\`, \`docker\`, \`docs\`, \`auth\`, \`api\`, \`tests\`, \`config\`, \`deps\`
+            Scope is free-form (any lowercase word) — no fixed length limit on the title/subject.
 
             Please update your PR title and refer to [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) for detailed guidelines.`;
 


### PR DESCRIPTION
Follow-up to #464.

- Odstránené `scope-enum` — scope už nemusí byť z pevného zoznamu.
- Odstránené `subject-max-length` / `header-max-length` / `body-max-line-length` — bez limitu dĺžky.
- Type (`feat`, `fix`, ...) ostáva vynútený, len scope a dĺžka sú teraz voľné.
- Aktualizovaný komentár vo `commit-lint.yml` (failure message) zodpovedajúco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)