### PR TITLE
feat(ui): zadávaj diéty ako samostatnú položku pod Menu A

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1191,6 +1191,35 @@ select {
 .zp-menurow .diet-trigger:hover { background: var(--peach-400); }
 .zp-menurow .spacer { flex: 1; }
 
+/* Diéty: pod-riadok naviazaný na Menu A nad ním. */
+.zp-menurow--diet {
+    width: 100%;
+    padding-left: 28px;
+    gap: 6px;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--line-soft);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    color: var(--mustard-700);
+}
+.zp-menurow--diet:hover:not(:disabled) { background: var(--peach-300); }
+.zp-menurow--diet:disabled { opacity: 0.5; cursor: default; }
+.zp-menurow--diet .name {
+    flex: 0 0 auto;
+    font-size: 13px;
+    color: var(--mustard-700);
+}
+.zp-menurow--diet-icon { flex: 0 0 auto; }
+.zp-menurow--diet-count {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--ink-3);
+}
+.zp-menurow--diet-count.active { color: var(--mustard-700); }
+
 .zp-menurow--occupied {
     opacity: 0.5;
 }

--- a/frontend/src/pages/admin/AdminOrderEditorModal.test.tsx
+++ b/frontend/src/pages/admin/AdminOrderEditorModal.test.tsx
@@ -337,6 +337,75 @@ describe('AdminOrderEditorModal', () => {
         });
     });
 
+    it('shows the plain menu A count and opens diets from their own row', async () => {
+        render(
+            <AdminOrderEditorModal
+                {...BASE_PROPS}
+                existingOrder={{
+                    id: 7,
+                    date: '2026-07-30',
+                    // Stará objednávka: A=10 znamenalo „7 bežných + 3 diétne“.
+                    data: {
+                        lunch: {
+                            Škôlka: {
+                                menuCounts: { A: 10 },
+                                diets: { 'Bez lepku': 3 },
+                            },
+                        },
+                    },
+                }}
+            />,
+        );
+
+        const lunchCard = getMealCard('Obed');
+        const skolkaCard = within(lunchCard).getByText('Škôlka').closest('.zp-cat') as HTMLElement;
+
+        const menuAInput = within(skolkaCard).getByLabelText('Počet porcií pre menu A');
+        expect((menuAInput as HTMLInputElement).value).toBe('7');
+
+        const dietButton = within(skolkaCard).getByRole('button', { name: /Diéty/ });
+        expect(dietButton).toHaveTextContent('3');
+
+        fireEvent.click(dietButton);
+        expect(await screen.findByTestId('diet-selector')).toBeInTheDocument();
+    });
+
+    it('adds diets on top of the plain menu A count in the payload', async () => {
+        mockApiFetch.mockResolvedValueOnce(makeMockResponse({ id: 7 }, true));
+
+        render(
+            <AdminOrderEditorModal
+                {...BASE_PROPS}
+                existingOrder={{
+                    id: 7,
+                    date: '2026-07-30',
+                    data: {
+                        lunch: {
+                            Škôlka: { menuCounts: { A: 4 }, diets: { 'Bez lepku': 1 } },
+                        },
+                    },
+                }}
+            />,
+        );
+
+        const lunchCard = getMealCard('Obed');
+        const skolkaCard = within(lunchCard).getByText('Škôlka').closest('.zp-cat') as HTMLElement;
+
+        // 3 bežné porcie (4 − 1 diéta) navýšime na 4 => uloží sa 4 + 1 = 5.
+        const menuAInput = within(skolkaCard).getByLabelText('Počet porcií pre menu A');
+        expect((menuAInput as HTMLInputElement).value).toBe('3');
+        fireEvent.change(menuAInput, { target: { value: '4' } });
+        fireEvent.blur(menuAInput);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Uložiť' }));
+
+        await waitFor(() => {
+            const body = getRequestBody();
+            expect(body.data.lunch.Škôlka.menuCounts.A).toBe(5);
+            expect(body.data.lunch.Škôlka.diets['Bez lepku']).toBe(1);
+        });
+    });
+
     it('preserves special_diet_note in the PATCH payload when saving without editing it', async () => {
         mockApiFetch.mockResolvedValueOnce(makeMockResponse({ id: 7 }, true));
 

--- a/frontend/src/pages/admin/AdminOrderEditorModal.tsx
+++ b/frontend/src/pages/admin/AdminOrderEditorModal.tsx
@@ -618,11 +618,6 @@ const AdminOrderEditorModal: React.FC<Props> = ({
                             ? fullDayData[activeDietModal.category]?.diets ?? {}
                             : order[activeDietModal.meal]?.[activeDietModal.category]?.diets ?? {}
                     }
-                    maxPortions={
-                        activeDietModal.meal === 'fullDay'
-                            ? fullDayData[activeDietModal.category]?.menuCounts?.A || 0
-                            : order[activeDietModal.meal]?.[activeDietModal.category]?.menuCounts?.A || 0
-                    }
                     onUpdateDiet={(diet, count) =>
                         activeDietModal.meal === 'fullDay'
                             ? updateFullDayDiet(activeDietModal.category, diet, count)

--- a/frontend/src/pages/client/components/order/CategoryRow.tsx
+++ b/frontend/src/pages/client/components/order/CategoryRow.tsx
@@ -1,17 +1,16 @@
-import { Minus, Plus, Utensils } from 'lucide-react';
+import { Fragment } from 'react';
+import { ChevronRight, Minus, Plus, Utensils } from 'lucide-react';
 import NumericCountInput from './NumericCountInput';
 
 interface MenuCounterProps {
     type: string;
     count: number;
     onChange: (val: number) => void;
-    onOpenDiets: (() => void) | null;
-    dietCount: number;
     disabled?: boolean;
     isOccupied?: boolean;
 }
 
-const MenuCounter = ({ type, count, onChange, onOpenDiets, dietCount, disabled, isOccupied }: MenuCounterProps) => {
+const MenuCounter = ({ type, count, onChange, disabled, isOccupied }: MenuCounterProps) => {
     if (isOccupied) {
         return (
             <div className="zp-menurow zp-menurow--occupied">
@@ -25,12 +24,6 @@ const MenuCounter = ({ type, count, onChange, onOpenDiets, dietCount, disabled, 
     return (
         <div className="zp-menurow">
             <span className="name">Menu {type}</span>
-            {type === 'A' && onOpenDiets && (
-                <button className="diet-trigger" onClick={onOpenDiets} disabled={disabled}>
-                    <Utensils style={{ width: 10, height: 10 }} />
-                    {dietCount > 0 ? `${dietCount} diét` : 'Diéty'}
-                </button>
-            )}
             <span className="spacer"></span>
             <div className="zp-counter">
                 <button
@@ -58,6 +51,31 @@ const MenuCounter = ({ type, count, onChange, onOpenDiets, dietCount, disabled, 
         </div>
     );
 };
+
+interface DietRowProps {
+    dietCount: number;
+    onOpenDiets: () => void;
+    disabled?: boolean;
+}
+
+/**
+ * Diéty sú samostatná položka hneď pod Menu A — nie výrez z jeho počtu.
+ * Klik otvorí modál, v ktorom sa diéty pripočítavajú bez limitu.
+ */
+const DietRow = ({ dietCount, onOpenDiets, disabled }: DietRowProps) => (
+    <button
+        type="button"
+        className="zp-menurow zp-menurow--diet"
+        onClick={onOpenDiets}
+        disabled={disabled}
+    >
+        <Utensils className="zp-menurow--diet-icon" style={{ width: 12, height: 12 }} />
+        <span className="name">Diéty</span>
+        <span className="spacer"></span>
+        <span className={`zp-menurow--diet-count${dietCount > 0 ? " active" : ""}`}>{dietCount}</span>
+        <ChevronRight style={{ width: 14, height: 14 }} />
+    </button>
+);
 
 interface CategoryRowProps {
     label: string;
@@ -98,18 +116,33 @@ const CategoryRow = ({
     return (
         <div data-tour-id={tourId} className="zp-cat">
             <div className="zp-cat-head">{label}</div>
-            {menus.map(menuType => (
-                <MenuCounter
-                    key={menuType}
-                    type={menuType}
-                    count={menuCounts[menuType]}
-                    onChange={(val) => !disabled && onMenuCountChange(menuType, val)}
-                    onOpenDiets={hasDietsEnabled && menuType === 'A' && !disabled ? onOpenDiets : null}
-                    dietCount={dietCount}
-                    disabled={disabled}
-                    isOccupied={occupiedMenus?.has(menuType)}
-                />
-            ))}
+            {menus.map(menuType => {
+                const isOccupied = occupiedMenus?.has(menuType);
+                // Menu A drží celkový počet vrátane diétnych porcií; klient edituje
+                // len bežné porcie, takže diéty od zobrazenej hodnoty odrátame.
+                const shownCount = menuType === 'A'
+                    ? Math.max(0, (menuCounts[menuType] || 0) - dietCount)
+                    : menuCounts[menuType];
+
+                return (
+                    <Fragment key={menuType}>
+                        <MenuCounter
+                            type={menuType}
+                            count={shownCount}
+                            onChange={(val) => !disabled && onMenuCountChange(menuType, val)}
+                            disabled={disabled}
+                            isOccupied={isOccupied}
+                        />
+                        {menuType === 'A' && hasDietsEnabled && !isOccupied && (
+                            <DietRow
+                                dietCount={dietCount}
+                                onOpenDiets={onOpenDiets}
+                                disabled={disabled}
+                            />
+                        )}
+                    </Fragment>
+                );
+            })}
         </div>
     );
 };

--- a/frontend/src/pages/client/components/order/DietSelector.tsx
+++ b/frontend/src/pages/client/components/order/DietSelector.tsx
@@ -10,7 +10,6 @@ interface DietSelectorProps {
     diets: Record<string, number>;
     enabledDiets: string[];
     onUpdateDiet: (diet: string, count: number) => void;
-    maxPortions: number;
 }
 
 const DietSelector = ({
@@ -20,13 +19,12 @@ const DietSelector = ({
     diets,
     enabledDiets,
     onUpdateDiet,
-    maxPortions
 }: DietSelectorProps) => {
     useScrollLock(isOpen);
     if (!isOpen) return null;
 
+    // Diéty sa pripočítavajú k Menu A, takže tu nie je žiadny strop.
     const currentDietSum = Object.values(diets || {}).reduce((a: number, b: number) => a + b, 0);
-    const remaining = maxPortions - currentDietSum;
 
     return createPortal(
         <div className="zp-sheet-scrim" onClick={onClose}>
@@ -36,7 +34,7 @@ const DietSelector = ({
                     <div>
                         <h3>Diéty · {categoryLabel}</h3>
                         <p className="sub">
-                            Dostupné: <span className="num">{remaining}</span> z {maxPortions} porcií Menu A
+                            Spolu diét: <span className="num">{currentDietSum}</span>
                         </p>
                     </div>
                     <button className="zp-sheet-close" aria-label="Zavrieť" onClick={onClose}>
@@ -74,7 +72,6 @@ const DietSelector = ({
                                         />
                                         <button
                                             className="plus"
-                                            disabled={remaining <= 0}
                                             aria-label="+"
                                             onClick={() => onUpdateDiet(diet, count + 1)}
                                         >

--- a/frontend/src/pages/client/pages/OrderPage.test.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.test.tsx
@@ -471,7 +471,7 @@ describe("OrderPage Logic & Triggers", () => {
     });
   });
 
-  it("typed diet input uses the same cap as the +/- path", async () => {
+  it("typed diet input has no cap and adds on top of menu A", async () => {
     const date = localDateStr();
     localStorageMock.setItem(
       `order_${date}`,
@@ -495,17 +495,50 @@ describe("OrderPage Logic & Triggers", () => {
 
     const lunchCard = getMealCard("Obed");
     const skolkaRow = getCategoryRow(lunchCard, "Škôlka");
-    fireEvent.click(await within(skolkaRow).findByText("1 diét"));
+    fireEvent.click(await within(skolkaRow).findByRole("button", { name: /Diéty/ }));
 
     const dietInput = await screen.findByLabelText("Počet diéty Bez lepku");
-    // Cap je menuCounts.A = 2, takže napísaná 5 sa nesmie uložiť — rovnako ako
-    // by ju neprepustilo klikanie na +.
+    // Diéty už nemajú strop — napísaná 5 sa uloží a pripočíta sa k bežným porciám.
     fireEvent.change(dietInput, { target: { value: "5" } });
     fireEvent.blur(dietInput);
 
     await waitFor(() => {
-      expect(getOrderData(date).lunch["Škôlka"].diets["Bez lepku"]).toBe(1);
+      expect(getOrderData(date).lunch["Škôlka"].diets["Bez lepku"]).toBe(5);
     });
+    // Pôvodne A=2 s 1 diétou => 1 bežná porcia; po zmene 1 + 5 = 6.
+    expect(getOrderData(date).lunch["Škôlka"].menuCounts.A).toBe(6);
+  });
+
+  it("shows the plain menu A count with diets broken out into their own row", async () => {
+    const date = localDateStr();
+    // Stará objednávka: A=10 znamenalo „7 bežných + 3 diétne“.
+    localStorageMock.setItem(
+      `order_${date}`,
+      JSON.stringify({
+        status: "draft",
+        breakfast: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+        lunch: { Škôlka: { menuCounts: { A: 10 }, diets: { "Bez lepku": 3 } } },
+        olovrant: { Škôlka: { menuCounts: { A: 0 }, diets: {} } },
+      }),
+    );
+    localStorageMock.setItem(
+      `activeMeals_${date}`,
+      JSON.stringify({ breakfast: false, lunch: true, olovrant: false }),
+    );
+    (OrderService.getAvailableDiets as Mock).mockReturnValue(["Bez lepku"]);
+
+    renderPage();
+
+    const lunchCard = getMealCard("Obed");
+    const skolkaRow = getCategoryRow(lunchCard, "Škôlka");
+
+    const menuAInput = await within(skolkaRow).findByLabelText(
+      "Počet porcií pre menu A",
+    );
+    expect((menuAInput as HTMLInputElement).value).toBe("7");
+
+    const dietButton = within(skolkaRow).getByRole("button", { name: /Diéty/ });
+    expect(dietButton).toHaveTextContent("3");
   });
 
   it("hides breakfast and olovrant menu choices configured to only menu A", async () => {

--- a/frontend/src/pages/client/pages/OrderPage.tsx
+++ b/frontend/src/pages/client/pages/OrderPage.tsx
@@ -508,7 +508,6 @@ const OrderPage = () => {
             categoryLabel={activeDietModal.category}
             enabledDiets={getAvailableDiets(activeDietModal.category)}
             diets={catData.diets}
-            maxPortions={catData.menuCounts?.["A"] || 0}
             onUpdateDiet={(diet, count) =>
               isFullDay
                 ? updateFullDayDiet(activeDietModal.category, diet, count)

--- a/frontend/src/pages/client/services/OrderService.test.ts
+++ b/frontend/src/pages/client/services/OrderService.test.ts
@@ -58,25 +58,53 @@ describe('OrderService', () => {
             expect(updatedOrder.lunch['Škôlka'].menuCounts.A).toBe(5);
         });
 
-        it('should reduce diets if menu count drops below total diets', () => {
+        it('should leave diets untouched when the plain menu A count drops', () => {
             let order: DailyOrder = {
                 breakfast: OrderService.createEmptyMeal(),
                 lunch: OrderService.createEmptyMeal(),
                 olovrant: OrderService.createEmptyMeal()
             };
 
-            // Set initial state: 5 menus, 5 diets
+            // 5 bežných porcií + 5 diét => celkovo 10 porcií Menu A
             order = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'A', 5);
             order = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'Bez lepku', 3);
             order = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'Bez laktózy', 2);
+            expect(order.lunch['Škôlka'].menuCounts.A).toBe(10);
 
-            // Reduce menu count to 3. Diets should sum to max 3. 
+            // Zníženie bežných porcií na 3 diéty nekráti — celkovo 3 + 5 = 8
             const updatedOrder = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'A', 3);
 
-            const newDiets = updatedOrder.lunch['Škôlka'].diets;
-            const totalDiets = (Object.values(newDiets) as number[]).reduce((a: number, b: number) => a + b, 0);
+            expect(updatedOrder.lunch['Škôlka'].diets['Bez lepku']).toBe(3);
+            expect(updatedOrder.lunch['Škôlka'].diets['Bez laktózy']).toBe(2);
+            expect(updatedOrder.lunch['Škôlka'].menuCounts.A).toBe(8);
+            expect(OrderService.getPlainMenuACount(updatedOrder.lunch['Škôlka'])).toBe(3);
+        });
 
-            expect(totalDiets).toBe(3);
+        it('should store plain menu A count plus the diet total', () => {
+            let order: DailyOrder = {
+                breakfast: OrderService.createEmptyMeal(),
+                lunch: OrderService.createEmptyMeal(),
+                olovrant: OrderService.createEmptyMeal()
+            };
+
+            order = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'Bez lepku', 2);
+            order = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'A', 4);
+
+            expect(order.lunch['Škôlka'].menuCounts.A).toBe(6);
+            expect(OrderService.getPlainMenuACount(order.lunch['Škôlka'])).toBe(4);
+        });
+
+        it('should not fold diets into menus other than A', () => {
+            let order: DailyOrder = {
+                breakfast: OrderService.createEmptyMeal(),
+                lunch: OrderService.createEmptyMeal(),
+                olovrant: OrderService.createEmptyMeal()
+            };
+
+            order = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'Bez lepku', 2);
+            order = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'B', 4);
+
+            expect(order.lunch['Škôlka'].menuCounts.B).toBe(4);
         });
     });
 
@@ -93,16 +121,66 @@ describe('OrderService', () => {
             expect(updatedOrder.lunch['Škôlka'].diets['Bez lepku']).toBe(3);
         });
 
-        it('should not update diet count if it exceeds menu A count', () => {
+        it('should add diets on top of menu A without any cap', () => {
             let order: DailyOrder = {
                 breakfast: OrderService.createEmptyMeal(),
                 lunch: OrderService.createEmptyMeal(),
                 olovrant: OrderService.createEmptyMeal()
             };
-            order = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'A', 2);
+            order = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'A', 10);
 
             const updatedOrder = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'Bez lepku', 3);
-            expect(updatedOrder.lunch['Škôlka'].diets['Bez lepku']).toBe(0); // Should remain 0
+
+            expect(updatedOrder.lunch['Škôlka'].diets['Bez lepku']).toBe(3);
+            expect(updatedOrder.lunch['Škôlka'].menuCounts.A).toBe(13);
+            // Bežné porcie sa pridaním diét nesmú zmeniť
+            expect(OrderService.getPlainMenuACount(updatedOrder.lunch['Škôlka'])).toBe(10);
+        });
+
+        it('should allow diets with no plain menu A portions at all', () => {
+            const order: DailyOrder = {
+                breakfast: OrderService.createEmptyMeal(),
+                lunch: OrderService.createEmptyMeal(),
+                olovrant: OrderService.createEmptyMeal()
+            };
+
+            const updatedOrder = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'Bez lepku', 3);
+
+            expect(updatedOrder.lunch['Škôlka'].menuCounts.A).toBe(3);
+            expect(OrderService.getPlainMenuACount(updatedOrder.lunch['Škôlka'])).toBe(0);
+        });
+
+        it('should shrink menu A back when a diet is removed', () => {
+            let order: DailyOrder = {
+                breakfast: OrderService.createEmptyMeal(),
+                lunch: OrderService.createEmptyMeal(),
+                olovrant: OrderService.createEmptyMeal()
+            };
+            order = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'A', 10);
+            order = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'Bez lepku', 3);
+
+            const updatedOrder = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'Bez lepku', 0);
+
+            expect(updatedOrder.lunch['Škôlka'].menuCounts.A).toBe(10);
+            expect(OrderService.getPlainMenuACount(updatedOrder.lunch['Škôlka'])).toBe(10);
+        });
+
+        it('reads a legacy order (diets carved out of menu A) as plain + diets', () => {
+            // Stará objednávka: A=10 znamenalo „7 bežných + 3 diétne“.
+            const order: DailyOrder = {
+                breakfast: OrderService.createEmptyMeal(),
+                lunch: OrderService.createEmptyMeal(),
+                olovrant: OrderService.createEmptyMeal()
+            };
+            order.lunch['Škôlka'].menuCounts.A = 10;
+            order.lunch['Škôlka'].diets['Bez lepku'] = 3;
+
+            expect(OrderService.getPlainMenuACount(order.lunch['Škôlka'])).toBe(7);
+
+            // Úprava bežných porcií na 8 => 8 + 3 = 11
+            const updatedOrder = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'A', 8);
+            expect(updatedOrder.lunch['Škôlka'].menuCounts.A).toBe(11);
+            expect(updatedOrder.lunch['Škôlka'].diets['Bez lepku']).toBe(3);
         });
 
         it('should reduce pack separately diets when diet count drops', () => {

--- a/frontend/src/pages/client/services/OrderService.ts
+++ b/frontend/src/pages/client/services/OrderService.ts
@@ -87,35 +87,42 @@ class OrderService {
         return enabledDiets;
     }
 
+    /** Súčet všetkých diétnych porcií v kategórii. */
+    static getDietTotal(categoryData: Pick<CategoryData, 'diets'>): number {
+        return (Object.values(categoryData.diets || {}) as number[])
+            .reduce((a, b) => a + b, 0);
+    }
+
+    /**
+     * Počet bežných (nediétnych) porcií Menu A — to, čo klient vidí a edituje.
+     *
+     * `menuCounts.A` drží CELKOVÝ počet porcií Menu A vrátane diétnych (diéta je
+     * naďalej podmnožina Menu A, tak ako to čaká backend, gramáž aj exporty).
+     * UI ale zadáva bežné porcie zvlášť a diéty sa k nim pripočítavajú, takže
+     * na vstupe/výstupe formulára prevádzame medzi týmito dvoma pohľadmi.
+     */
+    static getPlainMenuACount(categoryData: CategoryData): number {
+        return Math.max(0, (categoryData.menuCounts?.['A'] || 0) - this.getDietTotal(categoryData));
+    }
+
     static updateMenuCount(currentOrder: DailyOrder, mealKey: 'breakfast' | 'lunch' | 'olovrant', category: string, menuType: string, count: number): DailyOrder {
         const newCount = Math.max(0, count);
         const categoryData = currentOrder[mealKey][category];
 
+        // Pri Menu A je `count` počet BEŽNÝCH porcií — diéty sa k nemu pripočítajú.
+        // Znižovanie Menu A preto (na rozdiel od minulosti) diéty nekráti.
+        const storedCount = menuType === 'A'
+            ? newCount + this.getDietTotal(categoryData)
+            : newCount;
+
         const newMenuCounts = {
             ...categoryData.menuCounts,
-            [menuType]: newCount
+            [menuType]: storedCount
         };
-
-        const newDiets = { ...categoryData.diets };
-        if (menuType === 'A') {
-            const totalDiets = (Object.values(newDiets) as number[]).reduce((a: number, b: number) => a + b, 0);
-            if (newCount < totalDiets) {
-                let diff = totalDiets - newCount;
-                for (const diet of DIETS) {
-                    if (diff <= 0) break;
-                    if (newDiets[diet] > 0) {
-                        const toRemove = Math.min(newDiets[diet], diff);
-                        newDiets[diet] -= toRemove;
-                        diff -= toRemove;
-                    }
-                }
-            }
-        }
 
         const nextCategoryData = this.withClampedPackSeparately({
             ...categoryData,
-            menuCounts: newMenuCounts,
-            diets: newDiets
+            menuCounts: newMenuCounts
         });
 
         return {
@@ -129,18 +136,21 @@ class OrderService {
 
     static updateDiet(currentOrder: DailyOrder, mealKey: 'breakfast' | 'lunch' | 'olovrant', category: string, diet: string, count: number): DailyOrder {
         const categoryData = currentOrder[mealKey][category];
-        const menuACount = categoryData.menuCounts?.['A'] || 0;
+
+        // Diéty sa pripočítavajú bez limitu: bežné (nediétne) porcie ostávajú
+        // konštantné a celkové `menuCounts.A` rastie/klesá spolu s počtom diét.
+        const plainMenuACount = this.getPlainMenuACount(categoryData);
 
         const newCount = Math.max(0, count);
-        const totalOtherDiets = Object.entries(categoryData.diets)
-            .filter(([d]) => d !== diet)
-            .reduce((sum, [, c]) => sum + (c as number), 0);
-
-        if (totalOtherDiets + newCount > menuACount) return currentOrder;
+        const newDiets = { ...categoryData.diets, [diet]: newCount };
 
         const nextCategoryData = this.withClampedPackSeparately({
             ...categoryData,
-            diets: { ...categoryData.diets, [diet]: newCount }
+            menuCounts: {
+                ...categoryData.menuCounts,
+                A: plainMenuACount + this.getDietTotal({ diets: newDiets })
+            },
+            diets: newDiets
         });
 
         return {


### PR DESCRIPTION
## Prečo

Diéty sa doteraz **vykrajovali** z už zadaného počtu Menu A: pilulka „Diéty“ sedela vnútri riadku Menu A, modál hlásil „Dostupné: X z Y porcií Menu A“ a plus sa zablokovalo, len čo sa zvyšok minul. Klient tak musel poznať súčet skôr, než ho vedel rozdeliť.

## Čo sa mení (len frontend)

- Pod riadkom **Menu A** pribudol samostatný riadok **„Diéty“** so súčtom — vždy viditeľný, aj pri 0. Klik otvára ten istý modál ako doteraz.
- V modáli **žiadny strop**: diéty sa pripočítavajú, plus sa nezablokuje, zmizlo „Dostupné: X z Y“.
- Pole **Menu A** = počet **bežných (nediétnych)** porcií.

Novo je zadateľná aj kombinácia „0 bežných + 3 diéty“ (uloží sa `A=3`) — predtým nemožná.

## Uložený tvar dát sa nemení

Invariant `diéta ⊆ Menu A` platí ďalej — `menuCounts.A` drží **celkový** počet porcií vrátane diétnych. Prevod je čisto prezentačný:

```
zobrazené Menu A     = menuCounts.A − Σ diets
uložené menuCounts.A = zadané bežné + Σ diets
```

Menu A = 10 + 3 diéty → do backendu ide `menuCounts: {A: 13}`, `diets: {…: 3}`.

Dôsledky:
- **Backend, gramáž, exporty a reporty sa nemenia vôbec.** `report_service.py` ráta `total` zo samotných `menuCounts` a diéty vedie ako rozpis — ostáva presné.
- **Staré objednávky sa čítajú správne.** `A=10` s 3 diétami znamenalo „7 bežných + 3 diétne“ a presne tak sa zobrazí. **Žiadna migrácia dát.**
- **Backend nič nezablokuje** — `DailyOrderSerializer` validuje len nezáporné celé čísla ≤ 9999 a `packSeparately ≤ základné počty`; kontrola „diéty ≤ Menu A“ v repozitári neexistuje.

## Klient aj admin naraz

Obe obrazovky zdieľajú `OrderService`, `CategoryRow` a `DietSelector`, takže zmena v zdieľanej vrstve pokrýva klientske objednávanie aj admin editor objednávok.

## Testy

Dva testy kódovali práve rušený invariant a boli prepísané na nové správanie:
- „should reduce diets if menu count drops below total diets“ → zníženie Menu A diéty **nekráti**
- „should not update diet count if it exceeds menu A count“ → diéta nad počet Menu A **prejde** a navýši `menuCounts.A`

Nové pokrytie: pripočítavanie diét, round-trip starej objednávky (7 v poli Menu A), diéty bez bežných porcií, zmenšenie A po odobraní diéty, nemiešanie diét do Menu B, admin parita (riadok Diéty + payload).

## Overenie

- `npx tsc --noEmit` ✅ · `npm run lint` ✅ · `npx vitest run` → **198/198** ✅
- Backend (nedotknutý, kontrolne): `test_order_data.py`, `test_orders.py`, `test_exporters.py`, `test_report_service.py` → **53 passed** ✅

Vizuálna kontrola v bežiacej dev appke zatiaľ neprebehla — DOM štruktúru pokrývajú testy, ale vzhľad nového riadku stojí za pohľad pri review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zUtAguUpa2b36jBjcF18p