### PR TITLE
fix(audit): nezhoď uloženie profilu na poli s vnoreným source

### DIFF
--- a/backend/api/services/event_log_service.py
+++ b/backend/api/services/event_log_service.py
@@ -6,7 +6,7 @@ import datetime
 from decimal import Decimal
 from typing import Any
 
-from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.db.models import Model
 
 from ..models import EventLog
@@ -30,6 +30,19 @@ def _json_value(value: Any) -> Any:
     return value
 
 
+def _related_instance(instance: Model, field_name: str) -> Model | None:
+    """Súvisiaci objekt pre vnorený ``source``, alebo ``None`` ak ešte nie je.
+
+    Reverzná ``OneToOne`` väzba pri chýbajúcom objekte vyhodí
+    ``RelatedObjectDoesNotExist`` namiesto toho, aby vrátila ``None`` — to je
+    prípad používateľa, ktorému profil vzniká až týmto zápisom.
+    """
+    try:
+        return getattr(instance, field_name, None)
+    except ObjectDoesNotExist:
+        return None
+
+
 def build_model_diff(instance: Model | None, validated_data: dict[str, Any]) -> dict:
     """Return JSON-safe ``from``/``to`` values for serializer changes.
 
@@ -38,6 +51,12 @@ def build_model_diff(instance: Model | None, validated_data: dict[str, Any]) -> 
     preskakujú: pôvodnú hodnotu z inštancie prečítať nemáme odkiaľ a vymyslené
     ``from: null`` by v audite klamalo. Bez tejto poistky navyše `get_field()`
     vyhodí `FieldDoesNotExist` a zhodí celý zápis (teda aj uloženie).
+
+    Pole s vnoreným ``source`` (``UserProfileSerializer.onboarding_completed``
+    má ``source="profile.onboarding_completed"``) príde ako vnorený dict pod
+    menom väzby. Hodnota patrí súvisiacemu objektu, nie tejto inštancii, takže
+    sa diff počíta rekurzívne a zmena sa zapíše pod bodkovaným kľúčom —
+    rovnaký tvar, aký dáva :func:`build_nested_dict_diff`.
     """
     changes = {}
     for field_name, new_value in validated_data.items():
@@ -48,12 +67,25 @@ def build_model_diff(instance: Model | None, validated_data: dict[str, Any]) -> 
                 field = instance._meta.get_field(field_name)
             except FieldDoesNotExist:
                 continue
+            if field.is_relation and isinstance(new_value, dict):
+                nested = build_model_diff(
+                    _related_instance(instance, field_name), new_value
+                )
+                for nested_name, nested_change in nested.items():
+                    changes[f"{field_name}.{nested_name}"] = nested_change
+                continue
             if field.many_to_many:
                 old_value = list(
                     getattr(instance, field_name).values_list("pk", flat=True)
                 )
             elif field.is_relation:
-                old_value = getattr(instance, field.attname)
+                # Reverzná väzba (``OneToOneRel``, ``ManyToOneRel``) nemá na
+                # inštancii vlastný stĺpec, teda ani ``attname``. Prečítať sa dá
+                # len cez súvisiaci objekt — a to rieši vetva vyššie.
+                attname = getattr(field, "attname", None)
+                if attname is None:
+                    continue
+                old_value = getattr(instance, attname)
             else:
                 old_value = getattr(instance, field_name)
         old_json = _json_value(old_value)

--- a/backend/api/tests/integration/test_admin_change_audit.py
+++ b/backend/api/tests/integration/test_admin_change_audit.py
@@ -119,6 +119,59 @@ class TestCatalogAudit:
 
 
 @pytest.mark.django_db
+class TestNestedSourceAudit:
+    """Pole s vnoreným ``source`` nesmie zhodiť zápis, ktorý audituje.
+
+    ``UserProfileSerializer.onboarding_completed`` má
+    ``source="profile.onboarding_completed"``, takže do ``validated_data`` príde
+    ako ``{"profile": {...}}``. ``User._meta.get_field("profile")`` je reverzná
+    ``OneToOneRel`` — nemá ``attname`` a diff na nej padal na ``AttributeError``.
+    Zhodil tým **celé uloženie profilu**, nielen audit.
+    """
+
+    def test_saving_a_nested_field_succeeds_and_is_recorded(
+        self, authenticated_client, user
+    ):
+        response = authenticated_client.patch(
+            "/api/user/profile/", {"onboarding_completed": True}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        user.profile.refresh_from_db()
+        assert user.profile.onboarding_completed is True
+
+        event = _changes("api.userprofile").get()
+        assert event.payload["changes"]["profile.onboarding_completed"] == {
+            "from": False,
+            "to": True,
+        }
+
+    def test_saving_works_for_a_user_who_has_no_profile_yet(
+        self, admin_client, admin_user
+    ):
+        """Reverzná väzba pri chýbajúcom objekte hádže, nevracia ``None``.
+
+        Profil vzniká až v ``update()``, takže v okamihu diffu ešte nie je —
+        naivné ``getattr`` by tu spadlo na ``RelatedObjectDoesNotExist``.
+        """
+        assert not hasattr(admin_user, "profile")
+
+        response = admin_client.patch(
+            "/api/user/profile/", {"onboarding_completed": True}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        admin_user.refresh_from_db()
+        assert admin_user.profile.onboarding_completed is True
+
+        event = _changes("api.userprofile").get()
+        assert event.payload["changes"]["profile.onboarding_completed"] == {
+            "from": None,
+            "to": True,
+        }
+
+
+@pytest.mark.django_db
 def test_sensitive_values_are_never_written_to_the_audit():
     """Audit číta každý admin — heslá a tokeny doň nesmú ani omylom."""
     from api.views.audit_mixins import _redact


### PR DESCRIPTION
`PATCH /api/user/profile/` na aktuálnom `develop` vracia **500**. Nejde len o audit: diff sa počíta **pred** `serializer.save()`, takže výnimka zhodí celé uloženie. Rozbité je ukladanie profilu pre bežného používateľa aj pre admina — `AdminProfileModal` ide cez ten istý endpoint.

```
File "/app/api/views/settings_views.py", line 46, in profile
    changes = build_model_diff(request.user, serializer.validated_data)
File "/app/api/services/event_log_service.py", line 56, in build_model_diff
    old_value = getattr(instance, field.attname)
AttributeError: 'OneToOneRel' object has no attribute 'attname'
```

## Príčina

`UserProfileSerializer.onboarding_completed` má `source="profile.onboarding_completed"`, takže DRF ho do `validated_data` vloží ako vnorený dict **pod menom väzby**, nie pod menom poľa:

```python
{"profile": {"onboarding_completed": False}}
```

`User._meta.get_field("profile")` je reverzná `OneToOneRel` (z `UserProfile.user`). Tá má `is_relation == True`, ale vlastný stĺpec na inštancii nemá — a teda ani `attname`. Vetva pre väzby si ho vypýtala a spadla.

Zaviedol to b06cccb (*feat(audit): zapisuj aj ostatné administrátorské zmeny*); predtým sa `build_model_diff` na profil nevolal.

## Oprava

Vnorený dict sa diffuje **rekurzívne** proti súvisiacemu objektu a zmena sa zapíše pod bodkovaným kľúčom:

```json
{"profile.onboarding_completed": {"from": false, "to": true}}
```

Je to rovnaký tvar, aký už produkuje `build_nested_dict_diff` v tom istom module, takže konzumenti auditu nedostávajú nový formát. Podstatné je, že zmena v audite **ostane** — jednoduchšia oprava (preskočiť reverzné väzby) by 500-ku odstránila, ale zmenu nastavenia by ticho zahodila, čo je presne to, čo mal ten audit chytať.

Reverzné väzby bez `attname` sa navyše preskakujú aj mimo tejto vetvy, aby ďalší serializer s podobným tvarom nespôsobil to isté.

## Testy

`TestNestedSourceAudit` v `test_admin_change_audit.py`, dva prípady:

1. **používateľ s profilom** — uloženie prejde a zmena je v audite pod `profile.onboarding_completed`. Bez opravy padá presne na tom `AttributeError` z produkcie (overené vrátením pôvodného súboru).
2. **používateľ bez profilu** — profil vzniká až v `update()`, takže v čase diffu ešte nie je a reverzná väzba hádže `RelatedObjectDoesNotExist` namiesto toho, aby vrátila `None`. Naivné `getattr` by tu spadlo tiež.

Overené proti dev stacku:

```
pytest                                    # 1068 passed, 1 deselected
black --check . && isort --check-only .   # OK
flake8 --select=E9,F63,F7,F82             # OK
mypy api --ignore-missing-imports         # Success: no issues in 223 source files
```

Vedľajší efekt: prechádza aj `frontend/e2e/tour.spec.ts`, ktorý na `develop` padal — `resetOnboarding()` ide cez ten istý endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zUtAguUpa2b36jBjcF18p
