### PR TITLE
feat(admin): použiteľná admin konzola na mobile

### DIFF
--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -36,6 +36,23 @@ vôbec, na mobile ho tooltip prekryl).
 **viacerými** prevádzkami, aby testy prechádzali aj cestou výberu prevádzky,
 kde vznikali chyby (objednávky sa vedú per prevádzka).
 
+Pre `/admin` je to `admin@example.com` / `admin` (`loginAsAdmin()`). Nejde cez
+`login()`: ten čaká na `/home`, kam sa staff nikdy nedostane.
+
+## Admin na mobile
+
+`admin-mobile.spec.ts` beží len v projekte `mobile` (nad 900px sa mobilný shell
+vôbec nezapína, preto sa na desktope preskočí). Stráži tri veci:
+
+- žiadna admin obrazovka netečie do strán — ani dokument, ani `.zpa-main`.
+  Široké tabuľky (gramáž, logy) smú scrollovať, ale vo vlastnom
+  `.zpa-table-wrap`;
+- zásuvka s navigáciou sa otvorí nad topbarom, má čitateľné popisky (rail sa na
+  desktope rozbaľuje hoverom, ktorý na dotyku neexistuje) a po výbere položky sa
+  zavrie. Zatvára sa posunom, takže sa testuje **poloha**, nie `toBeHidden()`;
+- poradie prevádzok v trase sa dá meniť šípkami — HTML5 drag & drop sa na
+  dotyku vôbec nespustí.
+
 ## Na čo si dať pozor pri písaní testov
 
 - **Mobilné modály.** Po prihlásení sa na mobile otvorí `PWAInstallBanner` a

--- a/frontend/e2e/admin-mobile.spec.ts
+++ b/frontend/e2e/admin-mobile.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "@playwright/test";
+import { loginAsAdmin } from "./helpers";
+
+/**
+ * Admin konzola na mobile.
+ *
+ * Admin bol navrhnutý na širokú obrazovku a shell je flex **riadok** (rail
+ * vľavo, obsah vpravo). Mobilný topbar je ďalší priamy potomok toho istého
+ * flexu — kým sa shell na úzkej obrazovke neprepol na stĺpec, sadol si vedľa
+ * obsahu ako úzky stĺpec a zvyšok appky vytlačil mimo viewport. Testy nižšie
+ * strážia presne to: že sa nič nerozleje do strán a že sa zásuvka dá ovládať.
+ */
+
+const ADMIN_PAGES = [
+  "/admin/dashboard",
+  "/admin/prevadzka-overview",
+  "/admin/delivery-layout",
+  "/admin/meal-plan",
+  "/admin/meal-catalog",
+  "/admin/facilities",
+  "/admin/diets",
+  "/admin/settings",
+  "/admin/holidays",
+  "/admin/logs",
+  "/admin/push-notifications",
+  "/admin/roles",
+];
+
+test.describe("admin na mobile", () => {
+  test.skip(
+    ({ viewport }) => (viewport?.width ?? 0) > 900,
+    "mobilný shell sa zapína pod 900px",
+  );
+
+  /**
+   * Široké tabuľky (gramáž, logy) smú scrollovať vodorovne — ale vo vlastnom
+   * `.zpa-table-wrap`, nie celým obsahom stránky. Preto sa meria dokument aj
+   * `.zpa-main`, nie jednotlivé prvky.
+   */
+  const sidewaysOverflow = (page: import("@playwright/test").Page) =>
+    page.evaluate(() => {
+      const main = document.querySelector(".zpa-main");
+      return {
+        doc: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        main: main ? main.scrollWidth - main.clientWidth : 0,
+      };
+    });
+
+  test("žiadna obrazovka netečie do strán", async ({ page }) => {
+    await loginAsAdmin(page);
+
+    for (const path of ADMIN_PAGES) {
+      await page.goto(path);
+      // Obsah sa dopĺňa asynchrónne; čakáme na hlavičku stránky, nie na timeout.
+      await expect(page.locator(".zpa-pagehead h1")).toBeVisible();
+
+      const overflow = await sidewaysOverflow(page);
+      expect(overflow.doc, `${path}: dokument tečie do strán`).toBeLessThanOrEqual(1);
+      expect(overflow.main, `${path}: obsah tečie do strán`).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("detailové obrazovky netečú ani na 320px", async ({ page }) => {
+    // Najužší displej, s ktorým sa reálne počíta (iPhone SE 1. gen). Nadpisy
+    // sú tu dáta — e-mail admina ani názov celku nemajú kde zalomiť.
+    await page.setViewportSize({ width: 320, height: 844 });
+    await loginAsAdmin(page);
+
+    await page.goto("/admin/roles");
+    await page.locator('a[href^="/admin/roles/"]').first().click();
+    await expect(page.getByText("Osobné údaje a rola")).toBeVisible();
+    expect((await sidewaysOverflow(page)).main, "detail admina tečie").toBeLessThanOrEqual(1);
+
+    await page.goto("/admin/facilities");
+    await page.locator(".zpa-celok-toggle").first().click();
+    await page.locator('a[href^="/admin/facilities/"]').first().click();
+    await expect(page.locator(".zpa-tabs")).toBeVisible();
+    expect((await sidewaysOverflow(page)).main, "detail prevádzky tečie").toBeLessThanOrEqual(1);
+
+    await page.goto("/admin/settings");
+    await expect(page.locator(".zpa-pagehead h1")).toBeVisible();
+    expect((await sidewaysOverflow(page)).main, "systémové nastavenia tečú").toBeLessThanOrEqual(1);
+  });
+
+  test("zásuvka s navigáciou sa otvorí, prekryje topbar a zavrie sa výberom", async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto("/admin/dashboard");
+
+    const sidebar = page.locator(".zpa-sidebar");
+    const navLink = page.getByRole("link", { name: "Voľné dni" });
+
+    /**
+     * Zásuvka sa zatvára posunom (`translateX(-100%)`), takže z pohľadu DOM
+     * ostáva „viditeľná“ — jediný spoľahlivý signál je jej poloha.
+     */
+    const sidebarRightEdge = async () => {
+      const box = await sidebar.boundingBox();
+      return (box?.x ?? 0) + (box?.width ?? 0);
+    };
+
+    expect(await sidebarRightEdge()).toBeLessThanOrEqual(1);
+
+    await page.getByRole("button", { name: "Otvoriť menu" }).click();
+    await expect(navLink).toBeVisible();
+
+    // Hlavička zásuvky nesmie skončiť pod topbarom — kvôli tomu má na mobile
+    // vyšší z-index ako topbar.
+    const brand = page.locator(".zpa-sidebar .brand-full img");
+    await expect(brand).toBeVisible();
+    const brandBox = await brand.boundingBox();
+    expect(brandBox!.y).toBeGreaterThanOrEqual(0);
+
+    // Rail sa na desktope rozbaľuje hoverom; na dotyku musia byť popisky vidno
+    // aj bez neho.
+    await expect(navLink).toHaveText(/Voľné dni/);
+
+    await navLink.click();
+    await expect(page).toHaveURL(/\/admin\/holidays/);
+    await expect.poll(sidebarRightEdge).toBeLessThanOrEqual(1);
+  });
+
+  test("poradie prevádzok v trase sa dá meniť bez ťahania", async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto("/admin/delivery-layout");
+    await expect(page.locator(".zpa-pagehead h1")).toBeVisible();
+
+    const rows = page.locator(".zpa-table tbody tr.zpa-draggable-row");
+    await expect(rows.first()).toBeVisible();
+
+    const nameOf = (index: number) =>
+      rows.nth(index).locator("td div").first().innerText();
+
+    const before = [await nameOf(0), await nameOf(1)];
+
+    // Prvý riadok nemôže ísť vyššie — šípka je vypnutá.
+    await expect(rows.nth(0).getByRole("button", { name: /vyššie$/i })).toBeDisabled();
+
+    await rows.nth(0).getByRole("button", { name: /nižšie$/i }).click();
+
+    await expect
+      .poll(async () => [await nameOf(0), await nameOf(1)])
+      .toEqual([before[1], before[0]]);
+
+    // Vrátime späť, aby test nemenil stav pre ďalšie behy.
+    await rows.nth(1).getByRole("button", { name: /vyššie$/i }).click();
+    await expect.poll(async () => [await nameOf(0), await nameOf(1)]).toEqual(before);
+  });
+});

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -6,6 +6,12 @@ export const MULTI_PREVADZKA_LOGIN = {
   password: "prevadzka",
 };
 
+/** Demo admin zo `init_roles` — jediný login, ktorý vidí `/admin`. */
+export const ADMIN_LOGIN = {
+  email: "admin@example.com",
+  password: "admin",
+};
+
 /**
  * Na mobilnom viewporte sa po prihlásení otvorí modál „Nainštalovať aplikáciu“
  * (`PWAInstallBanner`) a prekryje celé UI. Je to správne správanie appky, len
@@ -33,6 +39,21 @@ export async function login(
   await page.fill('input[type="password"]', credentials.password);
   await page.click('button[type="submit"]');
   await page.waitForURL(/\/home/);
+}
+
+/**
+ * Prihlási admina a počká na admin shell.
+ *
+ * Nejde cez `login()`: ten čaká na `/home`, kam sa staff nikdy nedostane —
+ * `ProtectedRoute` ho hneď presmeruje na `/admin`.
+ */
+export async function loginAsAdmin(page: Page): Promise<void> {
+  await dismissMobilePrompts(page);
+  await page.goto("/login");
+  await page.fill('input[inputmode="email"]', ADMIN_LOGIN.email);
+  await page.fill('input[type="password"]', ADMIN_LOGIN.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/admin/);
 }
 
 /**

--- a/frontend/src/pages/admin/AdminUserDetail.tsx
+++ b/frontend/src/pages/admin/AdminUserDetail.tsx
@@ -111,8 +111,10 @@ const AdminUserDetail: React.FC = () => {
           <span className="zpa-avatar-sm" style={{ width: 60, height: 60, fontSize: 24 }}>
             {user.email.charAt(0).toUpperCase()}
           </span>
-          <div>
-            <h1 style={{ fontFamily: "var(--font-display)", fontSize: 28, fontWeight: 700, color: "var(--green-900)", margin: 0 }}>
+          {/* `minWidth: 0` nie je kozmetika: bez neho sa flex položka nezmenší
+              pod svoj obsah a e-mail v nadpise vytečie z obrazovky. */}
+          <div style={{ minWidth: 0 }}>
+            <h1 style={{ fontFamily: "var(--font-display)", fontSize: 28, fontWeight: 700, color: "var(--green-900)", margin: 0, overflowWrap: "anywhere" }}>
               {user.first_name || user.last_name ? `${user.first_name} ${user.last_name}`.trim() : user.email}
             </h1>
             <p style={{ color: "var(--ink-3)", margin: "4px 0 0" }}>Úprava osobných údajov a rolí</p>

--- a/frontend/src/pages/admin/DeliveryLayoutAdmin.tsx
+++ b/frontend/src/pages/admin/DeliveryLayoutAdmin.tsx
@@ -169,6 +169,31 @@ const DeliveryLayoutAdmin: React.FC = () => {
     });
   };
 
+  /**
+   * Posunie prevádzku o krok v rámci jej trasy.
+   *
+   * Duplikuje to, čo sa dá spraviť ťahaním riadku — ale HTML5 drag & drop sa na
+   * dotykovom displeji vôbec nespustí, takže bez týchto tlačidiel je poradie
+   * prevádzok na mobile nemenné. Rovnaký vzor už používajú bloky (`moveBlock`).
+   */
+  const movePrevadzkaInRoute = (routeId: number, prevadzkaId: number, delta: number) => {
+    updateLayout((current) => ({
+      ...current,
+      blocks: current.blocks.map((block) => ({
+        ...block,
+        routes: block.routes.map((route) => {
+          if (route.id !== routeId) return route;
+          const prevadzky = [...route.prevadzky];
+          const index = prevadzky.findIndex((item) => item.id === prevadzkaId);
+          const target = index + delta;
+          if (index < 0 || target < 0 || target >= prevadzky.length) return route;
+          [prevadzky[index], prevadzky[target]] = [prevadzky[target], prevadzky[index]];
+          return { ...route, prevadzky };
+        }),
+      })),
+    }));
+  };
+
   const startDrag = (event: React.DragEvent, nextDragging: DragState) => {
     setDragging(nextDragging);
     event.dataTransfer.effectAllowed = "move";
@@ -499,7 +524,7 @@ const DeliveryLayoutAdmin: React.FC = () => {
                         {route.prevadzky.length === 0 ? (
                           <tr><td style={{ color: "var(--ink-mute)" }}>Žiadne prevádzky v trase.</td></tr>
                         ) : (
-                          route.prevadzky.map((prevadzka) => (
+                          route.prevadzky.map((prevadzka, prevadzkaIndex) => (
                             <tr
                               key={prevadzka.id}
                               className={`zpa-draggable-row${dragging?.type === "prevadzka" && dragging.prevadzkaId === prevadzka.id ? " is-dragging" : ""}`}
@@ -515,7 +540,7 @@ const DeliveryLayoutAdmin: React.FC = () => {
                                 setDragging(null);
                               }}
                             >
-                              <td style={{ width: 48 }}>
+                              <td className="zpa-gripcell" style={{ width: 48 }}>
                                 <span className="zpa-row-grip" title="Presunúť prevádzku" aria-label="Presunúť prevádzku">
                                   <GripVertical />
                                 </span>
@@ -525,13 +550,31 @@ const DeliveryLayoutAdmin: React.FC = () => {
                                 <div style={{ fontSize: 12, color: "var(--ink-3)" }}>{prevadzka.celok}{prevadzka.adresa ? ` · ${prevadzka.adresa}` : ""}</div>
                               </td>
                               <td className="r">
-                                <Button
-                                  sm
-                                  variant="ghost"
-                                  onClick={() => requestUnassignPrevadzka(prevadzka, () => assignPrevadzka(prevadzka.id, null))}
-                                >
-                                  Odobrať
-                                </Button>
+                                <div className="zpa-rowactions">
+                                  <IconButton
+                                    onClick={() => movePrevadzkaInRoute(route.id, prevadzka.id, -1)}
+                                    disabled={prevadzkaIndex === 0}
+                                    title="Vyššie"
+                                    aria-label={`Posunúť ${prevadzka.report_alias || prevadzka.nazov} vyššie`}
+                                  >
+                                    <ArrowUp />
+                                  </IconButton>
+                                  <IconButton
+                                    onClick={() => movePrevadzkaInRoute(route.id, prevadzka.id, 1)}
+                                    disabled={prevadzkaIndex === route.prevadzky.length - 1}
+                                    title="Nižšie"
+                                    aria-label={`Posunúť ${prevadzka.report_alias || prevadzka.nazov} nižšie`}
+                                  >
+                                    <ArrowDown />
+                                  </IconButton>
+                                  <Button
+                                    sm
+                                    variant="ghost"
+                                    onClick={() => requestUnassignPrevadzka(prevadzka, () => assignPrevadzka(prevadzka.id, null))}
+                                  >
+                                    Odobrať
+                                  </Button>
+                                </div>
                               </td>
                             </tr>
                           ))
@@ -582,7 +625,7 @@ const DeliveryLayoutAdmin: React.FC = () => {
                           setDragging(null);
                         }}
                       >
-                        <td style={{ width: 48 }}>
+                        <td className="zpa-gripcell" style={{ width: 48 }}>
                           <span className="zpa-row-grip" title="Presunúť prevádzku" aria-label="Presunúť prevádzku">
                             <GripVertical />
                           </span>
@@ -592,7 +635,7 @@ const DeliveryLayoutAdmin: React.FC = () => {
                           <div style={{ fontSize: 12, color: "var(--ink-3)" }}>{prevadzka.celok}</div>
                         </td>
                         <td className="r">
-                          <Select defaultValue="" onChange={(e) => assignPrevadzka(prevadzka.id, Number(e.target.value))} style={{ width: 260 }}>
+                          <Select defaultValue="" onChange={(e) => assignPrevadzka(prevadzka.id, Number(e.target.value))} style={{ width: "min(260px, 100%)" }}>
                             <option value="" disabled>Priradiť do trasy…</option>
                             {routeOptions.map(({ route, block }) => (
                               <option key={route.id} value={route.id}>{block.name} / {route.name}</option>

--- a/frontend/src/pages/admin/DietManager.tsx
+++ b/frontend/src/pages/admin/DietManager.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { GripVertical, Layers, Plus, Pencil, Trash2 } from "lucide-react";
+import { ArrowDown, ArrowUp, GripVertical, Layers, Plus, Pencil, Trash2 } from "lucide-react";
 import { useAuth } from "../../context/auth";
 import { useToast } from "../../context/ToastContext";
 import { logger } from '../../lib/logger';
 import { PageHead, Card, Button, IconButton, Field, Input, Textarea, Modal, Empty, ColorSwatchPicker, Checkbox } from "./ui";
 import { DietColorSwatch } from "./DietColorSwatch";
-import { dietReorderPayload, moveDietBefore } from "./dietReorder";
+import { dietReorderPayload, moveDietBefore, moveDietBy } from "./dietReorder";
 
 export interface Diet {
   id: number;
@@ -277,6 +277,13 @@ const DietManager: React.FC = () => {
     void persistDietOrder(nextDiets);
   };
 
+  const moveDiet = (dietId: number, delta: number) => {
+    const nextDiets = moveDietBy(diets, dietId, delta);
+    if (nextDiets === diets) return;
+    setDiets(nextDiets);
+    void persistDietOrder(nextDiets);
+  };
+
   const composableDiets = diets.filter((diet) => (diet.base_diets || []).length === 0);
 
   return (
@@ -373,7 +380,23 @@ const DietManager: React.FC = () => {
                   )}
                   </div>
                 </div>
-                <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>
+                <div className="zpa-rowactions" style={{ flexShrink: 0 }}>
+                  <IconButton
+                    title="Vyššie"
+                    aria-label={`Posunúť diétu ${diet.name} vyššie`}
+                    disabled={dietPosition === 0}
+                    onClick={() => moveDiet(diet.id, -1)}
+                  >
+                    <ArrowUp />
+                  </IconButton>
+                  <IconButton
+                    title="Nižšie"
+                    aria-label={`Posunúť diétu ${diet.name} nižšie`}
+                    disabled={dietPosition === diets.length - 1}
+                    onClick={() => moveDiet(diet.id, 1)}
+                  >
+                    <ArrowDown />
+                  </IconButton>
                   <IconButton
                     title="Upraviť"
                     onClick={() =>

--- a/frontend/src/pages/admin/SystemSettings.tsx
+++ b/frontend/src/pages/admin/SystemSettings.tsx
@@ -290,7 +290,9 @@ const SystemSettings: React.FC = () => {
                             Prepíše objednávky EduPage prevádzok pre zvolený deň aktuálnymi
                             počtami. Použi ráno, keď rodičia po večernom scrape odhlásili deti.
                         </p>
-                        <div style={{ display: 'flex', gap: 12, alignItems: 'flex-end', marginTop: 12 }}>
+                        {/* `flexWrap` kvôli úzkym displejom: tlačidlo má nowrap
+                            a vedľa dátumu sa na 320px nezmestí. */}
+                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'flex-end', marginTop: 12 }}>
                             <Field label="Deň">
                                 <Input
                                     type="date"

--- a/frontend/src/pages/admin/admin.css
+++ b/frontend/src/pages/admin/admin.css
@@ -292,6 +292,9 @@
     margin: 0;
     letter-spacing: -0.01em;
     line-height: 1.1;
+    /* Nadpis býva dáta, nie text — e-mail admina ani názov celku nemajú kde
+     * zalomiť a na úzkej obrazovke by vytiekli von. */
+    overflow-wrap: anywhere;
 }
 .zpa-pagehead p {
     margin: 6px 0 0;
@@ -368,6 +371,16 @@
 }
 .zpa-draggable-row:hover .zpa-row-grip { color: var(--green-700); background: rgba(114,136,75,0.10); }
 .zpa-row-grip svg { width: 17px; height: 17px; }
+
+/* Akcie riadku (šípky poradia + ostatné tlačidlá). */
+.zpa-rowactions { display: inline-flex; align-items: center; gap: 4px; justify-content: flex-end; flex-wrap: wrap; }
+
+/* Na dotyku sa HTML5 drag & drop nespustí, takže úchyt nič nesľubuje —
+ * poradie sa tam mení šípkami. Miesto po ňom využijú akcie riadku. */
+@media (hover: none) and (pointer: coarse) {
+    .zpa-row-grip { display: none; }
+    .zpa-gripcell { display: none; }
+}
 
 /* ========================================================== *
  * Cards
@@ -735,27 +748,138 @@
  * ========================================================== */
 .zpa-topbar { display: none; }
 @media (max-width: 900px) {
+    /* Shell je na desktope flex **riadok** (rail vľavo, obsah vpravo). Na mobile
+     * pribúda topbar ako ďalší priamy potomok — v riadku by si sadol vedľa
+     * obsahu ako úzky stĺpec a zvyšok appky stlačil mimo viewport. Preto sa tu
+     * shell prepína na stĺpec: topbar hore, obsah pod ním. */
+    .zpa-app { flex-direction: column; }
     .zpa-topbar {
-        display: flex; align-items: center; gap: 12px;
+        display: flex; align-items: center; gap: 12px; flex: 0 0 auto;
         position: sticky; top: 0; z-index: 40;
         height: 56px; padding: 0 16px;
+        padding-left: max(16px, env(safe-area-inset-left));
+        padding-right: max(16px, env(safe-area-inset-right));
         background: var(--bg-cream-warm);
         border-bottom: 1px solid var(--line-soft);
     }
     .zpa-topbar img { height: 26px; width: auto; }
     .zpa-topbar .zpa-iconbtn { margin-left: auto; }
-    .zpa-sidebar { transform: translateX(-100%); transition: transform 240ms cubic-bezier(.4,0,.2,1); width: 264px; }
+    /* V stĺpci by `height: 100%` z desktopu pretiekol o výšku topbaru. */
+    .zpa-main { height: auto; flex: 1 1 auto; min-height: 0; }
+    /* Zásuvka prekrýva aj topbar — inak by jej hlavička s logom zmizla pod ním. */
+    .zpa-sidebar {
+        transform: translateX(-100%);
+        transition: transform 240ms cubic-bezier(.4,0,.2,1);
+        width: 264px;
+        z-index: 45;
+    }
     .zpa-sidebar::after { display: none; }
     .zpa-sidebar:hover { width: 264px; box-shadow: none; }
-    .zpa-sidebar .brand-mini { display: none; }
-    .zpa-sidebar .brand-full { display: flex; }
-    .zpa-sidebar .zpa-nav-item .lbl, .zpa-sidebar .zpa-nav-section .lbl { opacity: 1; }
-    .zpa-sidebar .zpa-user .body, .zpa-sidebar .zpa-user .logout { opacity: 1; pointer-events: auto; }
+    /* Rail sa na desktope rozbaľuje cez `:hover`; na dotyku hover neexistuje,
+     * takže je zásuvka vždy „rozbalená". Selektory musia prebiť
+     * `.zpa-sidebar:not(:hover) …` — `:not(:hover)` sa počíta do špecificity,
+     * takže bez zopakovania `:not(:hover)` by tieto pravidlá prehrali. */
+    .zpa-sidebar:not(:hover) .brand-mini { display: none; }
+    .zpa-sidebar:not(:hover) .brand-full { display: flex; }
+    .zpa-sidebar:not(:hover) .zpa-nav-item .lbl,
+    .zpa-sidebar:not(:hover) .zpa-nav-section .lbl { opacity: 1; }
+    .zpa-sidebar:not(:hover) .zpa-user .body,
+    .zpa-sidebar:not(:hover) .zpa-user .logout { opacity: 1; pointer-events: auto; }
     .zpa-app.nav-open .zpa-sidebar { transform: translateX(0); box-shadow: 10px 0 44px rgba(23,53,5,0.16); }
     .zpa-main { margin-left: 0; }
-    .zpa-scrim-nav { position: fixed; inset: 0; z-index: 25; background: rgba(23,53,5,0.28); }
-    .zpa-content { padding: 20px 16px 48px; }
+    .zpa-scrim-nav { position: fixed; inset: 0; z-index: 42; background: rgba(23,53,5,0.28); }
+    .zpa-content {
+        padding: 20px 16px 48px;
+        padding-left: max(16px, env(safe-area-inset-left));
+        padding-right: max(16px, env(safe-area-inset-right));
+        padding-bottom: calc(48px + env(safe-area-inset-bottom));
+    }
     .zpa-content--wide { max-width: none; }
+    /* Gramáž si drží vlastný scroll; na desktope si odpočítava hlavičku stránky,
+     * na mobile navyše 56px topbaru. */
+    .zpa-gram-wrap { max-height: calc(100vh - 224px); }
+}
+
+/* ========================================================== *
+ * Mobile: obsah stránok
+ * ----------------------------------------------------------
+ * Admin bol navrhnutý na širokú obrazovku — riadky s pevnými stĺpcami,
+ * toolbary v jednom riadku, tabuľky so 6+ stĺpcami. Tu sa tie isté vzory
+ * preskladajú na výšku; širokú tabuľku (gramáž, logy) necháme scrollovať
+ * vodorovne vo vlastnom kontajneri, nie celou stránkou.
+ * ========================================================== */
+@media (max-width: 700px) {
+    .zpa-pagehead { margin-bottom: 20px; gap: 14px; }
+    .zpa-pagehead h1 { font-size: 24px; }
+    .zpa-pagehead .actions { width: 100%; }
+
+    /* Toolbary a hlavičky kariet: radšej zalomiť ako pretiecť. */
+    .zpa-card-head { flex-wrap: wrap; gap: 12px; padding: 16px; }
+    .zpa-card--pad { padding: 16px; }
+    .zpa-listrow { flex-wrap: wrap; gap: 10px; padding: 14px 16px; }
+    .zpa-listgroup-label { padding: 8px 16px; }
+    .zpa-statusgrid { grid-template-columns: 1fr; }
+
+    /* Tabuľky: užšie odsadenie, aby sa vodorovný scroll spustil čo najneskôr. */
+    .zpa-table thead th { padding: 12px 14px; }
+    .zpa-table tbody td { padding: 12px 14px; }
+
+    /* Taby sa nezmestia vedľa seba — nech sa dajú prejsť prstom. */
+    .zpa-tabs { overflow-x: auto; scrollbar-width: none; }
+    .zpa-tabs::-webkit-scrollbar { display: none; }
+    .zpa-tab { flex: 0 0 auto; padding: 13px 18px; white-space: nowrap; }
+
+    /* Dátový navigátor: šípky po stranách, dátum na vlastný riadok. */
+    .zpa-datenav { flex-wrap: wrap; justify-content: space-between; row-gap: 10px; padding: 14px 16px; }
+    .zpa-datenav .mid { order: 3; flex: 1 0 100%; justify-content: center; flex-wrap: wrap; }
+    .zpa-navchip { padding: 9px 12px; }
+
+    /* Kalendár jedálnička: 7 stĺpcov na 390px znamená ~50px na bunku. */
+    .zpa-cal-grid, .zpa-cal-dow { gap: 3px; }
+    .zpa-cal-cell { min-height: 56px; padding: 5px 4px; gap: 3px; border-radius: var(--radius-sm); }
+    .zpa-cal-cell .dnum { font-size: 12px; }
+    /* Text „Plán" sa do bunky nezmestí — ostáva bodka ako indikátor. */
+    .zpa-cal-plan { font-size: 0; gap: 0; }
+    .zpa-cal-plan .dot { width: 6px; height: 6px; }
+    .zpa-cal-plan .grams { display: none; }
+    .zpa-cal-legend { flex-wrap: wrap; gap: 10px 16px; font-size: 12px; }
+
+    /* Riadok s koeficientom diéty: názov mal pevných 180px. */
+    .zpa-coefrow { flex-wrap: wrap; }
+    .zpa-coefrow .nm { flex: 1 0 100%; }
+
+    .zpa-tplrow { flex-wrap: wrap; }
+    .zpa-tplrow .wl { margin-left: 0; }
+}
+
+/* Modál ako bottom sheet: na výšku obrazovky je stred plytvanie miestom
+ * a tlačidlá v päte sú príliš ďaleko od palca. */
+@media (max-width: 600px) {
+    .zpa-scrim { padding: 0; align-items: flex-end; }
+    .zpa-modal {
+        max-width: none;
+        max-height: 92%;
+        border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    }
+    .zpa-modal--wide { max-width: none; }
+    .zpa-modal-head { padding: 16px; }
+    .zpa-modal-body { padding: 16px; }
+    .zpa-modal-foot {
+        padding: 12px 16px;
+        padding-bottom: calc(12px + env(safe-area-inset-bottom));
+        flex-direction: column-reverse;
+    }
+    .zpa-modal-foot .zpa-btn { width: 100%; }
+}
+
+/* Dotykové ciele: 34px ikonové tlačidlo sa myšou trafí, prstom nie.
+ * Viazané na hrubý ukazovateľ, nie na šírku — dotykový tablet v šírke
+ * desktopu má rovnaký problém. */
+@media (hover: none) and (pointer: coarse) {
+    .zpa-iconbtn { width: 42px; height: 42px; }
+    .zpa-btn { padding: 12px 18px; }
+    .zpa-btn--sm { padding: 10px 14px; }
+    .zpa-tab { min-height: 46px; }
 }
 
 /* ── Celok → prevádzky (rozbaliteľný zoznam v Správe prevádzok) ── */
@@ -772,7 +896,12 @@
     display: flex; align-items: center; gap: 10px; flex: 1; min-width: 0;
     padding: 6px 0; background: none; border: none; cursor: pointer;
     text-align: left; font: inherit; color: inherit;
+    /* Bez zalomenia sa dlhý názov celku aj s odznakmi rozlial cez tlačidlá
+     * akcií vpravo (flex položky sa implicitne nezmenšujú pod svoj obsah). */
+    flex-wrap: wrap; row-gap: 6px;
 }
+.zpa-celok-toggle > span { min-width: 0; overflow-wrap: anywhere; }
+.zpa-celok-toggle .zpa-badge { flex: 0 0 auto; }
 .zpa-celok-toggle .chev { color: var(--green-600); }
 .zpa-celok-actions { display: inline-flex; gap: 4px; flex-shrink: 0; }
 .zpa-celok-body {
@@ -782,6 +911,15 @@
     overflow-x: auto;
 }
 .zpa-celok-body .zpa-table { background: transparent; }
+
+/* Štyri ikonové akcie zožerú na mobile polovicu šírky — názov celku dostane
+ * vlastný riadok a akcie sa zarovnajú pod neho doprava. Pravidlá musia stáť až
+ * za definíciami vyššie: majú rovnakú špecificitu, takže rozhoduje poradie. */
+@media (max-width: 700px) {
+    .zpa-celok-row { flex-wrap: wrap; padding: 10px 12px 10px 14px; }
+    .zpa-celok-toggle { flex: 1 1 100%; }
+    .zpa-celok-actions { margin-left: auto; }
+}
 
 /* ========================================================== *
  * Filter sekcií gramáže (raňajky / polievka / menu / olovrant)

--- a/frontend/src/pages/admin/dietReorder.test.ts
+++ b/frontend/src/pages/admin/dietReorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { dietReorderPayload, moveDietBefore } from "./dietReorder";
+import { dietReorderPayload, moveDietBefore, moveDietBy } from "./dietReorder";
 
 describe("diet reorder helpers", () => {
   it("moves the dragged diet before the drop target and renumbers the local order", () => {
@@ -18,6 +18,38 @@ describe("diet reorder helpers", () => {
       { id: 3, sort_order: 2 },
       { id: 7, sort_order: 3 },
     ]);
+  });
+
+  it("swaps a diet with its neighbour and renumbers", () => {
+    const diets = [
+      { id: 3, sort_order: 1 },
+      { id: 7, sort_order: 2 },
+      { id: 9, sort_order: 3 },
+    ];
+
+    expect(moveDietBy(diets, 9, -1)).toEqual([
+      { id: 3, sort_order: 1 },
+      { id: 9, sort_order: 2 },
+      { id: 7, sort_order: 3 },
+    ]);
+    expect(moveDietBy(diets, 3, 1)).toEqual([
+      { id: 7, sort_order: 1 },
+      { id: 3, sort_order: 2 },
+      { id: 9, sort_order: 3 },
+    ]);
+  });
+
+  it("keeps the list identical at the edges and for unknown diets", () => {
+    const diets = [
+      { id: 3, sort_order: 1 },
+      { id: 7, sort_order: 2 },
+    ];
+
+    // Rovnaká referencia, nie len rovnaký obsah — DietManager na tom stojí,
+    // keď sa rozhoduje, či vôbec posielať zápis na server.
+    expect(moveDietBy(diets, 3, -1)).toBe(diets);
+    expect(moveDietBy(diets, 7, 1)).toBe(diets);
+    expect(moveDietBy(diets, 42, 1)).toBe(diets);
   });
 
   it("builds the reorder endpoint payload from the displayed order", () => {

--- a/frontend/src/pages/admin/dietReorder.ts
+++ b/frontend/src/pages/admin/dietReorder.ts
@@ -18,6 +18,28 @@ export const moveDietBefore = <T extends ReorderableDiet>(
   return withoutMoved.map((diet, index) => ({ ...diet, sort_order: index + 1 }));
 };
 
+/**
+ * Posunie diétu o `delta` pozícií (−1 vyššie, +1 nižšie).
+ *
+ * Existuje popri `moveDietBefore`, ktoré obsluhuje ťahanie myšou: HTML5 drag &
+ * drop sa na dotykovom displeji nespustí, takže na mobile je toto jediný spôsob,
+ * ako poradie diét zmeniť. Mimo rozsah zoznamu vracia pôvodné pole (identita sa
+ * zachová, takže volajúci vie preskočiť zbytočný zápis).
+ */
+export const moveDietBy = <T extends ReorderableDiet>(
+  diets: T[],
+  dietId: number,
+  delta: number,
+): T[] => {
+  const index = diets.findIndex((diet) => diet.id === dietId);
+  const target = index + delta;
+  if (index < 0 || target < 0 || target >= diets.length) return diets;
+
+  const next = [...diets];
+  [next[index], next[target]] = [next[target], next[index]];
+  return next.map((diet, position) => ({ ...diet, sort_order: position + 1 }));
+};
+
 export const dietReorderPayload = (diets: ReorderableDiet[]) => ({
   diets: diets.map((diet, index) => ({ id: diet.id, sort_order: index + 1 })),
 });


### PR DESCRIPTION
Admin konzola sa doteraz na telefóne nedala použiť. `.zpa-app` je flex **riadok** (rail vľavo, obsah vpravo) a mobilný topbar je jeho ďalší priamy potomok — v riadku si sadol *vedľa* obsahu ako ~310px stĺpec a zvyšok appky vytlačil mimo viewport. Názvy prevádzok, dátumy aj polovica tabuliek boli mimo obrazovky.

Zmena je **čisto frontendová** — žiadny súbor v `backend/`.

## Čo je opravené

**Shell**
- pod 900px sa `.zpa-app` prepína na stĺpec: topbar hore, obsah pod ním
- safe-area insets (notch, spodná lišta)

**Zásuvka s navigáciou**
- prekrýva topbar — predtým jej hlavička s logom zmizla pod ním
- popisky sú čitateľné: rail sa na desktope rozbaľuje cez `:hover`, ktorý na dotyku neexistuje. Pôvodné mobilné pravidlá prehrávali na špecificite, lebo `:not(:hover)` sa do nej počíta — `.zpa-sidebar .lbl` (0,3,0) < `.zpa-sidebar:not(:hover) .lbl` (0,4,0)

**Obsah stránok**
- hlavičky, toolbary, riadky celkov, koeficienty diét a kalendár sa skladajú na výšku
- široké tabuľky (gramáž, logy) scrollujú vodorovne vo vlastnom `.zpa-table-wrap`, nie celou stránkou
- modály sú na mobile bottom sheet s tlačidlami na plnú šírku
- dotykové ciele 42px, viazané na `pointer: coarse` — dotykový tablet v šírke desktopu má rovnaký problém

**Poradie ťahaním → šípky**

HTML5 drag & drop sa na dotykovom displeji vôbec nespustí, takže poradie prevádzok v trase a poradie diét sa na mobile nedalo zmeniť **vôbec**. Obe dostali tlačidlá vyššie/nižšie — rovnaký vzor, aký už mali rozvozové bloky. Úchyt na ťahanie sa na dotyku skrýva, keďže nič nesľubuje. Priraďovanie prevádzky do trasy už touch-friendly bolo (select), rovnako odobratie.

**Pretečenia nájdené pri kontrole na 320px**
- detail admina: e-mail v nadpise vytekal von — flex položka bez `min-width: 0`
- systémové nastavenia: tlačidlo „Načítať z EduPage" (`white-space: nowrap`) sa vedľa poľa dátumu nezmestilo

## Testy

`frontend/e2e/admin-mobile.spec.ts` — beží len v projekte `mobile`, nad 900px sa mobilný shell nezapína:

- 12 admin obrazoviek na pretečenie do strán (meria sa dokument aj `.zpa-main`, nie jednotlivé prvky — široké tabuľky *smú* scrollovať vo vlastnom kontajneri)
- detailové obrazovky na 320px (iPhone SE) — nadpisy sú tu dáta, nie text
- ovládanie zásuvky: otvorenie nad topbarom, čitateľné popisky, zatvorenie výberom. Zásuvka sa zatvára posunom, takže sa testuje **poloha**, nie `toBeHidden()`
- presun prevádzky v trase šípkami, vrátane vypnutej šípky na kraji

Plus unit testy pre `moveDietBy` (swap, hranice, zachovanie referencie).

Overené lokálne proti dev stacku:

```
npx tsc --noEmit && npx tsc -p e2e/tsconfig.json --noEmit   # OK
npm run lint                                                 # OK
npx vitest run                                               # 239 passed
npm run build                                                # OK
npx playwright test --project=mobile admin-mobile            # 4 passed
```

Vizuálne prejdené na 390×844 a 320×844, desktop 1440×900 skontrolovaný na regresie (rail sa stále rozbaľuje hoverom).

## Pozor — nesúvisiaca chyba v `develop` zrejme zčervená CI

`e2e/tour.spec.ts` na tejto vetve padá, ale **nie kvôli tejto zmene** — padá rovnako na čistom `develop`. `PATCH /api/user/profile/` vracia 500:

```
File "/app/api/views/settings_views.py", line 46, in profile
File "/app/api/services/event_log_service.py", line 56, in build_model_diff
AttributeError: 'OneToOneRel' object has no attribute 'attname'
```

Pochádza z b06cccb (`feat(audit): zapisuj aj ostatné administrátorské zmeny`) — `build_model_diff` iteruje `_meta.get_fields()` a narazí na reverznú `OneToOne` väzbu. Netýka sa to len testov: **rozbité je ukladanie profilu pre bežného používateľa aj pre admina** (`AdminProfileModal` ide cez ten istý endpoint). Patrí to do samostatného PR-ka, tento naň len upozorňuje.

## Čo zostáva neoverené

- **iOS Safari na reálnom zariadení.** Všetko vyššie je Chromium emulujúci Pixel 7. Dve konkrétne veci, ktoré sa v emulátore neprejavia: `.zpa-input` má `font-size: 14px`, takže iOS pri fokuse zoomne stránku a už neodzoomuje; a `.zpa-gram-wrap` používa `100vh`, ktoré na iOS počíta so skrytým URL barom. Ani jedno som nemenil naslepo.
- **`AdminOrderEditorModal`** — v demo dátach sa mi ho nepodarilo otvoriť (demo prevádzky nemajú objednávky). Najzložitejší modál v adminovi, na mobile neoverený.
- **Landscape a tablet 768–900px.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zUtAguUpa2b36jBjcF18p
