### PR TITLE
fix(orders): nezahadzuj vlastné názvy diét pri načítaní objednávky

### DIFF
--- a/frontend/src/pages/client/services/OrderService.test.ts
+++ b/frontend/src/pages/client/services/OrderService.test.ts
@@ -44,6 +44,68 @@ describe('OrderService', () => {
             expect(result).not.toHaveProperty('unknownMeal');
             expect(result.lunch['Škôlka'].menuCounts).not.toHaveProperty('unexpected');
         });
+
+        it('keeps admin-defined diet names that are not in the DIETS constant', () => {
+            const schema = OrderService.createEmptyOrder();
+            const result = OrderService.enforceStructure<DailyOrder>(
+                {
+                    lunch: {
+                        Škôlka: {
+                            menuCounts: { A: 13 },
+                            // Mená z `Diet` modelu — konštanta DIETS ich nepozná.
+                            diets: { HISTAMIN: 3, 'NO EGG': 2 },
+                        },
+                    },
+                },
+                schema
+            );
+
+            const cat = result.lunch['Škôlka'];
+            expect(cat.diets['HISTAMIN']).toBe(3);
+            expect(cat.diets['NO EGG']).toBe(2);
+            // Známe diéty ostávajú ako defaulty na nule
+            expect(cat.diets['Bez lepku']).toBe(0);
+            // A odvodený počet bežných porcií tým pádom sedí: 13 − 5 = 8
+            expect(OrderService.getPlainMenuACount(cat)).toBe(8);
+        });
+
+        it('ignores non-numeric or negative diet counts', () => {
+            const schema = OrderService.createEmptyOrder();
+            const result = OrderService.enforceStructure<DailyOrder>(
+                {
+                    lunch: {
+                        Škôlka: {
+                            menuCounts: { A: 2 },
+                            diets: { HISTAMIN: 2, BROKEN: 'x', NEGATIVE: -3, FLAGGED: true },
+                        },
+                    },
+                },
+                schema
+            );
+
+            const diets = result.lunch['Škôlka'].diets;
+            expect(diets['HISTAMIN']).toBe(2);
+            expect(diets).not.toHaveProperty('BROKEN');
+            expect(diets).not.toHaveProperty('NEGATIVE');
+            expect(diets).not.toHaveProperty('FLAGGED');
+        });
+
+        it('keeps custom diet names through a full save/load round trip', () => {
+            let order = OrderService.createEmptyOrder();
+            order = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'A', 10);
+            order = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'HISTAMIN', 3);
+            expect(order.lunch['Škôlka'].menuCounts.A).toBe(13);
+
+            // Presne to, čo robí useOrder pri odpovedi zo servera / localStorage.
+            const reloaded = OrderService.enforceStructure<DailyOrder>(
+                JSON.parse(JSON.stringify(order)),
+                OrderService.createEmptyOrder()
+            );
+
+            expect(reloaded.lunch['Škôlka'].diets['HISTAMIN']).toBe(3);
+            expect(reloaded.lunch['Škôlka'].menuCounts.A).toBe(13);
+            expect(OrderService.getPlainMenuACount(reloaded.lunch['Škôlka'])).toBe(10);
+        });
     });
 
     describe('updateMenuCount', () => {

--- a/frontend/src/pages/client/services/OrderService.ts
+++ b/frontend/src/pages/client/services/OrderService.ts
@@ -265,6 +265,36 @@ class OrderService {
         }, 0);
     }
 
+    /**
+     * Kľúče, ktorých obsah je mapa počtov s OTVORENOU množinou názvov.
+     *
+     * Diéty si definuje admin (`Diet` model → `prevadzka.visible_diets`), takže
+     * ich mená nevie konštanta `DIETS` poznať — tá je len default pre prázdnu
+     * objednávku. Keby ich `enforceStructure` filtrovala schémou, vlastná diéta
+     * by sa pri načítaní ticho zahodila, prepísala do `currentOrder` aj
+     * localStorage, a najbližšie odoslanie by ju vynulovalo aj v DB.
+     *
+     * `menuCounts` zámerne NIE je v zozname: tam je filtrovanie podľa
+     * `GROUP_CONFIG` úmyselné (kategória má pevnú množinu menu variantov).
+     */
+    private static readonly OPEN_COUNT_MAP_KEYS = new Set(['diets']);
+
+    /** Zlúči mapu počtov: defaulty zo schémy + všetky platné počty z dát. */
+    private static enforceCountMap(
+        data: unknown,
+        schema: Record<string, unknown>
+    ): Record<string, number> {
+        const result = { ...schema } as Record<string, number>;
+        if (!data || typeof data !== 'object' || Array.isArray(data)) return result;
+
+        Object.entries(data as Record<string, unknown>).forEach(([key, value]) => {
+            if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return;
+            result[key] = value;
+        });
+
+        return result;
+    }
+
     static enforceStructure<T>(data: unknown, schema: T): T {
         if (!data) return schema;
         if (typeof data !== 'object') return schema;
@@ -287,7 +317,12 @@ class OrderService {
         Object.keys(schemaRecord).forEach(key => {
             if (Object.prototype.hasOwnProperty.call(dataRecord, key)) {
                 const schemaValue = schemaRecord[key];
-                if (typeof schemaValue === 'object' && schemaValue !== null && !Array.isArray(schemaValue)) {
+                if (this.OPEN_COUNT_MAP_KEYS.has(key)) {
+                    result[key] = this.enforceCountMap(
+                        dataRecord[key],
+                        (schemaValue ?? {}) as Record<string, unknown>
+                    );
+                } else if (typeof schemaValue === 'object' && schemaValue !== null && !Array.isArray(schemaValue)) {
                     result[key] = this.enforceStructure(dataRecord[key], schemaValue);
                 } else {
                     result[key] = dataRecord[key];


### PR DESCRIPTION
## Problém

`OrderService.enforceStructure` prepúšťa len kľúče prítomné v schéme, a schéma diét vzniká z hardcoded konštanty `DIETS` (`constants.ts:3`) — 11 mien typu `Bez lepku`, `Bez laktózy`. Diéty si však definuje admin (`Diet` model → `prevadzka.visible_diets`), takže **akýkoľvek vlastný názov sa pri načítaní ticho zahodil**.

V produkcii sa vlastné diéty používajú, takže to nie je teoretický prípad.

```
Zadanie diéty     → fungovalo  (modál berie mená z visible_diets, nie z konštanty)
Odoslanie         → fungovalo  (do DB pristálo správne)
Načítanie späť    → diéty ZMIZLI (odfiltrované na 0)
```

**Nešlo len o zlé zobrazenie.** Vynulované diéty sa prepísali do `currentOrder`, odtiaľ do localStorage, a najbližšie odoslanie — hoc aj bez toho, aby sa klient diét dotkol — poslalo nuly a prepísalo ich v DB. Tichá strata dát. Postihnuté boli obe cesty: odpoveď zo servera (`useOrder.ts:233`) aj localStorage (`safeParse`).

## Riešenie

Diéty sú od teraz **otvorená mapa počtov**: defaulty zo schémy sa zlúčia so všetkými platnými počtami z dát. Nečíselné, záporné a nekonečné hodnoty sa naďalej odfiltrujú, takže ochrana proti nezmyslom v dátach ostáva.

Konštanta `DIETS` ostáva len ako default pre prázdnu objednávku.

`menuCounts` **zámerne ostáva filtrované** schémou — tam je väzba na `GROUP_CONFIG` úmyselná (kategória má pevnú množinu menu variantov) a existujúci test to explicitne stráži.

Zaujímavosť, ktorá potvrdzuje smer: `packSeparately.diets` tento problém nikdy nemal, lebo jeho schéma je prázdny objekt a `enforceStructure` má vetvu „prázdna schéma → prepusť dáta". Filtrovala sa nekonzistentne len hlavná mapa `diets`.

## Nie je to regresia z #468

Chyba je dlhodobá — komentár dokumentujúci presne tento jav je v repe od `0d4b11a`, a `enforceStructure` sa #468 vôbec nedotkol. Zmena zadávania diét ju len zviditeľnila, keďže diéty sú teraz samostatná položka namiesto schovanej pilulky.

## Overenie

Nové testy: zachovanie admin-definovaných mien, odfiltrovanie nečíselných/záporných počtov, plný save/load round trip.

- `tsc` ✅ · `lint` ✅ · `vitest` **203/203** ✅ (v kontajneri, proti závislostiam z develop)
- **Reálny round-trip v bežiacej appke** (čistý prehliadač, objednávka načítaná z API):

| | pred opravou | po oprave |
|---|---|---|
| pole Menu A | `13` ❌ | `10` ✅ |
| riadok Diéty | `0` ❌ | `3` ✅ |

- **Scenár straty dát overený priamo:** objednávka `A=13, HISTAMIN=3` načítaná zo servera a znova odoslaná **bez dotknutia sa diét** → v DB zostalo `A=13, HISTAMIN=3`. Predtým by sa diéty vynulovali.

## Ešte pred nasadením stojí za zváženie

Či už k strate došlo v produkčných dátach — teda dohľadať objednávky, ktoré diéty mali a po neskoršej editácii ich majú vynulované. Táto oprava zabráni ďalším stratám, ale nič spätne neobnoví.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zUtAguUpa2b36jBjcF18p