### PR TITLE
chore: release develop to main

### DIFF
--- a/backend/api/management/commands/seed_meal_weight_catalog.py
+++ b/backend/api/management/commands/seed_meal_weight_catalog.py
@@ -8,7 +8,8 @@ Admins pick one of these per day/slot instead of uploading a weekly xlsx.
 Data is hardcoded here (not read from any xlsx file at runtime) — it mirrors
 `test/jedalnicky/Váhy jedál - apka ZP.xlsx`.
 
-Uses update_or_create keyed by `name`, so it is safe to run repeatedly.
+Matches existing rows by `name` (oldest wins), so it is safe to run repeatedly
+even when an admin has created a row that shares a catalog name.
 
 Usage:
     python manage.py seed_meal_weight_catalog
@@ -250,21 +251,31 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         created_count = 0
         for category, name, components, unit_exception in CATALOG:
-            _, created = MealTemplate.objects.update_or_create(
-                name=name,
-                defaults={
-                    "category": category,
-                    "components": components,
-                    "unit_exception": unit_exception,
-                    "weight_label": _weight_label(components, unit_exception),
-                    "base_weight_grams": _base_weight_grams(components),
-                    "menu_variant": "",
-                    "is_active": True,
-                },
-            )
-            if created:
+            defaults = {
+                "category": category,
+                "components": components,
+                "unit_exception": unit_exception,
+                "weight_label": _weight_label(components, unit_exception),
+                "base_weight_grams": _base_weight_grams(components),
+                "menu_variant": "",
+                "is_active": True,
+            }
+            # Deliberately not update_or_create(name=...): `name` has no unique
+            # constraint and admins may add their own catalog rows through
+            # /api/admin/meal-templates, so a name can occur more than once and
+            # get() would raise MultipleObjectsReturned — killing the whole
+            # deploy bootstrap. Keep the oldest (lowest-id) row as the seeded
+            # one and leave any admin-created namesakes untouched.
+            existing = MealTemplate.objects.filter(name=name).order_by("id").first()
+            if existing is None:
+                MealTemplate.objects.create(name=name, **defaults)
                 created_count += 1
                 self.stdout.write(f"  MealTemplate created: {name}")
+                continue
+
+            for field, value in defaults.items():
+                setattr(existing, field, value)
+            existing.save(update_fields=[*defaults, "updated_at"])
 
         if created_count:
             self.stdout.write(

--- a/backend/api/serializers_menu.py
+++ b/backend/api/serializers_menu.py
@@ -117,6 +117,18 @@ class MealTemplateSerializer(serializers.ModelSerializer):
     def get_diet_name(self, obj) -> str | None:
         return obj.diet.name if obj.diet_id else None
 
+    def validate_name(self, value: str) -> str:
+        # `name` has no DB unique constraint (prod already carries a duplicate
+        # from before this check), but a duplicate breaks seed_meal_weight_catalog
+        # and with it the whole deploy bootstrap — so block it at the API edge.
+        name = value.strip()
+        clash = MealTemplate.objects.filter(name__iexact=name)
+        if self.instance is not None:
+            clash = clash.exclude(pk=self.instance.pk)
+        if clash.exists():
+            raise serializers.ValidationError("Šablóna s týmto názvom už existuje.")
+        return name
+
     def validate(self, attrs: dict) -> dict:
         # A weight description is required from either the structured
         # `components` list (preferred — supports g/ml/text units) or a

--- a/backend/api/tests/test_meal_template_api.py
+++ b/backend/api/tests/test_meal_template_api.py
@@ -1,0 +1,91 @@
+"""Admin API katalógu šablón — duplicitný názov sa nesmie dať vytvoriť.
+
+Duplicita v `MealTemplate.name` položí seed katalógu a s ním celý
+`deploy_bootstrap`, preto ju odmietame už na vstupe.
+"""
+
+import pytest
+
+from api.models import MealCategory, MealTemplate
+
+URL = "/api/admin/meal-templates/"
+
+
+@pytest.fixture
+def template(db):
+    return MealTemplate.objects.create(
+        category=MealCategory.SOUP,
+        name="Polievka 3",
+        weight_label="200g",
+        base_weight_grams="200.00",
+        components=[{"label": "Polievka", "grams": "200", "unit": "g"}],
+    )
+
+
+def _payload(**overrides):
+    data = {
+        "category": MealCategory.SOUP,
+        "name": "Polievka 3",
+        "components": [{"label": "Polievka", "grams": "200", "unit": "g"}],
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.django_db
+def test_create_rejects_duplicate_name(admin_client, template):
+    response = admin_client.post(URL, _payload(), format="json")
+
+    assert response.status_code == 400
+    assert "name" in response.data["error"]["details"]
+    assert MealTemplate.objects.filter(name="Polievka 3").count() == 1
+
+
+@pytest.mark.django_db
+def test_create_rejects_duplicate_name_case_and_whitespace_insensitively(
+    admin_client, template
+):
+    response = admin_client.post(URL, _payload(name="  polievka 3  "), format="json")
+
+    assert response.status_code == 400
+    assert MealTemplate.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_create_allows_a_new_name(admin_client, template):
+    response = admin_client.post(URL, _payload(name="Polievka 5"), format="json")
+
+    assert response.status_code == 201
+    assert MealTemplate.objects.filter(name="Polievka 5").exists()
+
+
+@pytest.mark.django_db
+def test_update_keeping_own_name_is_allowed(admin_client, template):
+    response = admin_client.patch(
+        f"{URL}{template.id}/",
+        {"name": "Polievka 3", "weight_label": "250g"},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    template.refresh_from_db()
+    assert template.name == "Polievka 3"
+
+
+@pytest.mark.django_db
+def test_update_to_another_existing_name_is_rejected(admin_client, template):
+    other = MealTemplate.objects.create(
+        category=MealCategory.SOUP,
+        name="Polievka 4",
+        weight_label="200g",
+        base_weight_grams="200.00",
+        components=[{"label": "Polievka", "grams": "200", "unit": "g"}],
+    )
+
+    response = admin_client.patch(
+        f"{URL}{other.id}/", {"name": "Polievka 3"}, format="json"
+    )
+
+    assert response.status_code == 400
+    other.refresh_from_db()
+    assert other.name == "Polievka 4"

--- a/backend/api/tests/test_seed_meal_weight_catalog.py
+++ b/backend/api/tests/test_seed_meal_weight_catalog.py
@@ -1,0 +1,58 @@
+"""Seed katalógu gramáží musí prežiť duplicitné názvy šablón.
+
+`MealTemplate.name` nie je unique a admini si môžu pridať vlastnú položku cez
+/api/admin/meal-templates. Keď taká položka trafí názov z katalógu, seed nesmie
+spadnúť — inak zhorí `deploy_bootstrap` a nenaštartuje backend (prod 2026-08-12).
+"""
+
+from decimal import Decimal
+
+import pytest
+from django.core.management import call_command
+
+from api.management.commands.seed_meal_weight_catalog import CATALOG
+from api.models import MealTemplate
+
+
+@pytest.mark.django_db
+def test_seed_is_idempotent():
+    call_command("seed_meal_weight_catalog", verbosity=0)
+    first_ids = set(MealTemplate.objects.values_list("id", flat=True))
+
+    call_command("seed_meal_weight_catalog", verbosity=0)
+
+    assert MealTemplate.objects.count() == len(CATALOG)
+    assert set(MealTemplate.objects.values_list("id", flat=True)) == first_ids
+
+
+@pytest.mark.django_db
+def test_seed_survives_admin_created_duplicate_name():
+    call_command("seed_meal_weight_catalog", verbosity=0)
+    category, name, _components, _unit_exception = CATALOG[0]
+    seeded = MealTemplate.objects.get(name=name)
+
+    duplicate = MealTemplate.objects.create(
+        category=category,
+        name=name,
+        weight_label="ručne zadané",
+        base_weight_grams=Decimal("42.00"),
+        components=[{"label": "Vlastná zložka", "grams": "42", "unit": "g"}],
+        is_active=False,
+    )
+
+    call_command("seed_meal_weight_catalog", verbosity=0)
+
+    # Seed aktualizuje najstarší (najnižšie id) riadok…
+    seeded.refresh_from_db()
+    assert seeded.is_active is True
+    assert seeded.base_weight_grams != Decimal("42.00")
+
+    # …a ručne vytvoreného menovca nechá tak.
+    duplicate.refresh_from_db()
+    assert duplicate.is_active is False
+    assert duplicate.weight_label == "ručne zadané"
+    assert duplicate.base_weight_grams == Decimal("42.00")
+    assert duplicate.components == [
+        {"label": "Vlastná zložka", "grams": "42", "unit": "g"}
+    ]
+    assert MealTemplate.objects.filter(name=name).count() == 2

--- a/frontend/src/pages/client/services/OrderService.test.ts
+++ b/frontend/src/pages/client/services/OrderService.test.ts
@@ -44,6 +44,68 @@ describe('OrderService', () => {
             expect(result).not.toHaveProperty('unknownMeal');
             expect(result.lunch['Škôlka'].menuCounts).not.toHaveProperty('unexpected');
         });
+
+        it('keeps admin-defined diet names that are not in the DIETS constant', () => {
+            const schema = OrderService.createEmptyOrder();
+            const result = OrderService.enforceStructure<DailyOrder>(
+                {
+                    lunch: {
+                        Škôlka: {
+                            menuCounts: { A: 13 },
+                            // Mená z `Diet` modelu — konštanta DIETS ich nepozná.
+                            diets: { HISTAMIN: 3, 'NO EGG': 2 },
+                        },
+                    },
+                },
+                schema
+            );
+
+            const cat = result.lunch['Škôlka'];
+            expect(cat.diets['HISTAMIN']).toBe(3);
+            expect(cat.diets['NO EGG']).toBe(2);
+            // Známe diéty ostávajú ako defaulty na nule
+            expect(cat.diets['Bez lepku']).toBe(0);
+            // A odvodený počet bežných porcií tým pádom sedí: 13 − 5 = 8
+            expect(OrderService.getPlainMenuACount(cat)).toBe(8);
+        });
+
+        it('ignores non-numeric or negative diet counts', () => {
+            const schema = OrderService.createEmptyOrder();
+            const result = OrderService.enforceStructure<DailyOrder>(
+                {
+                    lunch: {
+                        Škôlka: {
+                            menuCounts: { A: 2 },
+                            diets: { HISTAMIN: 2, BROKEN: 'x', NEGATIVE: -3, FLAGGED: true },
+                        },
+                    },
+                },
+                schema
+            );
+
+            const diets = result.lunch['Škôlka'].diets;
+            expect(diets['HISTAMIN']).toBe(2);
+            expect(diets).not.toHaveProperty('BROKEN');
+            expect(diets).not.toHaveProperty('NEGATIVE');
+            expect(diets).not.toHaveProperty('FLAGGED');
+        });
+
+        it('keeps custom diet names through a full save/load round trip', () => {
+            let order = OrderService.createEmptyOrder();
+            order = OrderService.updateMenuCount(order, 'lunch', 'Škôlka', 'A', 10);
+            order = OrderService.updateDiet(order, 'lunch', 'Škôlka', 'HISTAMIN', 3);
+            expect(order.lunch['Škôlka'].menuCounts.A).toBe(13);
+
+            // Presne to, čo robí useOrder pri odpovedi zo servera / localStorage.
+            const reloaded = OrderService.enforceStructure<DailyOrder>(
+                JSON.parse(JSON.stringify(order)),
+                OrderService.createEmptyOrder()
+            );
+
+            expect(reloaded.lunch['Škôlka'].diets['HISTAMIN']).toBe(3);
+            expect(reloaded.lunch['Škôlka'].menuCounts.A).toBe(13);
+            expect(OrderService.getPlainMenuACount(reloaded.lunch['Škôlka'])).toBe(10);
+        });
     });
 
     describe('updateMenuCount', () => {

--- a/frontend/src/pages/client/services/OrderService.ts
+++ b/frontend/src/pages/client/services/OrderService.ts
@@ -265,6 +265,36 @@ class OrderService {
         }, 0);
     }
 
+    /**
+     * Kľúče, ktorých obsah je mapa počtov s OTVORENOU množinou názvov.
+     *
+     * Diéty si definuje admin (`Diet` model → `prevadzka.visible_diets`), takže
+     * ich mená nevie konštanta `DIETS` poznať — tá je len default pre prázdnu
+     * objednávku. Keby ich `enforceStructure` filtrovala schémou, vlastná diéta
+     * by sa pri načítaní ticho zahodila, prepísala do `currentOrder` aj
+     * localStorage, a najbližšie odoslanie by ju vynulovalo aj v DB.
+     *
+     * `menuCounts` zámerne NIE je v zozname: tam je filtrovanie podľa
+     * `GROUP_CONFIG` úmyselné (kategória má pevnú množinu menu variantov).
+     */
+    private static readonly OPEN_COUNT_MAP_KEYS = new Set(['diets']);
+
+    /** Zlúči mapu počtov: defaulty zo schémy + všetky platné počty z dát. */
+    private static enforceCountMap(
+        data: unknown,
+        schema: Record<string, unknown>
+    ): Record<string, number> {
+        const result = { ...schema } as Record<string, number>;
+        if (!data || typeof data !== 'object' || Array.isArray(data)) return result;
+
+        Object.entries(data as Record<string, unknown>).forEach(([key, value]) => {
+            if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return;
+            result[key] = value;
+        });
+
+        return result;
+    }
+
     static enforceStructure<T>(data: unknown, schema: T): T {
         if (!data) return schema;
         if (typeof data !== 'object') return schema;
@@ -287,7 +317,12 @@ class OrderService {
         Object.keys(schemaRecord).forEach(key => {
             if (Object.prototype.hasOwnProperty.call(dataRecord, key)) {
                 const schemaValue = schemaRecord[key];
-                if (typeof schemaValue === 'object' && schemaValue !== null && !Array.isArray(schemaValue)) {
+                if (this.OPEN_COUNT_MAP_KEYS.has(key)) {
+                    result[key] = this.enforceCountMap(
+                        dataRecord[key],
+                        (schemaValue ?? {}) as Record<string, unknown>
+                    );
+                } else if (typeof schemaValue === 'object' && schemaValue !== null && !Array.isArray(schemaValue)) {
                     result[key] = this.enforceStructure(dataRecord[key], schemaValue);
                 } else {
                     result[key] = dataRecord[key];


### PR DESCRIPTION
Release všetkého, čo je na `develop` od posledného releasu (#469).

Obsahovo prináša **jednu zmenu** — opravu zahadzovania vlastných názvov diét. Druhý commit vo výpise (`fix(seed): nespadni na duplicitnom názve šablóny jedla`) je už na `main` aplikovaný samostatne (`60f8b49`, identický diff), takže sa vezie len ako duplicitná história, nie ako zmena obsahu. Merge je bezkonfliktný.

Obsahový diff `main` → `develop`: 2 súbory, +98/−1, všetko pod `frontend/src/pages/client/services/`.

## Nezahadzuj vlastné názvy diét pri načítaní objednávky (#470)

`OrderService.enforceStructure` prepúšťala len kľúče prítomné v schéme, a schéma diét vzniká z hardcoded konštanty `DIETS`. Diéty si však definuje admin (`Diet` model → `prevadzka.visible_diets`), takže **akýkoľvek vlastný názov sa pri načítaní ticho zahodil**. V produkcii sa vlastné diéty používajú, takže to nebol teoretický prípad.

Nešlo len o zlé zobrazenie. Vynulované diéty sa prepísali do `currentOrder`, odtiaľ do localStorage, a najbližšie odoslanie — hoc aj bez toho, aby sa klient diét dotkol — poslalo nuly a **prepísalo ich v DB**. Tichá strata dát. Postihnuté boli obe cesty: odpoveď zo servera (`useOrder.ts:233`) aj localStorage (`safeParse`).

### Riešenie

Diéty sú od teraz otvorená mapa počtov: defaulty zo schémy sa zlúčia so všetkými platnými počtami z dát. Nečíselné, záporné a nekonečné hodnoty sa naďalej odfiltrujú, takže ochrana proti nezmyslom v dátach ostáva. Konštanta `DIETS` slúži už len ako default pre prázdnu objednávku.

`menuCounts` zámerne ostáva filtrované schémou — tam je väzba na `GROUP_CONFIG` úmyselná a existujúci test to explicitne stráži.

### Nie je to regresia z #468

Chyba je dlhodobá — komentár dokumentujúci presne tento jav je v repe od `0d4b11a` a `enforceStructure` sa #468 vôbec nedotkol. Zmena zadávania diét ju len zviditeľnila.

## Overenie

- `tsc` ✅ · `lint` ✅ · `vitest` **203/203** ✅ (v kontajneri, proti závislostiam z develop)
- Round-trip v bežiacej appke (čistý prehliadač, objednávka načítaná z API): pole Menu A `13 → 10`, riadok Diéty `0 → 3`.
- **Scenár straty dát overený priamo:** objednávka `A=13, HISTAMIN=3` načítaná zo servera a znova odoslaná bez dotknutia sa diét → v DB zostalo `A=13, HISTAMIN=3`. Predtým by sa vynulovali.

## Po nasadení stojí za zváženie

Oprava zabráni ďalším stratám, ale nič spätne neobnoví. Odporúčam dohľadať objednávky, ktoré diéty mali a po neskoršej editácii ich majú vynulované.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zUtAguUpa2b36jBjcF18p