### PR TITLE
feat: výdajné body, čitateľnejšia tabuľka a neznáme diéty z EduPage

### DIFF
--- a/backend/api/edupage_scraper.py
+++ b/backend/api/edupage_scraper.py
@@ -42,6 +42,26 @@ ALLOWED_DIET_NAMES = {
     "NO ZELER",
     "DIA",
 }
+
+
+def allowed_diet_names() -> set[str]:
+    """Povolené diéty = aktívne `Diet` z DB ∪ zabudovaný zoznam.
+
+    Škola pridá do EduPage novú diétu kedykoľvek (Cvernička, 17. 8. 2026). Keby sa
+    whitelist držal len v kóde, každá takáto diéta by čakala na nasadenie; takto ju
+    stačí založiť v appke a najbližší scrape ju už pozná. Zabudovaný zoznam ostáva
+    ako poistka, keby DB bola prázdna (testy, čerstvá inštalácia pred seedom).
+
+    Import modelu je lokálny zámerne — modul sa načítava aj mimo Django kontextu
+    (parser testy, skripty) a nesmie na import ťahať ORM.
+    """
+    from api.models import Diet
+
+    names = set(ALLOWED_DIET_NAMES)
+    names.update(Diet.objects.filter(is_active=True).values_list("name", flat=True))
+    return names
+
+
 DEFAULT_PORTION_NAME = "Škôlka"
 PORTION_CODE_MAP = {
     "0": "Škôlka",
@@ -262,7 +282,12 @@ class ScrapeResult:
     order_data_by_prevadzka: dict[str, dict[str, Any]] = field(default_factory=dict)
     # EduPage riadky, ktoré nesadli na žiadnu prevádzku. Neprázdne = neúplný scrape.
     unmatched_prevadzka: list[str] = field(default_factory=list)
+    # Diéty, ktoré appka nepozná. Porcie sa NEZAHADZUJÚ (celkový počet musí sedieť),
+    # zapíšu sa pod názvom z EduPage a admin ich vidí ako upozornenie.
     unmapped_letters: list[str] = field(default_factory=list)
+    # `unmapped_letters` rozpadnuté podľa prevádzky, do ktorej porcie padli.
+    # Prázdne pri jedno-prevádzkovom scrape (vtedy platí `unmapped_letters`).
+    unmapped_by_prevadzka: dict[str, list[str]] = field(default_factory=dict)
     # Scrape zlyhal štrukturálne — volajúci z toho robí "neimportuj nič".
     warnings: list[str] = field(default_factory=list)
     # Scrape prebehol, ale per-prevádzka config nesedí s realitou (škola zmenila
@@ -289,12 +314,17 @@ class EdupageScraper:
         mealsguest_url: str,
         target_date: date,
         prevadzka_matches: dict[str, list[str]] | None = None,
+        allowed_diets: set[str] | None = None,
     ) -> ScrapeResult:
         url = self._inject_date(mealsguest_url, target_date)
         html = self._fetch(url)
         config = config_pre_url(mealsguest_url)
         result = self._parse(
-            html, target_date, config=config, prevadzka_matches=prevadzka_matches
+            html,
+            target_date,
+            config=config,
+            prevadzka_matches=prevadzka_matches,
+            allowed_diets=allowed_diets,
         )
         if config is not None:
             result = apply_config(result, config)
@@ -600,6 +630,7 @@ class EdupageScraper:
         target_date: date,
         config: PrevadzkaConfig | None = None,
         prevadzka_matches: dict[str, list[str]] | None = None,
+        allowed_diets: set[str] | None = None,
     ) -> ScrapeResult:
         prehlad_raw = self._extract_block(html, "prehlad")
         nazov_menu_raw = self._extract_block(html, "nazovMenu")
@@ -609,6 +640,11 @@ class EdupageScraper:
         warnings: list[str] = []
         unmapped: list[str] = []
         attention: list[str] = []
+        # Normalizovaný index, aby `no milk` z EduPage sadlo na našu `NO MILK` a
+        # nezaložilo druhú, len inak písanú diétu.
+        allowed_by_key = {
+            _normalise_key(name): name for name in (allowed_diets or ALLOWED_DIET_NAMES)
+        }
         letter_hook = config.letter_hook if config is not None else None
         payer_hook = config.payer_hook if config is not None else None
 
@@ -636,6 +672,8 @@ class EdupageScraper:
         unmatched: list[str] = []
         # bucket (názov prevádzky) -> flagy, ktoré do neho reálne padli
         attention_buckets: dict[str, set[str]] = {}
+        # to isté pre neznáme diéty (`unmapped`)
+        unmapped_buckets: dict[str, set[str]] = {}
 
         date_key = target_date.isoformat()
         day_data = prehlad.get(date_key, {})
@@ -662,6 +700,7 @@ class EdupageScraper:
                 portion_override = rule.portion if rule else None
 
                 flag_label: str | None = None
+                unmapped_label: str | None = None
                 if rule is not None and (rule.menu or rule.diet):
                     menu_variant = rule.menu
                     diet_name = rule.diet
@@ -673,11 +712,20 @@ class EdupageScraper:
                     diet_name = None
                     if menu_variant is None:
                         diet_name = self.resolve_diet_name(skratka, nazov)
-                        if diet_name not in ALLOWED_DIET_NAMES:
-                            unmapped.append(f"{letter}:{diet_name}")
-                            continue
-                        if diet_name == letter and letter not in nazov_menu:
-                            unmapped.append(letter)
+                        canonical = allowed_by_key.get(_normalise_key(diet_name))
+                        if canonical is not None:
+                            diet_name = canonical
+                            if diet_name == letter and letter not in nazov_menu:
+                                unmapped_label = letter
+                        else:
+                            # Neznámu diétu NEZAHADZUJEME: skorší `continue` tu zmazal
+                            # celý riadok vrátane počtu porcií, takže kuchyni chýbali
+                            # jedlá a nikde to nebolo vidno (Cvernička, 17. 8. 2026).
+                            # Radšej ju zapíšeme pod názvom z EduPage a nahlásime —
+                            # admin ju založí v appke a od ďalšieho behu je známa.
+                            unmapped_label = f"{letter}:{diet_name}"
+                        if unmapped_label is not None:
+                            unmapped.append(unmapped_label)
 
                 tp = letter_data.get("typ_platitela", {})
                 if not isinstance(tp, dict):
@@ -731,6 +779,10 @@ class EdupageScraper:
                     for bucket in buckets:
                         if flag_label is not None:
                             attention_buckets.setdefault(bucket, set()).add(flag_label)
+                        if unmapped_label is not None:
+                            unmapped_buckets.setdefault(bucket, set()).add(
+                                unmapped_label
+                            )
 
                         counts_by_meal = counts.setdefault(bucket, {})
                         meal_counts = counts_by_meal.setdefault(meal_key, {})
@@ -776,7 +828,12 @@ class EdupageScraper:
             order_data=order_data,
             order_data_by_prevadzka=by_prevadzka,
             unmatched_prevadzka=sorted(set(unmatched)),
-            unmapped_letters=list(set(unmapped)),
+            unmapped_letters=sorted(set(unmapped)),
+            unmapped_by_prevadzka={
+                bucket: sorted(labels)
+                for bucket, labels in unmapped_buckets.items()
+                if bucket and labels
+            },
             warnings=warnings,
             attention=sorted(set(attention)),
             attention_by_prevadzka={

--- a/backend/api/exporters/assets/gramage-pdf.css
+++ b/backend/api/exporters/assets/gramage-pdf.css
@@ -15,6 +15,8 @@
     --line: rgba(23, 53, 5, 0.16);
     --line-soft: rgba(23, 53, 5, 0.08);
     --mustard-700: #C48116;
+    --coral-600: #C92E52;
+    --coral-logo: #D52E4E;
     --peach-400: #F7D09A;
     --bg-cream: #FBF7E4;
     --bg-cream-soft: #F5F1CD;
@@ -113,8 +115,11 @@ h1 small {
 .zpa-gram tbody .band td,
 .zpa-gram tfoot .band td,
 .zpa-gram .portion-summary-band td { padding: 1.2mm 2mm; font-size: 7pt; }
-.zpa-gram .route-row td { padding: 1.6mm 2mm 1mm; }
-.zpa-gram .route-pill { padding: 0.6mm 1.6mm; font-size: 7pt; }
+.zpa-gram .route-row td { padding: 1.4mm 2mm; }
+/* Trasa je na papieri o triedu väčšia než dáta — vodič ju hľadá očami zďaleka. */
+.zpa-gram .route-pill { padding: 0.8mm 2mm; font-size: 9pt; }
+.zpa-gram .route-pill small { font-size: 7.5pt; }
+.zpa-gram tbody .block-band td { font-size: 11pt; padding: 2mm; }
 .zpa-gram .sub-row.diet .lbl { font-size: 6.5pt; padding-left: 3mm; }
 .zpa-gram .note-admin td,
 .zpa-gram .note-delivery td { font-size: 6.5pt; padding: 1.2mm 2mm; }
@@ -135,6 +140,16 @@ h1 small {
 .zpa-gram .mh-snack-cell { background: transparent; }
 .zpa-gram .sub-row.zebra td { background: #EDEDEA; }
 
+/* Každý výdajný bod (blok) začína na vlastnom liste — kuchyňa vydáva z dvoch
+ * miest naraz a každé chce svoju tabuľku, nie polovicu spoločnej strany. */
+.zpa-gram tr.page-break { break-before: page; page-break-before: always; }
+
+/* Poznámkový stĺpec musí ostať dosť široký, aby sa doň dalo písať rukou. */
+.zpa-gram .cell-note,
+.zpa-gram thead .grp-note,
+.zpa-gram thead .comp-note { width: 22mm; }
+.zpa-gram thead .mealband { font-size: 8pt; padding: 1.2mm; }
+
 /* `tfoot` je štandardne table-footer-group a zopakoval by sa na konci každej
  * strany — celkový súčet by potom vyzeral ako medzisúčet. Patrí raz, na koniec. */
 .zpa-gram tfoot { display: table-row-group; }
@@ -142,7 +157,7 @@ h1 small {
 /* Sticky a tiene sú pre papier bezvýznamné a WeasyPrintu len prekážajú. */
 .zpa-gram thead th,
 .zpa-gram .corner { position: static; }
-.zpa-gram .meal-sep { box-shadow: none; border-left: 1px solid rgba(23, 53, 5, 0.35); }
+.zpa-gram .meal-sep { box-shadow: none; border-left: 1.2pt solid rgba(23, 53, 5, 0.55); }
 
 /* Na obrazovke je to rozbaľovacie tlačidlo; na papieri obyčajný riadok. */
 .zpa-gram .client-toggle {

--- a/backend/api/exporters/assets/gramage-pdf.css
+++ b/backend/api/exporters/assets/gramage-pdf.css
@@ -115,11 +115,12 @@ h1 small {
 .zpa-gram tbody .band td,
 .zpa-gram tfoot .band td,
 .zpa-gram .portion-summary-band td { padding: 1.2mm 2mm; font-size: 7pt; }
-.zpa-gram .route-row td { padding: 1.4mm 2mm; }
-/* Trasa je na papieri o triedu väčšia než dáta — vodič ju hľadá očami zďaleka. */
-.zpa-gram .route-pill { padding: 0.8mm 2mm; font-size: 9pt; }
-.zpa-gram .route-pill small { font-size: 7.5pt; }
-.zpa-gram tbody .block-band td { font-size: 11pt; padding: 2mm; }
+.zpa-gram .route-row td { padding: 1.2mm 2mm; }
+/* Trasa je na papieri o kúsok väčšia než dáta — vodič ju hľadá očami, ale
+ * tabuľka musí ostať čitateľná ako celok. */
+.zpa-gram .route-pill { padding: 0.5mm 1.6mm; font-size: 7.5pt; }
+.zpa-gram .route-pill small { font-size: 6.5pt; }
+.zpa-gram tbody .block-band td { font-size: 8.5pt; padding: 1.6mm 2mm; }
 .zpa-gram .sub-row.diet .lbl { font-size: 6.5pt; padding-left: 3mm; }
 .zpa-gram .note-admin td,
 .zpa-gram .note-delivery td { font-size: 6.5pt; padding: 1.2mm 2mm; }

--- a/backend/api/exporters/assets/gramage-table.css
+++ b/backend/api/exporters/assets/gramage-table.css
@@ -73,41 +73,39 @@
     text-transform: uppercase; letter-spacing: var(--tracking-caps);
     padding: 9px 16px;
 }
-/* Blok = výdajný bod kuchyne (cluster). Musí byť vidieť na prvý pohľad, že tu
- * začína druhá tabuľka — v tlači ide navyše na vlastný list. */
+/* Výdajný bod kuchyne. Vidieť, že tu začína druhá tabuľka (v tlači aj druhý
+ * list), ale bez krikľavého pásu — stačí tmavý pruh a tenká červená linka. */
 .zpa-gram tbody .block-band td {
     background: var(--green-900); color: #fff;
-    font-size: 15px; letter-spacing: 0.1em;
-    padding: 14px 16px;
-    border-top: 4px solid var(--coral-600);
+    font-size: 12px; letter-spacing: var(--tracking-caps);
+    padding: 10px 16px;
+    border-top: 2px solid var(--coral-600);
 }
-/* Trasa — celý riadok červený a o poschodie väčšie písmo. Zelený pás sa v
- * hustej tabuľke strácal a rozvoz nevedel, kde jedna trasa končí (17. 8. 2026). */
+/* Trasa — jemný červený pás. Musí byť vidieť, kde trasa začína, ale nesmie
+ * prekričať dáta: sýta výplň cez celý riadok bola priveľká (17. 8. 2026). */
 .zpa-gram .route-row td {
-    min-width: 0; padding: 10px 16px;
-    background: var(--coral-600);
-    border-top: 3px solid var(--coral-logo);
-    border-bottom: 2px solid var(--coral-logo);
+    min-width: 0; padding: 7px 16px;
+    background: rgba(201,46,82,0.07);
+    border-top: 1px solid rgba(201,46,82,0.35);
+    border-bottom: 1px solid rgba(201,46,82,0.16);
 }
 .zpa-gram .route-pill {
-    display: inline-flex; align-items: center; gap: 10px; max-width: 100%;
-    padding: 6px 12px; border-radius: var(--radius-pill);
+    display: inline-flex; align-items: center; gap: 8px; max-width: 100%;
+    padding: 3px 10px; border-radius: var(--radius-pill);
     background: #fff; color: var(--coral-600);
-    border: 1px solid rgba(255,255,255,0.9);
-    box-shadow: 0 1px 0 rgba(23,53,5,0.08);
-    font-family: var(--font-display); font-weight: 700; font-size: 15px;
-    text-transform: uppercase; letter-spacing: 0.02em;
+    border: 1px solid rgba(201,46,82,0.30);
+    font-family: var(--font-display); font-weight: 700; font-size: 13px;
 }
 .zpa-gram .route-pill::before {
-    content: ""; width: 8px; height: 8px; border-radius: 999px;
+    content: ""; width: 6px; height: 6px; border-radius: 999px;
     background: var(--coral-600); flex: 0 0 auto;
 }
 .zpa-gram .route-pill > span {
     min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .zpa-gram .route-pill small {
-    flex: 0 0 auto; color: var(--coral-600);
-    font-family: var(--font-sans); font-size: 12px; font-weight: 600;
+    flex: 0 0 auto; color: var(--ink-3);
+    font-family: var(--font-sans); font-size: 11px; font-weight: 600;
 }
 .zpa-gram .portion-summary-band td {
     background: rgba(255,201,92,0.18); color: var(--mustard-700);

--- a/backend/api/exporters/assets/gramage-table.css
+++ b/backend/api/exporters/assets/gramage-table.css
@@ -34,13 +34,28 @@
     box-shadow: 0 1px 0 rgba(23,53,5,0.16);
 }
 .zpa-gram thead th { background-clip: padding-box; }
-.zpa-gram .meal-sep { box-shadow: inset 1px 0 rgba(23,53,5,0.22); }
-.zpa-gram thead .meal-sep { box-shadow: inset 1px 0 rgba(255,255,255,0.32); }
+/* Predel medzi jedlami je hrubší než mriežka riadkov — kuchyňa v tabuľke
+ * hľadala, kde končia raňajky a začína obed (spätná väzba 17. 8. 2026). */
+.zpa-gram .meal-sep { box-shadow: inset 3px 0 rgba(23,53,5,0.38); }
+.zpa-gram thead .meal-sep { box-shadow: inset 3px 0 rgba(255,255,255,0.55); }
 .zpa-gram thead .grp { color: #fff; text-align: center; font-family: var(--font-display); font-weight: 700; font-size: 12.5px; }
 .zpa-gram thead .grp small { display: block; max-width: 128px; margin: 0 auto; font-weight: 400; font-size: 10px; opacity: 0.8; text-transform: none; letter-spacing: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .zpa-gram thead .comp { color: #fff; text-align: center; font-size: 11px; font-weight: 500; }
 .zpa-gram thead .comp small { display: block; font-size: 9.5px; opacity: 0.7; white-space: nowrap; }
 .zpa-gram .corner { background: var(--green-900); color: var(--bg-cream); text-align: left; font-family: var(--font-display); font-weight: 700; font-size: 12px; position: sticky; left: 0; z-index: 7; }
+/* Nadradený pás hlavičky — jedno políčko na jedlo (Raňajky / Obed / Olovrant). */
+.zpa-gram thead .mealband {
+    color: #fff; text-align: center;
+    font-family: var(--font-display); font-weight: 700; font-size: 13px;
+    text-transform: uppercase; letter-spacing: var(--tracking-caps);
+    padding: 8px;
+}
+.zpa-gram thead .mb-break { background: #8A5709; }
+.zpa-gram thead .mb-lunch { background: #24310E; }
+.zpa-gram thead .mb-snack { background: #63283F; }
+.zpa-gram thead .mb-other { background: var(--green-800); }
+.zpa-gram thead .mb-note { background: var(--green-900); }
+
 /* meal hues */
 /* meal hues — seven visually distinct families (raňajky ≠ olovrant;
  * Menu A/B/C/V each its own colour). -1 header, -2 sub-header, -cell tint. */
@@ -58,30 +73,41 @@
     text-transform: uppercase; letter-spacing: var(--tracking-caps);
     padding: 9px 16px;
 }
+/* Blok = výdajný bod kuchyne (cluster). Musí byť vidieť na prvý pohľad, že tu
+ * začína druhá tabuľka — v tlači ide navyše na vlastný list. */
+.zpa-gram tbody .block-band td {
+    background: var(--green-900); color: #fff;
+    font-size: 15px; letter-spacing: 0.1em;
+    padding: 14px 16px;
+    border-top: 4px solid var(--coral-600);
+}
+/* Trasa — celý riadok červený a o poschodie väčšie písmo. Zelený pás sa v
+ * hustej tabuľke strácal a rozvoz nevedel, kde jedna trasa končí (17. 8. 2026). */
 .zpa-gram .route-row td {
-    min-width: 0; padding: 12px 16px 7px;
-    background: linear-gradient(180deg, rgba(114,136,75,0.08), rgba(114,136,75,0.03));
-    border-top: 2px solid rgba(114,136,75,0.28);
-    border-bottom: 1px solid rgba(114,136,75,0.14);
+    min-width: 0; padding: 10px 16px;
+    background: var(--coral-600);
+    border-top: 3px solid var(--coral-logo);
+    border-bottom: 2px solid var(--coral-logo);
 }
 .zpa-gram .route-pill {
     display: inline-flex; align-items: center; gap: 10px; max-width: 100%;
-    padding: 6px 10px 6px 12px; border-radius: var(--radius-pill);
-    background: #fff; color: var(--green-900);
-    border: 1px solid rgba(114,136,75,0.28);
-    box-shadow: 0 1px 0 rgba(23,53,5,0.04);
-    font-family: var(--font-display); font-weight: 700; font-size: 12.5px;
+    padding: 6px 12px; border-radius: var(--radius-pill);
+    background: #fff; color: var(--coral-600);
+    border: 1px solid rgba(255,255,255,0.9);
+    box-shadow: 0 1px 0 rgba(23,53,5,0.08);
+    font-family: var(--font-display); font-weight: 700; font-size: 15px;
+    text-transform: uppercase; letter-spacing: 0.02em;
 }
 .zpa-gram .route-pill::before {
-    content: ""; width: 7px; height: 7px; border-radius: 999px;
-    background: var(--green-600); flex: 0 0 auto;
+    content: ""; width: 8px; height: 8px; border-radius: 999px;
+    background: var(--coral-600); flex: 0 0 auto;
 }
 .zpa-gram .route-pill > span {
     min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .zpa-gram .route-pill small {
-    flex: 0 0 auto; color: var(--ink-3);
-    font-family: var(--font-sans); font-size: 11px; font-weight: 600;
+    flex: 0 0 auto; color: var(--coral-600);
+    font-family: var(--font-sans); font-size: 12px; font-weight: 600;
 }
 .zpa-gram .portion-summary-band td {
     background: rgba(255,201,92,0.18); color: var(--mustard-700);
@@ -147,6 +173,12 @@
 .zpa-gram .note-delivery td { background: rgba(255,201,92,0.14); color: var(--mustard-700); }
 .zpa-gram .note-admin strong,
 .zpa-gram .note-delivery strong { font-family: var(--font-display); }
+
+/* Prázdny stĺpec „Poznámka" — kuchyňa doň píše rukou do vytlačenej tabuľky,
+ * na obrazovke ostáva prázdny. */
+.zpa-gram .cell-note { background: rgba(255,255,255,0.55); min-width: 120px; }
+.zpa-gram thead .grp-note,
+.zpa-gram thead .comp-note { background: var(--green-900); }
 
 /* Farebná bodka pred názvom diéty. Na obrazovke ju kreslí DietColorSwatch,
  * v PDF gramage_table_html._swatch — obe len dosadia `background`. */

--- a/backend/api/exporters/gramage_dashboard_export.py
+++ b/backend/api/exporters/gramage_dashboard_export.py
@@ -224,24 +224,3 @@ def readable_text_color(hex_color: str) -> str:
             break
         rgb = [round(channel * 0.85) for channel in rgb]
     return "".join(f"{channel:02X}" for channel in rgb)
-
-
-def flat_client_rows(data: dict) -> list[dict]:
-    """All per-client rows, whether or not the day has a delivery-block layout.
-
-    ``data["rows"]`` only holds every row when there is no block layout; once
-    ``blocks``/``unassigned_rows`` are populated those replace it as the
-    source of truth. Both PDF and XLSX exporters need the full row set (e.g.
-    for the CELKOM totals row), so compute it once here.
-    """
-    blocks = data.get("blocks") or []
-    if not blocks:
-        return list(data.get("rows") or [])
-    flat = [
-        row
-        for block in blocks
-        for route in block.get("routes", [])
-        for row in route.get("rows", [])
-    ]
-    flat.extend(data.get("unassigned_rows") or [])
-    return flat

--- a/backend/api/exporters/gramage_table_html.py
+++ b/backend/api/exporters/gramage_table_html.py
@@ -162,14 +162,28 @@ def render_table(spec: dict) -> str:
         f"<small>{escape(str(component.get('sub') or ''))}</small></th>"
         for component in header.get("components") or []
     )
+    meals = "".join(
+        f"<th{_attrs(**{'class': band.get('css'), 'colspan': band.get('colspan')})}>"
+        f"{escape(str(band.get('text') or ''))}</th>"
+        for band in header.get("meals") or []
+    )
     body = "".join(_row(row) for row in spec.get("rows") or [])
     footer = "".join(_row(row) for row in spec.get("footer") or [])
 
+    # Hlavička má tri poschodia (jedlo → stĺpcová skupina → zložka). Rohová bunka
+    # ich preklenie všetky, preto sa `rowspan` odvíja od toho, či spec pás jedál
+    # nesie — bez neho ostáva hlavička dvojposchodová.
+    corner = (
+        f'<th class="corner" rowspan="{3 if meals else 2}">'
+        f"{escape(str(header.get('corner') or ''))}</th>"
+    )
+    head_rows = ([f"<tr>{corner}{meals}</tr>"] if meals else []) + [
+        f"<tr>{groups}</tr>" if meals else f"<tr>{corner}{groups}</tr>",
+        f"<tr>{components}</tr>",
+    ]
     return (
         '<table class="zpa-gram">'
-        f'<thead><tr><th class="corner" rowspan="2">'
-        f"{escape(str(header.get('corner') or ''))}</th>{groups}</tr>"
-        f"<tr>{components}</tr></thead>"
+        f"<thead>{''.join(head_rows)}</thead>"
         f"<tbody>{body}</tbody>"
         f"<tfoot>{footer}</tfoot>"
         "</table>"

--- a/backend/api/exporters/gramage_table_spec.py
+++ b/backend/api/exporters/gramage_table_spec.py
@@ -27,6 +27,24 @@ from .gramage_dashboard_export import (
 
 EMPTY = "—"
 
+# Prázdny stĺpec na ručné poznámky pri tlači (požiadavka prevádzky 17. 8. 2026).
+NOTE_COLUMN_LABEL = "Poznámka"
+
+# Ktoré stĺpcové skupiny patria pod ktoré jedlo. Kuchyňa čítala tabuľku ako jeden
+# pás stĺpcov a hľadala, kde končia raňajky a začína obed — hlavička preto nesie
+# ešte jednu, nadradenú úroveň s názvom jedla.
+_MEAL_BANDS: dict[str, str] = {
+    "breakfast_snack": "Raňajky / desiata",
+    "soup": "Obed",
+    "main_course": "Obed",
+    "afternoon_snack": "Olovrant",
+}
+_MEAL_BAND_CSS: dict[str, str] = {
+    "Raňajky / desiata": "mb-break",
+    "Obed": "mb-lunch",
+    "Olovrant": "mb-snack",
+}
+
 
 def _decimal_text(value: Decimal) -> str:
     """Číslo do bunky: bez chvostových núl, s desatinnou čiarkou.
@@ -92,8 +110,19 @@ def _filter_col_groups(col_groups: list[dict], sections: list[str] | None) -> li
     return keep or list(range(len(col_groups)))
 
 
+def _note_cell() -> dict:
+    """Prázdna bunka posledného stĺpca — miesto na ručnú poznámku vo vytlačenej
+    tabuľke. Vracia sa nová inštancia, nie zdieľaný dict, nech si ju renderer
+    nemôže omylom premutovať naprieč riadkami."""
+    return {"text": "", "css": "cell-note"}
+
+
 def _gram_cells(col_grams: list, groups: list[dict], hues: list[str]) -> list[dict]:
-    """Bunky s gramážou pre jeden riadok, vrátane oddeľovača medzi jedlami."""
+    """Bunky s gramážou pre jeden riadok, vrátane oddeľovača medzi jedlami.
+
+    Na konci vždy pribudne prázdna bunka stĺpca „Poznámka" — je súčasťou každého
+    dátového riadku, takže ju dopĺňa jedno miesto namiesto každého volajúceho.
+    """
     cells = []
     for position, (group_index, group) in enumerate(groups):
         grams = []
@@ -112,6 +141,7 @@ def _gram_cells(col_grams: list, groups: list[dict], hues: list[str]) -> list[di
                         "css": f"cell-num mh-{hues[position]}-cell{separator}",
                     }
                 )
+    cells.append(_note_cell())
     return cells
 
 
@@ -140,7 +170,8 @@ def build_table_spec(data: dict, sections: list[str] | None = None) -> dict:
     hues = [meal_hue(g.get("meal"), g.get("variant")) for _, g in groups]
 
     total_components = sum(len(g.get("components") or []) for _, g in groups)
-    total_columns = 1 + total_components
+    # 1 = názov prevádzky/riadku, +1 = prázdny stĺpec „Poznámka" na konci.
+    total_columns = 1 + total_components + 1
 
     header = _build_header(groups, hues)
     rows: list[dict] = []
@@ -148,7 +179,17 @@ def build_table_spec(data: dict, sections: list[str] | None = None) -> dict:
     blocks = data.get("blocks") or []
     if blocks:
         for block_index, block in enumerate(blocks):
-            rows.append(_band("block-band", block.get("name") or "", total_columns))
+            # Bloky sú výdajné body kuchyne (cluster 1 / cluster 2) — v tlači ide
+            # každý na vlastný list, aby si ich dva body vedeli rozdať bez
+            # hľadania, kde jeden končí.
+            rows.append(
+                _band(
+                    "block-band",
+                    block.get("name") or "",
+                    total_columns,
+                    css="band block-band" + (" page-break" if block_index else ""),
+                )
+            )
             for route in block.get("routes") or []:
                 route_rows = route.get("rows") or []
                 # Prázdne trasy sa nevykresľujú — obrazovka ich tiež preskakuje.
@@ -176,7 +217,14 @@ def build_table_spec(data: dict, sections: list[str] | None = None) -> dict:
             )
         unassigned = data.get("unassigned_rows") or []
         if unassigned:
-            rows.append(_band("block-band", "Nepriradené prevádzky", total_columns))
+            rows.append(
+                _band(
+                    "block-band",
+                    "Nepriradené prevádzky",
+                    total_columns,
+                    css="band block-band page-break",
+                )
+            )
             for client_row in unassigned:
                 rows.extend(_client_rows(client_row, data, groups, hues, total_columns))
     else:
@@ -212,6 +260,32 @@ def build_table_spec(data: dict, sections: list[str] | None = None) -> dict:
     }
 
 
+def _meal_band_cells(groups: list[dict]) -> list[dict]:
+    """Nadradený pás hlavičky: Raňajky / Obed / Olovrant.
+
+    Susedné stĺpcové skupiny toho istého jedla sa zlejú do jednej bunky (polievka
+    a všetky menu tvoria jeden „Obed"), takže hranica medzi jedlami je vidieť ako
+    jeden švík, nie ako séria malých nadpisov.
+    """
+    cells: list[dict] = []
+    for _, group in groups:
+        span = len(group.get("components") or [])
+        if not span:
+            continue
+        label = _MEAL_BANDS.get(str(group.get("meal") or ""), "Ostatné")
+        if cells and cells[-1]["text"] == label:
+            cells[-1]["colspan"] += span
+            continue
+        css = _MEAL_BAND_CSS.get(label, "mb-other")
+        separator = " meal-sep" if cells else ""
+        cells.append(
+            {"text": label, "css": f"mealband {css}{separator}", "colspan": span}
+        )
+    if cells:
+        cells.append({"text": "", "css": "mealband mb-note meal-sep", "colspan": 1})
+    return cells
+
+
 def _build_header(groups: list[dict], hues: list[str]) -> dict:
     group_cells = []
     component_cells = []
@@ -237,17 +311,27 @@ def _build_header(groups: list[dict], hues: list[str]) -> dict:
                     "css": f"comp mh-{hues[position]}-2{component_separator}",
                 }
             )
+    group_cells.append(
+        {
+            "text": NOTE_COLUMN_LABEL,
+            "sub": "",
+            "css": "grp grp-note meal-sep",
+            "colspan": 1,
+        }
+    )
+    component_cells.append({"text": "", "sub": "", "css": "comp comp-note meal-sep"})
     return {
         "corner": "Prevádzka / Riadok",
+        "meals": _meal_band_cells(groups),
         "groups": group_cells,
         "components": component_cells,
     }
 
 
-def _band(kind: str, text: str, total_columns: int) -> dict:
+def _band(kind: str, text: str, total_columns: int, css: str = "band") -> dict:
     return {
         "kind": kind,
-        "css": "band",
+        "css": css,
         "cells": [{"text": text, "colspan": total_columns}],
     }
 
@@ -447,6 +531,7 @@ def _totals_row(
             text = format_gram(raw)
             separator = " meal-sep" if position > 0 and component_index == 0 else ""
             cells.append({"text": text or EMPTY, "css": separator.strip()})
+    cells.append(_note_cell())
     return {
         "kind": "total",
         "css": "total",

--- a/backend/api/exporters/gramage_table_spec.py
+++ b/backend/api/exporters/gramage_table_spec.py
@@ -162,7 +162,48 @@ def _label_cell(text: str, count: object, css: str = "lbl", **extra) -> dict:
     return cell
 
 
-def build_table_spec(data: dict, sections: list[str] | None = None) -> dict:
+def _filter_blocks(all_blocks: list[dict], selected: list[str] | None) -> list[int]:
+    """Indexy blokov (výdajných bodov), ktoré sa majú vykresliť.
+
+    Blok je cluster kuchyne — vyberá sa podľa názvu, lebo to je to isté, čo vidí
+    používateľ v prepínači, a názov je v `DeliveryBlock` unikátny. Prázdny výber
+    aj neznámy názov padnú späť na celú tabuľku (rovnako ako filter sekcií), aby
+    preklep v URL nevrátil prázdnu stranu.
+    """
+    if not selected:
+        return list(range(len(all_blocks)))
+    wanted = {str(name) for name in selected}
+    keep = [
+        index
+        for index, block in enumerate(all_blocks)
+        if str(block.get("name") or "") in wanted
+    ]
+    return keep or list(range(len(all_blocks)))
+
+
+def _totals_from_summary(summary: list[dict]) -> list[list]:
+    """Riadok CELKOM z už spočítaného súhrnu porcií.
+
+    `data["totals"]` platí pre celý deň. Keď sa tlačí len jeden výdajný bod, sedeli
+    by v pätke gramáže druhého bodu — preto sa pri filtrovaní celkom počíta z tých
+    istých riadkov, z ktorých sa počítal súhrn (`portion_summary(data, rows)`
+    plní gramáž do stĺpca vlastnej skupiny, viď `portion_summary`).
+    """
+    return [
+        (
+            (item.get("col_grams") or [])[index]
+            if index < len(item.get("col_grams") or [])
+            else []
+        )
+        for index, item in enumerate(summary)
+    ]
+
+
+def build_table_spec(
+    data: dict,
+    sections: list[str] | None = None,
+    block_names: list[str] | None = None,
+) -> dict:
     """Prevedie payload z `gramage_dashboard()` na hotový popis tabuľky."""
     all_groups = data.get("col_groups") or []
     keep = _filter_col_groups(all_groups, sections)
@@ -176,7 +217,12 @@ def build_table_spec(data: dict, sections: list[str] | None = None) -> dict:
     header = _build_header(groups, hues)
     rows: list[dict] = []
 
-    blocks = data.get("blocks") or []
+    all_blocks = data.get("blocks") or []
+    keep_blocks = _filter_blocks(all_blocks, block_names)
+    blocks = [all_blocks[index] for index in keep_blocks]
+    # Filter na konkrétny výdajný bod je „vytlač túto tabuľku" — nepriradené
+    # prevádzky doň nepatria a v celej tabuľke sa aj tak ukážu.
+    filtered_blocks = len(blocks) != len(all_blocks)
     if blocks:
         for block_index, block in enumerate(blocks):
             # Bloky sú výdajné body kuchyne (cluster 1 / cluster 2) — v tlači ide
@@ -215,7 +261,7 @@ def build_table_spec(data: dict, sections: list[str] | None = None) -> dict:
                     total_columns,
                 )
             )
-        unassigned = data.get("unassigned_rows") or []
+        unassigned = [] if filtered_blocks else (data.get("unassigned_rows") or [])
         if unassigned:
             rows.append(
                 _band(
@@ -231,15 +277,28 @@ def build_table_spec(data: dict, sections: list[str] | None = None) -> dict:
         for client_row in data.get("rows") or []:
             rows.extend(_client_rows(client_row, data, groups, hues, total_columns))
 
+    if filtered_blocks:
+        visible_rows = [
+            row
+            for block in blocks
+            for route in block.get("routes") or []
+            for row in route.get("rows") or []
+        ]
+        footer_summary = portion_summary(data, visible_rows)
+        footer_totals = _totals_from_summary(footer_summary)
+    else:
+        footer_summary = portion_summary(data)
+        footer_totals = data.get("totals") or []
+
     footer = _portion_summary_rows(
         "Porcie celkom",
-        portion_summary(data),
+        footer_summary,
         keep,
         groups,
         hues,
         total_columns,
     )
-    footer.append(_totals_row(data, keep, groups, hues))
+    footer.append(_totals_row(footer_totals, keep, groups, hues))
 
     return {
         "date": data.get("date"),
@@ -256,6 +315,15 @@ def build_table_spec(data: dict, sections: list[str] | None = None) -> dict:
                 "selected": index in set(keep),
             }
             for index, group in enumerate(all_groups)
+        ],
+        # Prepínače výdajných bodov (clusterov) — tiež zo VŠETKÝCH blokov, nech sa
+        # odfiltrovaný dá zapnúť späť.
+        "blocks": [
+            {
+                "name": str(block.get("name") or ""),
+                "selected": index in set(keep_blocks),
+            }
+            for index, block in enumerate(all_blocks)
         ],
     }
 
@@ -520,9 +588,8 @@ def _portion_summary_rows(
 
 
 def _totals_row(
-    data: dict, keep: list[int], groups: list[dict], hues: list[str]
+    totals: list, keep: list[int], groups: list[dict], hues: list[str]
 ) -> dict:
-    totals = data.get("totals") or []
     cells = []
     for position, (group_index, group) in enumerate(groups):
         values = totals[group_index] if group_index < len(totals) else []

--- a/backend/api/exporters/gramage_table_spec.py
+++ b/backend/api/exporters/gramage_table_spec.py
@@ -162,23 +162,22 @@ def _label_cell(text: str, count: object, css: str = "lbl", **extra) -> dict:
     return cell
 
 
-def _filter_blocks(all_blocks: list[dict], selected: list[str] | None) -> list[int]:
-    """Indexy blokov (výdajných bodov), ktoré sa majú vykresliť.
+def _filter_vydaje(all_vydaje: list[dict], selected: list[str] | None) -> list[int]:
+    """Indexy výdajných bodov, ktoré sa majú vykresliť.
 
-    Blok je cluster kuchyne — vyberá sa podľa názvu, lebo to je to isté, čo vidí
-    používateľ v prepínači, a názov je v `DeliveryBlock` unikátny. Prázdny výber
-    aj neznámy názov padnú späť na celú tabuľku (rovnako ako filter sekcií), aby
-    preklep v URL nevrátil prázdnu stranu.
+    Výdaj sa vyberá kľúčom (`A`, `B` …), nie názvom — názov je len popiska a môže
+    sa zmeniť. Prázdny výber aj neznámy kľúč padnú späť na celú tabuľku (rovnako
+    ako filter sekcií), aby preklep v URL nevrátil prázdnu stranu.
     """
     if not selected:
-        return list(range(len(all_blocks)))
-    wanted = {str(name) for name in selected}
+        return list(range(len(all_vydaje)))
+    wanted = {str(key) for key in selected}
     keep = [
         index
-        for index, block in enumerate(all_blocks)
-        if str(block.get("name") or "") in wanted
+        for index, vydaj in enumerate(all_vydaje)
+        if str(vydaj.get("key") or "") in wanted
     ]
-    return keep or list(range(len(all_blocks)))
+    return keep or list(range(len(all_vydaje)))
 
 
 def _totals_from_summary(summary: list[dict]) -> list[list]:
@@ -202,7 +201,7 @@ def _totals_from_summary(summary: list[dict]) -> list[list]:
 def build_table_spec(
     data: dict,
     sections: list[str] | None = None,
-    block_names: list[str] | None = None,
+    vydaje: list[str] | None = None,
 ) -> dict:
     """Prevedie payload z `gramage_dashboard()` na hotový popis tabuľky."""
     all_groups = data.get("col_groups") or []
@@ -217,26 +216,25 @@ def build_table_spec(
     header = _build_header(groups, hues)
     rows: list[dict] = []
 
-    all_blocks = data.get("blocks") or []
-    keep_blocks = _filter_blocks(all_blocks, block_names)
-    blocks = [all_blocks[index] for index in keep_blocks]
+    all_vydaje = data.get("vydaje") or []
+    keep_vydaje = _filter_vydaje(all_vydaje, vydaje)
+    shown_vydaje = [all_vydaje[index] for index in keep_vydaje]
     # Filter na konkrétny výdajný bod je „vytlač túto tabuľku" — nepriradené
     # prevádzky doň nepatria a v celej tabuľke sa aj tak ukážu.
-    filtered_blocks = len(blocks) != len(all_blocks)
-    if blocks:
-        for block_index, block in enumerate(blocks):
-            # Bloky sú výdajné body kuchyne (cluster 1 / cluster 2) — v tlači ide
-            # každý na vlastný list, aby si ich dva body vedeli rozdať bez
-            # hľadania, kde jeden končí.
+    filtered = len(shown_vydaje) != len(all_vydaje)
+    if shown_vydaje:
+        for position, vydaj in enumerate(shown_vydaje):
+            # Výdajný bod je najvyššia úroveň tabuľky — v tlači ide každý na
+            # vlastný list, nech si ho jeho obsluha vezme celý.
             rows.append(
                 _band(
                     "block-band",
-                    block.get("name") or "",
+                    vydaj.get("name") or "",
                     total_columns,
-                    css="band block-band" + (" page-break" if block_index else ""),
+                    css="band block-band" + (" page-break" if position else ""),
                 )
             )
-            for route in block.get("routes") or []:
+            for route in vydaj.get("routes") or []:
                 route_rows = route.get("rows") or []
                 # Prázdne trasy sa nevykresľujú — obrazovka ich tiež preskakuje.
                 if not route_rows:
@@ -246,22 +244,22 @@ def build_table_spec(
                     rows.extend(
                         _client_rows(client_row, data, groups, hues, total_columns)
                     )
-            block_rows = [
+            vydaj_rows = [
                 r
-                for route in block.get("routes") or []
+                for route in vydaj.get("routes") or []
                 for r in route.get("rows") or []
             ]
             rows.extend(
                 _portion_summary_rows(
-                    f"Súhrn porcií {block_index + 1}",
-                    portion_summary(data, block_rows),
+                    f"Súhrn porcií — {vydaj.get('name') or position + 1}",
+                    portion_summary(data, vydaj_rows),
                     keep,
                     groups,
                     hues,
                     total_columns,
                 )
             )
-        unassigned = [] if filtered_blocks else (data.get("unassigned_rows") or [])
+        unassigned = [] if filtered else (data.get("unassigned_rows") or [])
         if unassigned:
             rows.append(
                 _band(
@@ -277,11 +275,11 @@ def build_table_spec(
         for client_row in data.get("rows") or []:
             rows.extend(_client_rows(client_row, data, groups, hues, total_columns))
 
-    if filtered_blocks:
+    if filtered:
         visible_rows = [
             row
-            for block in blocks
-            for route in block.get("routes") or []
+            for vydaj in shown_vydaje
+            for route in vydaj.get("routes") or []
             for row in route.get("rows") or []
         ]
         footer_summary = portion_summary(data, visible_rows)
@@ -316,14 +314,15 @@ def build_table_spec(
             }
             for index, group in enumerate(all_groups)
         ],
-        # Prepínače výdajných bodov (clusterov) — tiež zo VŠETKÝCH blokov, nech sa
-        # odfiltrovaný dá zapnúť späť.
-        "blocks": [
+        # Prepínače výdajných bodov — tiež zo VŠETKÝCH, nech sa odfiltrovaný dá
+        # zapnúť späť.
+        "vydaje": [
             {
-                "name": str(block.get("name") or ""),
-                "selected": index in set(keep_blocks),
+                "key": str(vydaj.get("key") or ""),
+                "name": str(vydaj.get("name") or ""),
+                "selected": index in set(keep_vydaje),
             }
-            for index, block in enumerate(all_blocks)
+            for index, vydaj in enumerate(all_vydaje)
         ],
     }
 

--- a/backend/api/management/commands/seed_real_delivery_layout.py
+++ b/backend/api/management/commands/seed_real_delivery_layout.py
@@ -13,7 +13,7 @@ from typing import Iterable
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
-from api.models import Celok, DeliveryBlock, DeliveryRoute, Diet, Prevadzka
+from api.models import Celok, DeliveryBlock, DeliveryRoute, Diet, Prevadzka, Vydaj
 
 
 @dataclass(frozen=True)
@@ -527,12 +527,21 @@ def _upsert_prevadzka(
         adresa=row.address or "",
         delivery_route=route,
         delivery_sort_order=sort_order,
+        # Výdajný bod hádame z bloku len pri ZAKLADANÍ. Existujúcim prevádzkam ho
+        # seed neprepisuje: výdaj si prevádzka nastavuje sama a seed beží pri
+        # každom nasadení — prepis by jej voľbu zakaždým zahodil.
+        vydaj=_vydaj_pre_blok(route),
         report_alias=row.alias,
         delivery_note=row.note,
         is_active=True,
     )
     prevadzka.save()
     return prevadzka
+
+
+def _vydaj_pre_blok(route: DeliveryRoute) -> str:
+    """Extra blok vozí druhý výdajný bod kuchyne, zvyšok prvý."""
+    return str(Vydaj.B if route.block.include_in_extra_summary else Vydaj.A)
 
 
 def _find_existing_prevadzka(row: DeliverySeedRow) -> Prevadzka | None:

--- a/backend/api/management/commands/seed_real_delivery_layout.py
+++ b/backend/api/management/commands/seed_real_delivery_layout.py
@@ -459,14 +459,26 @@ class Command(BaseCommand):
 
         routes: dict[str, DeliveryRoute] = {}
         for block_name, route_name, sort_order in ROUTES:
-            route, _ = DeliveryRoute.objects.update_or_create(
+            # Výdaj sa nastavuje len pri ZALOŽENÍ trasy (extra blok = druhý
+            # výdajný bod). Existujúcim trasám ho seed neprepisuje: beží pri
+            # každom nasadení a prepis by ručnú voľbu zakaždým zahodil.
+            route, _ = DeliveryRoute.objects.get_or_create(
                 name=route_name,
                 defaults={
                     "block": blocks[block_name],
                     "sort_order": sort_order,
                     "is_active": True,
+                    "vydaj": (
+                        Vydaj.B
+                        if blocks[block_name].include_in_extra_summary
+                        else Vydaj.A
+                    ),
                 },
             )
+            DeliveryRoute.objects.filter(pk=route.pk).update(
+                block=blocks[block_name], sort_order=sort_order, is_active=True
+            )
+            route.refresh_from_db()
             routes[route_name] = route
 
         for route_name, rows in _rows_by_route().items():
@@ -527,21 +539,12 @@ def _upsert_prevadzka(
         adresa=row.address or "",
         delivery_route=route,
         delivery_sort_order=sort_order,
-        # Výdajný bod hádame z bloku len pri ZAKLADANÍ. Existujúcim prevádzkam ho
-        # seed neprepisuje: výdaj si prevádzka nastavuje sama a seed beží pri
-        # každom nasadení — prepis by jej voľbu zakaždým zahodil.
-        vydaj=_vydaj_pre_blok(route),
         report_alias=row.alias,
         delivery_note=row.note,
         is_active=True,
     )
     prevadzka.save()
     return prevadzka
-
-
-def _vydaj_pre_blok(route: DeliveryRoute) -> str:
-    """Extra blok vozí druhý výdajný bod kuchyne, zvyšok prvý."""
-    return str(Vydaj.B if route.block.include_in_extra_summary else Vydaj.A)
 
 
 def _find_existing_prevadzka(row: DeliverySeedRow) -> Prevadzka | None:

--- a/backend/api/migrations/0069_prevadzka_vydaj.py
+++ b/backend/api/migrations/0069_prevadzka_vydaj.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+
+
+def rozdel_prevadzky_do_vydajov(apps, schema_editor):
+    """Prevádzky z extra blokov presuň do výdaja B, zvyšok ostáva v A.
+
+    Rozdelenie na dva výdajné body dnes reálne existuje ako blok „Trasa extra"
+    (`include_in_extra_summary`), len je zamknuté v rozvozovej štruktúre. Tento
+    krok ho prepíše do vlastnosti prevádzky, aby nastavenie prežilo aj zmeny
+    trás. Blokový príznak je spoľahlivejší než názov — ten si prevádzka
+    premenúva.
+    """
+    Prevadzka = apps.get_model("api", "Prevadzka")
+    Prevadzka.objects.filter(
+        delivery_route__block__include_in_extra_summary=True
+    ).update(vydaj="B")
+
+
+def vsetko_spat_do_a(apps, schema_editor):
+    Prevadzka = apps.get_model("api", "Prevadzka")
+    Prevadzka.objects.update(vydaj="A")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0068_alter_eventlog_event_type"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="prevadzka",
+            name="vydaj",
+            field=models.CharField(
+                choices=[("A", "Výdaj A"), ("B", "Výdaj B"), ("C", "Výdaj C")],
+                db_index=True,
+                default="A",
+                help_text=(
+                    "Výdajný bod kuchyne, z ktorého sa prevádzka vydáva. Podľa "
+                    "neho sa delí gramážová tabuľka aj tlač; trasa ostáva "
+                    "nezávislá."
+                ),
+                max_length=1,
+            ),
+        ),
+        migrations.RunPython(rozdel_prevadzky_do_vydajov, vsetko_spat_do_a),
+    ]

--- a/backend/api/migrations/0070_alter_dailyorder_scrape_flags.py
+++ b/backend/api/migrations/0070_alter_dailyorder_scrape_flags.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Len `help_text`: `scrape_flags` odteraz nesie aj `unmapped_diets`."""
+
+    dependencies = [
+        ("api", "0069_prevadzka_vydaj"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="dailyorder",
+            name="scrape_flags",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text=(
+                    "Poznámky z posledného EduPage scrapu tejto objednávky, napr. "
+                    "{'attention': [...], 'config_notes': [...], "
+                    "'unmapped_diets': [...]}. Prázdne pri ručných objednávkach a "
+                    "pri scrape bez upozornení."
+                ),
+            ),
+        ),
+    ]

--- a/backend/api/migrations/0071_delivery_route_vydaj.py
+++ b/backend/api/migrations/0071_delivery_route_vydaj.py
@@ -1,0 +1,56 @@
+from django.db import migrations, models
+
+
+def prenes_vydaj_z_prevadzok_na_trasy(apps, schema_editor):
+    """Výdaj sa presúva z prevádzky na trasu — jedno miesto namiesto dvoch.
+
+    Hodnota sa berie z prevádzok, ktoré v trase stoja (stačí jedna mimo výdaja A,
+    lebo tak ich tam dala predošlá migrácia z extra blokov). Trasa bez prevádzok
+    padne späť na príznak bloku, aby prázdna extra trasa neskončila v A.
+    """
+    DeliveryRoute = apps.get_model("api", "DeliveryRoute")
+    for route in DeliveryRoute.objects.select_related("block").all():
+        vydaje = set(route.prevadzky.values_list("vydaj", flat=True))
+        vydaje.discard("A")
+        if vydaje:
+            route.vydaj = sorted(vydaje)[0]
+        elif route.block.include_in_extra_summary:
+            route.vydaj = "B"
+        else:
+            continue
+        route.save(update_fields=["vydaj"])
+
+
+def prenes_vydaj_z_tras_na_prevadzky(apps, schema_editor):
+    Prevadzka = apps.get_model("api", "Prevadzka")
+    for vydaj in ("B", "C"):
+        Prevadzka.objects.filter(delivery_route__vydaj=vydaj).update(vydaj=vydaj)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0070_alter_dailyorder_scrape_flags"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="deliveryroute",
+            name="vydaj",
+            field=models.CharField(
+                choices=[("A", "Výdaj A"), ("B", "Výdaj B"), ("C", "Výdaj C")],
+                db_index=True,
+                default="A",
+                help_text=(
+                    "Výdajný bod kuchyne, ktorý túto trasu obsluhuje. Gramážová "
+                    "tabuľka sa delí podľa neho — trasy výdaja A tvoria tabuľku "
+                    "A, trasy výdaja B tabuľku B."
+                ),
+                max_length=1,
+            ),
+        ),
+        migrations.RunPython(
+            prenes_vydaj_z_prevadzok_na_trasy, prenes_vydaj_z_tras_na_prevadzky
+        ),
+        migrations.RemoveField(model_name="prevadzka", name="vydaj"),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -366,11 +366,11 @@ class Celok(models.Model):
 
 
 class Vydaj(models.TextChoices):
-    """Výdajný bod kuchyne (cluster), z ktorého sa prevádzka vydáva.
+    """Výdajný bod kuchyne, z ktorého ide jedlo von.
 
-    Kuchyňa vydáva stravu z dvoch miest súčasne a každé chce vlastnú tabuľku aj
-    vlastné trasy. Je to zámerne vlastnosť PREVÁDZKY, nie trasy: trasa môže voziť
-    do oboch výdajov a rozdelenie si prevádzka nastavuje sama.
+    Kuchyňa vydáva stravu z dvoch miest súčasne a každé chce vlastnú tabuľku.
+    Výdaj je vlastnosť TRASY: prevádzka patrí do toho výdaja, v ktorého trase
+    stojí, takže sa nastavuje na jednom mieste a nemá si ako protirečiť.
     """
 
     A = "A", "Výdaj A"
@@ -439,16 +439,6 @@ class Prevadzka(models.Model):
     delivery_sort_order = models.PositiveSmallIntegerField(
         default=0,
         help_text="Poradie prevádzky v rámci rozvozovej trasy.",
-    )
-    vydaj = models.CharField(
-        max_length=1,
-        choices=Vydaj.choices,
-        default=Vydaj.A,
-        db_index=True,
-        help_text=(
-            "Výdajný bod kuchyne, z ktorého sa prevádzka vydáva. Podľa neho sa "
-            "delí gramážová tabuľka aj tlač; trasa ostáva nezávislá."
-        ),
     )
     report_alias = models.CharField(
         max_length=255,
@@ -597,6 +587,17 @@ class DeliveryRoute(models.Model):
 
     block = models.ForeignKey(
         DeliveryBlock, on_delete=models.CASCADE, related_name="routes"
+    )
+    vydaj = models.CharField(
+        max_length=1,
+        choices=Vydaj.choices,
+        default=Vydaj.A,
+        db_index=True,
+        help_text=(
+            "Výdajný bod kuchyne, ktorý túto trasu obsluhuje. Gramážová tabuľka "
+            "sa delí podľa neho — trasy výdaja A tvoria tabuľku A, trasy výdaja "
+            "B tabuľku B."
+        ),
     )
     name = models.CharField(max_length=160)
     driver = models.CharField(max_length=80, blank=True, default="")

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -82,8 +82,7 @@ class DailyOrder(models.Model):
         help_text=(
             "Poznámky z posledného EduPage scrapu tejto objednávky, napr. "
             "{'attention': [...], 'config_notes': [...], 'unmapped_diets': [...]}. "
-            "Prázdne pri ručných "
-            "objednávkach a pri scrape bez upozornení."
+            "Prázdne pri ručných objednávkach a pri scrape bez upozornení."
         ),
     )
     is_auto = models.BooleanField(
@@ -366,6 +365,19 @@ class Celok(models.Model):
         return self.nazov
 
 
+class Vydaj(models.TextChoices):
+    """Výdajný bod kuchyne (cluster), z ktorého sa prevádzka vydáva.
+
+    Kuchyňa vydáva stravu z dvoch miest súčasne a každé chce vlastnú tabuľku aj
+    vlastné trasy. Je to zámerne vlastnosť PREVÁDZKY, nie trasy: trasa môže voziť
+    do oboch výdajov a rozdelenie si prevádzka nastavuje sama.
+    """
+
+    A = "A", "Výdaj A"
+    B = "B", "Výdaj B"
+    C = "C", "Výdaj C"
+
+
 class Prevadzka(models.Model):
     """Jedna prevádzka (miesto výdaja) v rámci celku.
 
@@ -427,6 +439,16 @@ class Prevadzka(models.Model):
     delivery_sort_order = models.PositiveSmallIntegerField(
         default=0,
         help_text="Poradie prevádzky v rámci rozvozovej trasy.",
+    )
+    vydaj = models.CharField(
+        max_length=1,
+        choices=Vydaj.choices,
+        default=Vydaj.A,
+        db_index=True,
+        help_text=(
+            "Výdajný bod kuchyne, z ktorého sa prevádzka vydáva. Podľa neho sa "
+            "delí gramážová tabuľka aj tlač; trasa ostáva nezávislá."
+        ),
     )
     report_alias = models.CharField(
         max_length=255,

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -81,7 +81,8 @@ class DailyOrder(models.Model):
         blank=True,
         help_text=(
             "Poznámky z posledného EduPage scrapu tejto objednávky, napr. "
-            "{'attention': [...], 'config_notes': [...]}. Prázdne pri ručných "
+            "{'attention': [...], 'config_notes': [...], 'unmapped_diets': [...]}. "
+            "Prázdne pri ručných "
             "objednávkach a pri scrape bez upozornení."
         ),
     )

--- a/backend/api/serializers_delivery.py
+++ b/backend/api/serializers_delivery.py
@@ -17,7 +17,6 @@ class DeliveryPrevadzkaSerializer(serializers.ModelSerializer):
             "report_alias",
             "adresa",
             "celok",
-            "vydaj",
             "delivery_route",
             "delivery_sort_order",
             "delivery_note",
@@ -34,6 +33,7 @@ class DeliveryRouteSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "block",
+            "vydaj",
             "name",
             "driver",
             "departure_time",

--- a/backend/api/serializers_delivery.py
+++ b/backend/api/serializers_delivery.py
@@ -17,6 +17,7 @@ class DeliveryPrevadzkaSerializer(serializers.ModelSerializer):
             "report_alias",
             "adresa",
             "celok",
+            "vydaj",
             "delivery_route",
             "delivery_sort_order",
             "delivery_note",

--- a/backend/api/serializers_facilities.py
+++ b/backend/api/serializers_facilities.py
@@ -79,6 +79,7 @@ class AdminPrevadzkaSerializer(serializers.ModelSerializer):
             "edupage_connection",
             "edupage_connection_name",
             "edupage_match",
+            "vydaj",
             "report_alias",
             "delivery_note",
             "sort_order",

--- a/backend/api/serializers_facilities.py
+++ b/backend/api/serializers_facilities.py
@@ -79,7 +79,6 @@ class AdminPrevadzkaSerializer(serializers.ModelSerializer):
             "edupage_connection",
             "edupage_connection_name",
             "edupage_match",
-            "vydaj",
             "report_alias",
             "delivery_note",
             "sort_order",

--- a/backend/api/services/meal_plan_service.py
+++ b/backend/api/services/meal_plan_service.py
@@ -1216,8 +1216,12 @@ class MealPlanService:
                             if prevadzka is not None
                             else 9999
                         ),
+                        # Výdaj berie prevádzka z trasy — tabuľku riadia trasy,
+                        # nie jednotlivé prevádzky.
                         "vydaj": (
-                            prevadzka.vydaj if prevadzka is not None else str(Vydaj.A)
+                            delivery_route.vydaj
+                            if delivery_route is not None
+                            else str(Vydaj.A)
                         ),
                         "delivery_note": delivery_note,
                         "total_count": _tidy_count(
@@ -1248,19 +1252,18 @@ class MealPlanService:
         def _vydaje_payload(rows_for_payload: list[dict]) -> tuple[list, list]:
             """Riadky zoskupené podľa výdajného bodu, vnútri podľa trás.
 
-            Výdaj je vlastnosť prevádzky, nie trasy — jedna trasa preto môže voziť
-            do oboch výdajov a objaví sa v oboch tabuľkách, zakaždým len so svojimi
-            riadkami. Poradie trás ostáva rozvozové (blok → trasa), aby vodič
-            čítal tabuľku v poradí, v akom nakladá.
+            Tabuľku riadia trasy: trasa patrí práve jednému výdaju a ťahá doň
+            všetky svoje prevádzky. Poradie trás ostáva rozvozové (blok → trasa),
+            aby vodič čítal tabuľku v poradí, v akom nakladá.
             """
-            route_rows: dict[tuple[str, int], list[dict]] = {}
+            route_rows: dict[int, list[dict]] = {}
             unassigned_rows = []
             for row in rows_for_payload:
                 route_id = row.get("delivery_route_id")
                 if route_id is None:
                     unassigned_rows.append(row)
                     continue
-                route_rows.setdefault((row["vydaj"], route_id), []).append(row)
+                route_rows.setdefault(route_id, []).append(row)
 
             if not route_rows:
                 return [], unassigned_rows
@@ -1275,7 +1278,9 @@ class MealPlanService:
             for value, label in Vydaj.choices:
                 routes_payload = []
                 for route in routes:
-                    rows_for_route = route_rows.get((value, route.id))
+                    if route.vydaj != value:
+                        continue
+                    rows_for_route = route_rows.get(route.id)
                     if not rows_for_route:
                         continue
                     routes_payload.append(

--- a/backend/api/services/meal_plan_service.py
+++ b/backend/api/services/meal_plan_service.py
@@ -16,6 +16,7 @@ from ..models import (
     MealCategory,
     MealPlanItem,
     MealTemplate,
+    Vydaj,
 )
 from ..order_data import OrderData
 from ..utils import (
@@ -1215,6 +1216,9 @@ class MealPlanService:
                             if prevadzka is not None
                             else 9999
                         ),
+                        "vydaj": (
+                            prevadzka.vydaj if prevadzka is not None else str(Vydaj.A)
+                        ),
                         "delivery_note": delivery_note,
                         "total_count": _tidy_count(
                             client_total_count + sum(diet_summary_counts.values())
@@ -1231,6 +1235,9 @@ class MealPlanService:
 
         rows.sort(
             key=lambda r: (
+                # Výdajný bod je najvyššia úroveň tabuľky — až v ňom sa radí podľa
+                # rozvozu, aby prevádzka nepreskakovala medzi dvoma tabuľkami.
+                r["vydaj"],
                 r["delivery_block_sort_order"],
                 r["delivery_route_sort_order"],
                 r["delivery_sort_order"],
@@ -1238,59 +1245,60 @@ class MealPlanService:
             )
         )
 
-        def _delivery_blocks_payload(rows_for_payload: list[dict]) -> tuple[list, list]:
-            route_rows: dict[int, list[dict]] = {}
+        def _vydaje_payload(rows_for_payload: list[dict]) -> tuple[list, list]:
+            """Riadky zoskupené podľa výdajného bodu, vnútri podľa trás.
+
+            Výdaj je vlastnosť prevádzky, nie trasy — jedna trasa preto môže voziť
+            do oboch výdajov a objaví sa v oboch tabuľkách, zakaždým len so svojimi
+            riadkami. Poradie trás ostáva rozvozové (blok → trasa), aby vodič
+            čítal tabuľku v poradí, v akom nakladá.
+            """
+            route_rows: dict[tuple[str, int], list[dict]] = {}
             unassigned_rows = []
             for row in rows_for_payload:
                 route_id = row.get("delivery_route_id")
                 if route_id is None:
                     unassigned_rows.append(row)
                     continue
-                route_rows.setdefault(route_id, []).append(row)
+                route_rows.setdefault((row["vydaj"], route_id), []).append(row)
 
             if not route_rows:
                 return [], unassigned_rows
 
-            routes = (
+            routes = list(
                 DeliveryRoute.objects.filter(is_active=True, block__is_active=True)
                 .select_related("block")
                 .order_by("block__sort_order", "sort_order", "name")
             )
-            blocks_by_id: dict[int, dict] = {}
-            for route in routes:
-                block = route.block
-                block_payload = blocks_by_id.setdefault(
-                    block.id,
-                    {
-                        "id": block.id,
-                        "name": block.name,
-                        "sort_order": block.sort_order,
-                        "include_in_main_summary": block.include_in_main_summary,
-                        "include_in_extra_summary": block.include_in_extra_summary,
-                        "routes": [],
-                    },
-                )
-                block_payload["routes"].append(
-                    {
-                        "id": route.id,
-                        "name": route.name,
-                        "driver": route.driver,
-                        "departure_time": (
-                            route.departure_time.isoformat()
-                            if route.departure_time
-                            else None
-                        ),
-                        "note": route.note,
-                        "sort_order": route.sort_order,
-                        "rows": route_rows.get(route.id, []),
-                    }
-                )
 
-            blocks = sorted(
-                blocks_by_id.values(),
-                key=lambda item: (item["sort_order"], item["name"].casefold()),
-            )
-            return blocks, unassigned_rows
+            vydaje = []
+            for value, label in Vydaj.choices:
+                routes_payload = []
+                for route in routes:
+                    rows_for_route = route_rows.get((value, route.id))
+                    if not rows_for_route:
+                        continue
+                    routes_payload.append(
+                        {
+                            "id": route.id,
+                            "name": route.name,
+                            "driver": route.driver,
+                            "departure_time": (
+                                route.departure_time.isoformat()
+                                if route.departure_time
+                                else None
+                            ),
+                            "note": route.note,
+                            "sort_order": route.sort_order,
+                            "block_name": route.block.name,
+                            "rows": rows_for_route,
+                        }
+                    )
+                if routes_payload:
+                    vydaje.append(
+                        {"key": value, "name": label, "routes": routes_payload}
+                    )
+            return vydaje, unassigned_rows
 
         totals_serialized = _serialize_group_totals(totals)
 
@@ -1388,14 +1396,14 @@ class MealPlanService:
                 }
             )
 
-        delivery_blocks, unassigned_rows = _delivery_blocks_payload(rows)
+        vydaje, unassigned_rows = _vydaje_payload(rows)
 
         return {
             "date": date_str,
             "meal_plan_id": plan_id,
             "col_groups": col_groups,
             "rows": rows,
-            "blocks": delivery_blocks,
+            "vydaje": vydaje,
             "unassigned_rows": unassigned_rows,
             "totals": totals_serialized,
             "count_summary": count_summary,

--- a/backend/api/services/notification_service.py
+++ b/backend/api/services/notification_service.py
@@ -22,6 +22,53 @@ OPERATIONS_MANUAL_PATH = (
 )
 OPERATIONS_MANUAL_FILENAME = "Navod-pre-prevadzky.pdf"
 
+#: Úvod prvého e-mailu (text klienta, 18. 8. 2026). Prevádzka dostane pri založení
+#: loginu jediný e-mail, takže vysvetlenie, PREČO má odteraz objednávať cez
+#: aplikáciu, patrí pred odkaz na nastavenie hesla — nie do samostatnej správy,
+#: ktorú nikto nepošle (rovnaká úvaha ako pri návode v prílohe). Text je klientov,
+#: meniť ho len po dohode s ním.
+ACCOUNT_SETUP_INTRO = """v Zdravom Projekte testujeme našu novú aplikáciu na \
+nahlasovanie stravy. V momente kedy budeme zabezpečovať stravu pre viac ako 4000 \
+stravníkov to už bude nevyhnutnosť. Od začiatku, kedy sme začali variť stravu pre \
+Vaše deti používame excelovskú tabuľku pretkanú vzorcami, rôznymi farbami na \
+rozoznanie škôlok a diét, súčtami a ešte inými poznámkami. Tabuľka mala prvé roky \
+iba pár strán no v Júni tohto roka to už bolo vyše 17 strán a 100 subjektov. Na \
+prípravu tejto tabuľky sú potrební dvaja ľudia, ktorí počas 1,5 hodiny nepretržite \
+zapisujú Vaše nahlásené počty z emailov, starej aplikácie, whatsappu a sms, \
+popríprade telefonátov. Kvôli neskoršiemu nahláseniu stravy nám potom mešká aj \
+tabuľka a to sa samozrejme môže odzrkadliť na meškaní stravy pri dodaní u Vás. \
+Preto potrebujeme všetky objednávky zlúčiť do jednej aplikácie.
+
+Nová aplikácia má Vám aj nám uľahčiť nahlasovanie stravy, zamedziť chybovosti a \
+ešte k tomu zrýchliť celý proces. Stále platí, že sa chceme zlepšovať vo všetkom \
+čo robíme.
+
+V tejto fáze testovania by sme Vás chceli poprosiť o pomoc. Nižšie si nájdete \
+prihlasovacie údaje do aplikácie plus základné informácie s popisom a návodom.
+
+Aplikácia je jednoduchá a všetky potrebné informácie na jej ovládanie sú aj priamo \
+v aplikácii. Funguje na Windows počítači / Macbooku aj na smartfónoch a tabletoch.
+
+Týmto by som Vás chcel poprosiť o nahlasovanie počtov tak ako nahlasujete doteraz, \
+ale od zajtra Vás k tomu poprosím tie isté počty vyplniť aj do aplikácie. Je to \
+kvôli našej internej kontrole a testovaniu. Stále platia časy uzatvorenia \
+objednávok (raňajky/desiata do 21:00 predchádzajúceho dňa, obedy/olovranty do 7:30 \
+daného dňa). Od spustenia aplikácie 1.9.2026 je však veľmi potrebné tieto časy \
+dodržiavať lebo aplikácia sa po tomto čase uzamkne a Vaše objednávky už nepošle a \
+automaticky nakopíruje počty z predchádzajúceho dňa.
+
+Zároveň Vás chcem poprosiť pred začiatkom roka nahlásiť všetky nové typy a \
+kombinácie diét, nakoľko potrebujeme tieto diéty doplniť do aplikácie. Bez tohto \
+kroku pre nich nebudete vedieť stravu objednať.
+
+Pre akékoľvek otázky nás prosím kontaktujte na 0903186328"""
+
+#: Podpis pod prvým e-mailom — text je klientov, tak sa aj podpíše.
+ACCOUNT_SETUP_SIGNATURE = (
+    "Vopred ďakujem a verím, že touto cestou zlepšíme kvalitu našich služieb.\n\n"
+    "Stanislav Šulc\nZdravý projekt"
+)
+
 
 class NotificationService:
     """Send transactional notification emails."""
@@ -58,13 +105,14 @@ class NotificationService:
             )
             message = (
                 f"Dobrý deň {user_operation_name(user)},\n\n"
+                f"{ACCOUNT_SETUP_INTRO}\n\n"
                 "Bol vám vytvorený účet v systéme Zdravý projekt.\n\n"
                 "Pre aktiváciu účtu si prosím nastavte heslo kliknutím na odkaz nižšie:\n"
                 f"{setup_url}\n\n"
                 "Odkaz je platný 7 dní.\n\n"
                 f"{manual_paragraph}"
                 "Ak ste o tento účet nežiadali, tento e-mail ignorujte.\n\n"
-                "S pozdravom, Tím Zdravý projekt"
+                f"{ACCOUNT_SETUP_SIGNATURE}"
             )
             from_email = getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@example.com")
 

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -603,6 +603,7 @@ def scrape_edupage_orders_task(
 
         from api.edupage_scraper import (
             EdupageScraper,
+            allowed_diet_names,
             build_prevadzka_matches,
             nest_order_data_by_category,
             prevadzky_without_match,
@@ -678,6 +679,8 @@ def scrape_edupage_orders_task(
                     target_meals.append(meal_type)
 
         scraper = EdupageScraper()
+        # Whitelist diét sa číta raz za beh — je rovnaký pre všetky prevádzky.
+        allowed_diets = allowed_diet_names()
         scraped = errors = skipped = 0
 
         for operation in edupage_operations():
@@ -712,6 +715,7 @@ def scrape_edupage_orders_task(
                         operation["url"],
                         target_date,
                         prevadzka_matches=matches if len(prevadzky) > 1 else None,
+                        allowed_diets=allowed_diets,
                     )
                 except Exception:
                     logger.exception(
@@ -735,6 +739,14 @@ def scrape_edupage_orders_task(
                         target_date,
                         result.attention,
                     )
+                if result.unmapped_letters:
+                    logger.warning(
+                        "scrape_edupage_orders_task: neznáme diéty pre %s na %s: %s "
+                        "— porcie sú započítané, ale diétu treba založiť v appke",
+                        operation["name"],
+                        target_date,
+                        result.unmapped_letters,
+                    )
 
                 # Jedna prevádzka → celý objem jej; viac → podľa edupage_match.
                 if len(prevadzky) > 1:
@@ -749,8 +761,12 @@ def scrape_edupage_orders_task(
                         attention_for_prevadzka = result.attention_by_prevadzka.get(
                             nazov, []
                         )
+                        unmapped_for_prevadzka = result.unmapped_by_prevadzka.get(
+                            nazov, []
+                        )
                     else:
                         attention_for_prevadzka = result.attention
+                        unmapped_for_prevadzka = result.unmapped_letters
 
                     nested_order_data = nest_order_data_by_category(
                         data_by_nazov.get(nazov, {}), nazov
@@ -799,6 +815,7 @@ def scrape_edupage_orders_task(
                         order.scrape_flags = {
                             "attention": list(attention_for_prevadzka),
                             "config_notes": list(result.config_notes),
+                            "unmapped_diets": list(unmapped_for_prevadzka),
                         }
                         order.save(update_fields=["data", "scrape_flags", "updated_at"])
                     scraped += 1

--- a/backend/api/tests/integration/test_admin_api.py
+++ b/backend/api/tests/integration/test_admin_api.py
@@ -1,5 +1,6 @@
 import io
 from datetime import date
+from decimal import Decimal
 
 import openpyxl
 import pytest
@@ -321,6 +322,38 @@ class MealTemplateCatalogApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         template.refresh_from_db()
         self.assertFalse(template.is_active)
+
+    def test_admin_can_rename_a_component(self):
+        """Kuchyňa si chcela prepísať „Hlavná zložka" na vlastné pomenovanie.
+
+        Popis váhy (`weight_label`) a `base_weight_grams` sa musia prepočítať zo
+        zložiek — inak by v katalógu ostala stará váha a tabuľka by ukazovala
+        niečo iné než katalóg.
+        """
+        self.client.force_authenticate(user=self.admin)
+        template = MealTemplate.objects.get(name="Olovrant 1")
+
+        response = self.client.patch(
+            f"/api/admin/meal-templates/{template.id}/",
+            {
+                "name": "Olovrant 1 - pečivo",
+                "components": [
+                    {"label": "Pečivo", "grams": "60", "unit": "g"},
+                    {"label": "Nátierka", "grams": "40", "unit": "g"},
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        template.refresh_from_db()
+        self.assertEqual(template.name, "Olovrant 1 - pečivo")
+        self.assertEqual(
+            [c["label"] for c in template.components], ["Pečivo", "Nátierka"]
+        )
+        self.assertEqual(template.base_weight_grams, Decimal("100.00"))
+        # Popis váhy nesie gramáže, nie názvy zložiek — musí sedeť s novými číslami.
+        self.assertEqual(template.weight_label, "60g + 40g")
 
     def test_creating_a_template_without_weight_data_is_rejected(self):
         self.client.force_authenticate(user=self.admin)

--- a/backend/api/tests/integration/test_edupage_connection_api.py
+++ b/backend/api/tests/integration/test_edupage_connection_api.py
@@ -126,7 +126,7 @@ def test_scrape_imports_orders_for_open_day(admin_client, admin_user, monkeypatc
     )
     monkeypatch.setattr(
         "api.views.edupage_views.EdupageScraper.scrape",
-        lambda self, url, date, prevadzka_matches=None: ScrapeResult(
+        lambda self, url, date, prevadzka_matches=None, allowed_diets=None: ScrapeResult(
             date=date,
             order_data={"lunch": {"menuCounts": {"A": 3}, "diets": {}}},
         ),

--- a/backend/api/tests/test_cron_run_logging.py
+++ b/backend/api/tests/test_cron_run_logging.py
@@ -74,7 +74,7 @@ class TestScrapeLogsItsRun:
         monkeypatch.setattr(timezone, "localdate", lambda: MONDAY)
         monkeypatch.setattr(
             "api.edupage_scraper.EdupageScraper.scrape",
-            lambda self, url, target_date, prevadzka_matches=None: ScrapeResult(
+            lambda self, url, target_date, prevadzka_matches=None, allowed_diets=None: ScrapeResult(
                 date=target_date, order_data={"lunch": {"menuCounts": {"A": 5}}}
             ),
         )
@@ -99,7 +99,7 @@ class TestScrapeLogsItsRun:
         _settings()
         monkeypatch.setattr(timezone, "localdate", lambda: MONDAY)
 
-        def boom(self, url, target_date, prevadzka_matches=None):
+        def boom(self, url, target_date, prevadzka_matches=None, allowed_diets=None):
             raise RuntimeError("EduPage nedostupné")
 
         monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", boom)

--- a/backend/api/tests/test_edupage_scrape_task.py
+++ b/backend/api/tests/test_edupage_scrape_task.py
@@ -50,6 +50,51 @@ def edupage_user(db):
 
 
 @pytest.mark.django_db
+def test_allowed_diet_names_includes_active_db_diets():
+    """Diéta založená v appke rozšíri whitelist scrapu bez nasadenia kódu;
+    neaktívna sa doň nedostane."""
+    from api.edupage_scraper import ALLOWED_DIET_NAMES, allowed_diet_names
+    from api.models import Diet
+
+    Diet.objects.create(name="NO KAKAO")
+    Diet.objects.create(name="ZRUŠENÁ", is_active=False)
+
+    names = allowed_diet_names()
+
+    assert "NO KAKAO" in names
+    assert "ZRUŠENÁ" not in names
+    assert ALLOWED_DIET_NAMES <= names
+
+
+@pytest.mark.django_db
+def test_edupage_scrape_persists_unmapped_diets_flag(edupage_user, monkeypatch):
+    """Neznáma diéta sa dostane do scrape_flags, nech ju admin prehľad ukáže —
+    inak by o nej nikto nevedel (Cvernička, 17. 8. 2026)."""
+    GlobalSettings.objects.create(
+        pk=1,
+        deadline_breakfast=datetime.time(18, 0),
+        deadline_lunch=datetime.time(9, 0),
+        deadline_olovrant=datetime.time(10, 0),
+    )
+    target_date = datetime.date(2026, 6, 30)
+
+    def fake_scrape(self, url, scrape_date, prevadzka_matches=None, allowed_diets=None):
+        return _scrape_result(
+            order_data={"lunch": {"menuCounts": {"A": 5}, "diets": {"NO KAKAO": 5}}},
+            warnings=[],
+            unmapped_letters=["N:NO KAKAO"],
+        )
+
+    monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", fake_scrape)
+    scrape_edupage_orders_task.run(date_str=target_date.isoformat())
+
+    order = DailyOrder.objects.get(user=edupage_user, date=target_date)
+    assert order.scrape_flags["unmapped_diets"] == ["N:NO KAKAO"]
+    # a hlavne: porcie sa naozaj zapísali
+    assert order.data
+
+
+@pytest.mark.django_db
 def test_edupage_scrape_uses_next_workday_for_day_before_meal(
     edupage_user, monkeypatch
 ):
@@ -63,7 +108,7 @@ def test_edupage_scrape_uses_next_workday_for_day_before_meal(
     today = datetime.date(2026, 6, 29)  # Monday
     seen_dates = []
 
-    def fake_scrape(self, url, target_date, prevadzka_matches=None):
+    def fake_scrape(self, url, target_date, prevadzka_matches=None, allowed_diets=None):
         seen_dates.append(target_date)
         return _scrape_result(
             order_data={
@@ -107,7 +152,9 @@ def test_edupage_scrape_persists_attention_flags(edupage_user, monkeypatch):
     )
     target_date = datetime.date(2026, 6, 30)
 
-    def flagged_scrape(self, url, scrape_date, prevadzka_matches=None):
+    def flagged_scrape(
+        self, url, scrape_date, prevadzka_matches=None, allowed_diets=None
+    ):
         return _scrape_result(
             order_data={"lunch": {"menuCounts": {"A": 5}}},
             warnings=[],
@@ -122,9 +169,12 @@ def test_edupage_scrape_persists_attention_flags(edupage_user, monkeypatch):
     assert order.scrape_flags == {
         "attention": ["A:KZ?"],
         "config_notes": ["olovrant chýba"],
+        "unmapped_diets": [],
     }
 
-    def clean_scrape(self, url, scrape_date, prevadzka_matches=None):
+    def clean_scrape(
+        self, url, scrape_date, prevadzka_matches=None, allowed_diets=None
+    ):
         return _scrape_result(
             order_data={"lunch": {"menuCounts": {"A": 5}}}, warnings=[]
         )
@@ -133,7 +183,11 @@ def test_edupage_scrape_persists_attention_flags(edupage_user, monkeypatch):
     scrape_edupage_orders_task.run(date_str=target_date.isoformat())
 
     order.refresh_from_db()
-    assert order.scrape_flags == {"attention": [], "config_notes": []}
+    assert order.scrape_flags == {
+        "attention": [],
+        "config_notes": [],
+        "unmapped_diets": [],
+    }
 
 
 @pytest.mark.django_db
@@ -175,7 +229,7 @@ def test_edupage_scrape_splits_attention_flags_per_prevadzka(monkeypatch):
     )
     target_date = datetime.date(2026, 6, 30)
 
-    def fake_scrape(self, url, scrape_date, prevadzka_matches=None):
+    def fake_scrape(self, url, scrape_date, prevadzka_matches=None, allowed_diets=None):
         return _scrape_result(
             order_data={"lunch": {"menuCounts": {"A": 8}}},
             order_data_by_prevadzka={
@@ -184,6 +238,8 @@ def test_edupage_scrape_splits_attention_flags_per_prevadzka(monkeypatch):
             },
             attention=["A:ZD?"],
             attention_by_prevadzka={"Jolly 1": ["A:ZD?"]},
+            unmapped_letters=["Z:Nová diéta"],
+            unmapped_by_prevadzka={"Jolly 1": ["Z:Nová diéta"]},
             config_notes=["olovrant chýba"],
             warnings=[],
         )
@@ -196,9 +252,14 @@ def test_edupage_scrape_splits_attention_flags_per_prevadzka(monkeypatch):
     assert o1.scrape_flags == {
         "attention": ["A:ZD?"],
         "config_notes": ["olovrant chýba"],
+        "unmapped_diets": ["Z:Nová diéta"],
     }
     # Jolly 2 nemá flag, ale zdieľané config_notes áno.
-    assert o2.scrape_flags == {"attention": [], "config_notes": ["olovrant chýba"]}
+    assert o2.scrape_flags == {
+        "attention": [],
+        "config_notes": ["olovrant chýba"],
+        "unmapped_diets": [],
+    }
 
 
 @pytest.mark.django_db
@@ -241,7 +302,7 @@ def test_edupage_scrape_records_explicit_zero_when_structurally_empty(
     )
     target_date = datetime.date(2026, 6, 30)
 
-    def fake_scrape(self, url, scrape_date, prevadzka_matches=None):
+    def fake_scrape(self, url, scrape_date, prevadzka_matches=None, allowed_diets=None):
         return _scrape_result(order_data={}, warnings=[], unmapped_letters=[])
 
     monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", fake_scrape)
@@ -273,7 +334,7 @@ def test_edupage_scrape_skips_without_recording_on_real_scrape_failure(
     )
     target_date = datetime.date(2026, 6, 30)
 
-    def fake_scrape(self, url, scrape_date, prevadzka_matches=None):
+    def fake_scrape(self, url, scrape_date, prevadzka_matches=None, allowed_diets=None):
         return _scrape_result(
             order_data={},
             warnings=["prehlad block not found in HTML"],
@@ -304,7 +365,7 @@ def test_edupage_scrape_skips_without_recording_on_unmapped_letters(
     )
     target_date = datetime.date(2026, 6, 30)
 
-    def fake_scrape(self, url, scrape_date, prevadzka_matches=None):
+    def fake_scrape(self, url, scrape_date, prevadzka_matches=None, allowed_diets=None):
         return _scrape_result(order_data={}, warnings=[], unmapped_letters=["Z:Z"])
 
     monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", fake_scrape)
@@ -340,7 +401,7 @@ def test_edupage_scrape_merges_requested_meals_without_replacing_existing_day(
         },
     )
 
-    def fake_scrape(self, url, scrape_date, prevadzka_matches=None):
+    def fake_scrape(self, url, scrape_date, prevadzka_matches=None, allowed_diets=None):
         assert scrape_date == target_date
         return _scrape_result(
             order_data={

--- a/backend/api/tests/test_edupage_scraper.py
+++ b/backend/api/tests/test_edupage_scraper.py
@@ -323,9 +323,9 @@ class TestParse(unittest.TestCase):
     TARGET_DATE = date(2026, 6, 17)
     DATE_STR = "2026-06-17"
 
-    def _scrape_html(self, html: str):
+    def _scrape_html(self, html: str, allowed_diets=None):
         scraper = EdupageScraper()
-        return scraper._parse(html, self.TARGET_DATE)
+        return scraper._parse(html, self.TARGET_DATE, allowed_diets=allowed_diets)
 
     def _typy(self, items):
         return [
@@ -695,7 +695,7 @@ class TestParse(unittest.TestCase):
         # Zero-count entries should not appear in order_data
         self.assertEqual(result.order_data, {})
 
-    def test_unknown_menu_letter_is_rejected_from_clean_output(self):
+    def test_unknown_diet_is_counted_and_reported(self):
         prehlad = {
             "prehlad": {
                 self.DATE_STR: {
@@ -720,8 +720,50 @@ class TestParse(unittest.TestCase):
         )
         result = self._scrape_html(html)
 
-        self.assertEqual(result.order_data, {})
+        # Neznáma diéta sa NEZAHADZUJE — porcie musia ostať v počte, inak
+        # kuchyni chýbajú jedlá a nikto o tom nevie.
+        self.assertEqual(
+            result.order_data,
+            {"lunch": {"Škôlka": {"menuCounts": {"A": 3}, "diets": {"Z": 3}}}},
+        )
         self.assertIn("Z:Z", result.unmapped_letters)
+
+    def test_diet_known_only_in_db_is_accepted(self):
+        """Diéta založená v appke (nie v zabudovanom zozname) sa už nehlási ako
+        neznáma — presne kvôli tomu, aby nová diéta školy nečakala na nasadenie."""
+        prehlad = {
+            "prehlad": {
+                self.DATE_STR: {
+                    "2": {
+                        "N": {
+                            "typ_platitela": {"1": {"o": 4}},
+                            "porcia": {},
+                            "v_skupina": {},
+                        },
+                    }
+                }
+            },
+            "mamUnknown": False,
+            "unknownTypyIDS": [],
+        }
+        nazov_menu = {"N": {"skratka": "NK", "nazov": "NO KAKAO"}}
+        html = _make_html(
+            prehlad,
+            nazov_menu,
+            [],
+            self._typy([(1, "MŠ Klasik", 0)]),
+            self.DATE_STR,
+        )
+
+        neznama = self._scrape_html(html)
+        self.assertEqual(neznama.unmapped_letters, ["N:NO KAKAO"])
+
+        znama = self._scrape_html(html, allowed_diets={"NO KAKAO"})
+        self.assertEqual(znama.unmapped_letters, [])
+        self.assertEqual(
+            znama.order_data,
+            {"lunch": {"Škôlka": {"menuCounts": {"A": 4}, "diets": {"NO KAKAO": 4}}}},
+        )
 
 
 class TestFetchError(unittest.TestCase):

--- a/backend/api/tests/test_gramage_table_spec.py
+++ b/backend/api/tests/test_gramage_table_spec.py
@@ -476,3 +476,86 @@ def test_meal_band_merges_soup_with_main_course():
     ]
     # Šírka pásov spolu sedí s počtom zložiek v hlavičke.
     assert sum(span for _, span in bands) == len(spec["header"]["components"])
+
+
+# ── Filter výdajných bodov (clusterov) ───────────────────────────────────────
+
+
+def _two_block_payload():
+    """Dva výdajné body, každý s jednou prevádzkou — kuchyňa vydáva z dvoch miest."""
+    rows = _payload()["rows"]
+    return _payload(
+        blocks=[
+            {
+                "id": 1,
+                "name": "Bežné trasy",
+                "routes": [{"id": 1, "name": "Trasa 1", "rows": rows}],
+            },
+            {
+                "id": 2,
+                "name": "Trasa extra",
+                "routes": [{"id": 2, "name": "Trasa extra 1", "rows": rows}],
+            },
+        ],
+        rows=[],
+        unassigned_rows=[],
+    )
+
+
+def _band_texts(spec):
+    return [
+        row["cells"][0]["text"] for row in spec["rows"] if "block-band" in row["css"]
+    ]
+
+
+def test_block_filter_prints_a_single_dispatch_point():
+    spec = build_table_spec(_two_block_payload(), block_names=["Trasa extra"])
+
+    assert _band_texts(spec) == ["Trasa extra"]
+    assert [block["selected"] for block in spec["blocks"]] == [False, True]
+
+
+def test_unknown_or_empty_block_selection_falls_back_to_everything():
+    payload = _two_block_payload()
+
+    assert _band_texts(build_table_spec(payload)) == ["Bežné trasy", "Trasa extra"]
+    assert _band_texts(build_table_spec(payload, block_names=["nezmysel"])) == [
+        "Bežné trasy",
+        "Trasa extra",
+    ]
+
+
+def test_every_block_but_the_first_starts_on_a_new_page():
+    spec = build_table_spec(_two_block_payload())
+
+    bands = [row for row in spec["rows"] if "block-band" in row["css"]]
+    assert "page-break" not in bands[0]["css"]
+    assert "page-break" in bands[1]["css"]
+
+
+def test_filtered_block_totals_ignore_the_other_block():
+    """Pri tlači jedného výdajného bodu nesmie v pätke svietiť gramáž celého dňa.
+
+    `data["totals"]` je predpočítaný súčet za celý deň — fixture mu dá hodnotu,
+    ktorú jeden blok dosiahnuť nemôže, takže je vidieť, či ju filtrovaná pätka
+    naozaj prepočítala z vlastných riadkov.
+    """
+    payload = _two_block_payload()
+    payload["totals"] = [["9999.00"], ["9999.00"], []]
+
+    full = build_table_spec(payload)
+    single = build_table_spec(payload, block_names=["Bežné trasy"])
+
+    assert full["footer"][-1]["cells"][1]["text"] == "9999"
+    # 8 porcií bez diét × 200 g polievky v jedinom bloku.
+    assert single["footer"][-1]["cells"][1]["text"] == "1600"
+
+
+def test_unassigned_prevadzky_stay_out_of_a_filtered_print():
+    payload = _two_block_payload()
+    payload["unassigned_rows"] = _payload()["rows"]
+
+    assert "Nepriradené prevádzky" in _band_texts(build_table_spec(payload))
+    assert "Nepriradené prevádzky" not in _band_texts(
+        build_table_spec(payload, block_names=["Bežné trasy"])
+    )

--- a/backend/api/tests/test_gramage_table_spec.py
+++ b/backend/api/tests/test_gramage_table_spec.py
@@ -128,11 +128,12 @@ def test_there_is_no_separate_count_column():
     """Počet je odznak v labeli, nie vlastný stĺpec — inak sa tlač rozíde s obrazovkou."""
     spec = build_table_spec(_payload())
 
-    assert spec["total_columns"] == 1 + 3
-    assert len(spec["header"]["components"]) == 3
+    # 1 = názov riadku, 3 = zložky, 1 = prázdny stĺpec „Poznámka".
+    assert spec["total_columns"] == 1 + 3 + 1
+    assert len(spec["header"]["components"]) == 3 + 1
     sub_row = next(r for r in spec["rows"] if r["kind"] == "sub-row")
     assert sub_row["cells"][0]["count"] == "8"
-    assert len(sub_row["cells"]) == 1 + 3
+    assert len(sub_row["cells"]) == 1 + 3 + 1
 
 
 def test_every_second_sub_row_is_striped():
@@ -169,7 +170,9 @@ def _sub_rows_by_client(spec):
 def test_header_keeps_the_template_name():
     spec = build_table_spec(_payload())
 
-    assert [g["sub"] for g in spec["header"]["groups"]] == [
+    assert [
+        g["sub"] for g in spec["header"]["groups"] if "grp-note" not in g["css"]
+    ] == [
         "Hrášková",
         "Kuracie",
         "Vege",
@@ -264,7 +267,9 @@ def test_totals_row_uses_a_dash_for_empty_columns():
     """Obrazovka tu dnes píše „0", čo si protirečí s telom tabuľky — spec to zjednocuje."""
     spec = build_table_spec(_payload())
 
-    assert spec["footer"][-1]["cells"][-1]["text"] == "—"
+    # Posledná bunka je prázdna „Poznámka"; gramáž je tá pred ňou.
+    assert spec["footer"][-1]["cells"][-1]["css"] == "cell-note"
+    assert spec["footer"][-1]["cells"][-2]["text"] == "—"
 
 
 # ── Filter sekcií (verzie tlače aj prehľadu) ─────────────────────────────────
@@ -310,7 +315,13 @@ def _with_breakfast_and_snack():
 
 
 def _group_labels(spec):
-    return [group["text"] for group in spec["header"]["groups"]]
+    """Názvy stĺpcových skupín bez koncového stĺpca „Poznámka" — ten nie je
+    jedlo a s filtrom sekcií nemá nič spoločné."""
+    return [
+        group["text"]
+        for group in spec["header"]["groups"]
+        if "grp-note" not in group["css"]
+    ]
 
 
 def test_no_filter_means_the_complete_table():
@@ -429,3 +440,39 @@ def test_a_diet_absent_from_the_visible_sections_is_not_summarised():
         "note-delivery",
         "summary-std",
     ]
+
+
+# ── Poznámkový stĺpec a pás jedál ────────────────────────────────────────────
+
+
+def test_note_column_is_empty_on_every_data_row():
+    """Prázdny stĺpec na ručné poznámky do vytlačenej tabuľky."""
+    spec = build_table_spec(_payload())
+
+    assert spec["header"]["groups"][-1]["text"] == "Poznámka"
+    data_rows = [
+        row
+        for row in spec["rows"] + spec["footer"]
+        # Pásy a poznámky idú cez celú šírku, tie posledný stĺpec nemajú.
+        if row["kind"]
+        in {"sub-row", "summary-std", "summary-diet", "portion-row", "total"}
+    ]
+    assert data_rows
+    for row in data_rows:
+        assert row["cells"][-1] == {"text": "", "css": "cell-note"}
+
+
+def test_meal_band_merges_soup_with_main_course():
+    """Polievka a menu tvoria jeden „Obed"; raňajky a olovrant vlastné pásy."""
+    spec = build_table_spec(_with_breakfast_and_snack())
+
+    bands = [(band["text"], band["colspan"]) for band in spec["header"]["meals"]]
+    # Posledný pás patrí stĺpcu „Poznámka" a je bez názvu.
+    assert bands[-1][0] == ""
+    assert [text for text, _ in bands[:-1]] == [
+        "Obed",
+        "Raňajky / desiata",
+        "Olovrant",
+    ]
+    # Šírka pásov spolu sedí s počtom zložiek v hlavičke.
+    assert sum(span for _, span in bands) == len(spec["header"]["components"])

--- a/backend/api/tests/test_gramage_table_spec.py
+++ b/backend/api/tests/test_gramage_table_spec.py
@@ -221,10 +221,10 @@ def test_client_row_carries_the_screen_metadata():
 
 def test_empty_routes_are_skipped():
     payload = _payload(
-        blocks=[
+        vydaje=[
             {
-                "id": 1,
-                "name": "Blok 1",
+                "key": "A",
+                "name": "Výdaj A",
                 "routes": [
                     {"id": 1, "name": "Prázdna trasa", "rows": []},
                     {"id": 2, "name": "Plná trasa", "rows": _payload()["rows"]},
@@ -478,22 +478,22 @@ def test_meal_band_merges_soup_with_main_course():
     assert sum(span for _, span in bands) == len(spec["header"]["components"])
 
 
-# ── Filter výdajných bodov (clusterov) ───────────────────────────────────────
+# ── Filter výdajných bodov ───────────────────────────────────────────────────
 
 
-def _two_block_payload():
+def _two_vydaje_payload():
     """Dva výdajné body, každý s jednou prevádzkou — kuchyňa vydáva z dvoch miest."""
     rows = _payload()["rows"]
     return _payload(
-        blocks=[
+        vydaje=[
             {
-                "id": 1,
-                "name": "Bežné trasy",
+                "key": "A",
+                "name": "Výdaj A",
                 "routes": [{"id": 1, "name": "Trasa 1", "rows": rows}],
             },
             {
-                "id": 2,
-                "name": "Trasa extra",
+                "key": "B",
+                "name": "Výdaj B",
                 "routes": [{"id": 2, "name": "Trasa extra 1", "rows": rows}],
             },
         ],
@@ -508,54 +508,54 @@ def _band_texts(spec):
     ]
 
 
-def test_block_filter_prints_a_single_dispatch_point():
-    spec = build_table_spec(_two_block_payload(), block_names=["Trasa extra"])
+def test_vydaj_filter_prints_a_single_dispatch_point():
+    spec = build_table_spec(_two_vydaje_payload(), vydaje=["B"])
 
-    assert _band_texts(spec) == ["Trasa extra"]
-    assert [block["selected"] for block in spec["blocks"]] == [False, True]
+    assert _band_texts(spec) == ["Výdaj B"]
+    assert [vydaj["selected"] for vydaj in spec["vydaje"]] == [False, True]
 
 
-def test_unknown_or_empty_block_selection_falls_back_to_everything():
-    payload = _two_block_payload()
+def test_unknown_or_empty_vydaj_selection_falls_back_to_everything():
+    payload = _two_vydaje_payload()
 
-    assert _band_texts(build_table_spec(payload)) == ["Bežné trasy", "Trasa extra"]
-    assert _band_texts(build_table_spec(payload, block_names=["nezmysel"])) == [
-        "Bežné trasy",
-        "Trasa extra",
+    assert _band_texts(build_table_spec(payload)) == ["Výdaj A", "Výdaj B"]
+    assert _band_texts(build_table_spec(payload, vydaje=["nezmysel"])) == [
+        "Výdaj A",
+        "Výdaj B",
     ]
 
 
-def test_every_block_but_the_first_starts_on_a_new_page():
-    spec = build_table_spec(_two_block_payload())
+def test_every_vydaj_but_the_first_starts_on_a_new_page():
+    spec = build_table_spec(_two_vydaje_payload())
 
     bands = [row for row in spec["rows"] if "block-band" in row["css"]]
     assert "page-break" not in bands[0]["css"]
     assert "page-break" in bands[1]["css"]
 
 
-def test_filtered_block_totals_ignore_the_other_block():
+def test_filtered_vydaj_totals_ignore_the_other_vydaj():
     """Pri tlači jedného výdajného bodu nesmie v pätke svietiť gramáž celého dňa.
 
     `data["totals"]` je predpočítaný súčet za celý deň — fixture mu dá hodnotu,
     ktorú jeden blok dosiahnuť nemôže, takže je vidieť, či ju filtrovaná pätka
     naozaj prepočítala z vlastných riadkov.
     """
-    payload = _two_block_payload()
+    payload = _two_vydaje_payload()
     payload["totals"] = [["9999.00"], ["9999.00"], []]
 
     full = build_table_spec(payload)
-    single = build_table_spec(payload, block_names=["Bežné trasy"])
+    single = build_table_spec(payload, vydaje=["A"])
 
     assert full["footer"][-1]["cells"][1]["text"] == "9999"
-    # 8 porcií bez diét × 200 g polievky v jedinom bloku.
+    # 8 porcií bez diét × 200 g polievky v jedinom výdaji.
     assert single["footer"][-1]["cells"][1]["text"] == "1600"
 
 
 def test_unassigned_prevadzky_stay_out_of_a_filtered_print():
-    payload = _two_block_payload()
+    payload = _two_vydaje_payload()
     payload["unassigned_rows"] = _payload()["rows"]
 
     assert "Nepriradené prevádzky" in _band_texts(build_table_spec(payload))
     assert "Nepriradené prevádzky" not in _band_texts(
-        build_table_spec(payload, block_names=["Bežné trasy"])
+        build_table_spec(payload, vydaje=["A"])
     )

--- a/backend/api/tests/test_report_chained_after_scrape.py
+++ b/backend/api/tests/test_report_chained_after_scrape.py
@@ -48,7 +48,7 @@ def _settings(**kwargs):
 
 
 def _stub_scrape(monkeypatch):
-    def fake_scrape(self, url, target_date, prevadzka_matches=None):
+    def fake_scrape(self, url, target_date, prevadzka_matches=None, allowed_diets=None):
         return ScrapeResult(
             date=target_date,
             order_data={"lunch": {"menuCounts": {"A": 5}}},
@@ -157,7 +157,7 @@ class TestScrapeGiveUp:
         _settings()
         monkeypatch.setattr(timezone, "localdate", lambda: datetime.date(2026, 6, 29))
 
-        def blow_up(self, url, target_date, prevadzka_matches=None):
+        def blow_up(self, url, target_date, prevadzka_matches=None, allowed_diets=None):
             raise RuntimeError("edupage down")
 
         monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", blow_up)

--- a/backend/api/views/edupage_views.py
+++ b/backend/api/views/edupage_views.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 
 from ..edupage_scraper import (
     EdupageScraper,
+    allowed_diet_names,
     build_prevadzka_matches,
     nest_order_data_by_category,
     prevadzky_without_match,
@@ -107,6 +108,7 @@ class AdminEdupageConnectionViewSet(viewsets.ModelViewSet):
             )
         results = []
         scraper = EdupageScraper()
+        allowed_diets = allowed_diet_names()
 
         for operation in operations:
             prevadzky = list(operation["prevadzky"])
@@ -143,6 +145,7 @@ class AdminEdupageConnectionViewSet(viewsets.ModelViewSet):
                     operation["url"],
                     target_date,
                     prevadzka_matches=matches if len(prevadzky) > 1 else None,
+                    allowed_diets=allowed_diets,
                 )
             except Exception:
                 logger.exception(
@@ -169,7 +172,10 @@ class AdminEdupageConnectionViewSet(viewsets.ModelViewSet):
                 )
                 continue
 
-            if result.warnings or result.unmapped_letters:
+            # Zápis blokujú len štrukturálne warningy. Neznáma diéta ho nezastaví —
+            # porcie sú započítané pod názvom z EduPage a vrátia sa v
+            # `unmapped_letters`, nech ju admin vie založiť v appke.
+            if result.warnings:
                 results.append(
                     {
                         "connection_id": operation["connection_id"],
@@ -237,7 +243,9 @@ class AdminEdupageConnectionViewSet(viewsets.ModelViewSet):
             return Response({"ok": False, "error": "url must start with https://"})
 
         try:
-            result = EdupageScraper().scrape(url, datetime.date.today())
+            result = EdupageScraper().scrape(
+                url, datetime.date.today(), allowed_diets=allowed_diet_names()
+            )
         except Exception:
             logger.warning("test_url failed for %s", url, exc_info=True)
             return Response({"ok": False, "error": EDUPAGE_TEST_URL_ERROR})

--- a/backend/api/views/meal_plan_views.py
+++ b/backend/api/views/meal_plan_views.py
@@ -291,7 +291,10 @@ class DailyMealPlanViewSet(AuditedModelViewSetMixin, viewsets.ModelViewSet):
         from ..exporters.gramage_table_spec import build_table_spec
 
         sections = request.query_params.getlist("section") or None
-        data["spec"] = build_table_spec(data, sections=sections)
+        block_names = request.query_params.getlist("block") or None
+        data["spec"] = build_table_spec(
+            data, sections=sections, block_names=block_names
+        )
         return Response(data)
 
     @action(detail=False, methods=["get"], url_path="gramage-dashboard-pdf")
@@ -313,7 +316,8 @@ class DailyMealPlanViewSet(AuditedModelViewSetMixin, viewsets.ModelViewSet):
         from ..exporters.gramage_table_spec import build_table_spec
 
         sections = request.query_params.getlist("section") or None
-        spec = build_table_spec(data, sections=sections)
+        block_names = request.query_params.getlist("block") or None
+        spec = build_table_spec(data, sections=sections, block_names=block_names)
         pdf_bytes = HTML(string=render_document(spec)).write_pdf()
         response = HttpResponse(pdf_bytes, content_type="application/pdf")
         fname = f"gramaz_{date}.pdf"

--- a/backend/api/views/meal_plan_views.py
+++ b/backend/api/views/meal_plan_views.py
@@ -291,10 +291,8 @@ class DailyMealPlanViewSet(AuditedModelViewSetMixin, viewsets.ModelViewSet):
         from ..exporters.gramage_table_spec import build_table_spec
 
         sections = request.query_params.getlist("section") or None
-        block_names = request.query_params.getlist("block") or None
-        data["spec"] = build_table_spec(
-            data, sections=sections, block_names=block_names
-        )
+        vydaje = request.query_params.getlist("vydaj") or None
+        data["spec"] = build_table_spec(data, sections=sections, vydaje=vydaje)
         return Response(data)
 
     @action(detail=False, methods=["get"], url_path="gramage-dashboard-pdf")
@@ -316,8 +314,8 @@ class DailyMealPlanViewSet(AuditedModelViewSetMixin, viewsets.ModelViewSet):
         from ..exporters.gramage_table_spec import build_table_spec
 
         sections = request.query_params.getlist("section") or None
-        block_names = request.query_params.getlist("block") or None
-        spec = build_table_spec(data, sections=sections, block_names=block_names)
+        vydaje = request.query_params.getlist("vydaj") or None
+        spec = build_table_spec(data, sections=sections, vydaje=vydaje)
         pdf_bytes = HTML(string=render_document(spec)).write_pdf()
         response = HttpResponse(pdf_bytes, content_type="application/pdf")
         fname = f"gramaz_{date}.pdf"

--- a/backend/api/views/report_views.py
+++ b/backend/api/views/report_views.py
@@ -39,7 +39,7 @@ def build_prevadzka_overview(target_date):
         is_edupage = prevadzka.celok.zdroj_objednavok == Celok.ZdrojObjednavok.EDUPAGE
         order = orders_by_prevadzka.get(prevadzka.id)
         data = {}
-        flags = {"attention": [], "config_notes": []}
+        flags = {"attention": [], "config_notes": [], "unmapped_diets": []}
         counts = meal_counts(data)
         delivery_status = "missing"
         if order is not None:
@@ -55,6 +55,8 @@ def build_prevadzka_overview(target_date):
                 flags = {
                     "attention": order.scrape_flags.get("attention", []) or [],
                     "config_notes": order.scrape_flags.get("config_notes", []) or [],
+                    "unmapped_diets": order.scrape_flags.get("unmapped_diets", [])
+                    or [],
                 }
 
         row = {
@@ -65,7 +67,9 @@ def build_prevadzka_overview(target_date):
             "delivery_status": delivery_status,
             "counts": counts,
             "flags": flags,
-            "has_warning": bool(flags["attention"] or flags["config_notes"]),
+            "has_warning": bool(
+                flags["attention"] or flags["config_notes"] or flags["unmapped_diets"]
+            ),
         }
         (edupage_rows if is_edupage else app_rows).append(row)
 

--- a/backend/tests/test_account_setup_email.py
+++ b/backend/tests/test_account_setup_email.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import User
 from django.core import mail
 
 from api.services.notification_service import (
+    ACCOUNT_SETUP_INTRO,
     OPERATIONS_MANUAL_FILENAME,
     OPERATIONS_MANUAL_PATH,
     NotificationService,
@@ -70,3 +71,33 @@ class TestAccountSetupEmailAttachment:
         assert message.attachments == []
         assert "https://example.com/set-password?token=abc" in message.body
         assert "V prílohe" not in message.body
+
+
+@pytest.mark.django_db
+class TestAccountSetupEmailIntro:
+    """Úvodný text klienta ide pred odkaz na heslo — je to jediný e-mail, ktorý
+    prevádzka dostane, takže vysvetlenie „prečo" nemá kam inam ísť."""
+
+    def test_intro_comes_before_the_password_link(self, new_user):
+        NotificationService.send_account_setup_email(
+            user=new_user, setup_url="https://example.com/set-password?token=abc"
+        )
+
+        body = mail.outbox[0].body
+        assert ACCOUNT_SETUP_INTRO in body
+        assert body.index(ACCOUNT_SETUP_INTRO) < body.index(
+            "https://example.com/set-password?token=abc"
+        )
+        # Pozdrav ostáva úplne hore, úvod až za ním.
+        assert body.startswith("Dobrý deň ")
+        assert body.rstrip().endswith("Stanislav Šulc\nZdravý projekt")
+
+    def test_intro_keeps_the_deadlines_and_contact(self, new_user):
+        """Časy uzávierok a telefón sú to, kvôli čomu e-mail vznikol."""
+        NotificationService.send_account_setup_email(
+            user=new_user, setup_url="https://example.com/set-password?token=abc"
+        )
+
+        body = mail.outbox[0].body
+        assert "21:00" in body and "7:30" in body
+        assert "0903186328" in body

--- a/backend/tests/test_delivery_layout.py
+++ b/backend/tests/test_delivery_layout.py
@@ -82,6 +82,23 @@ def test_delivery_layout_reorder_moves_prevadzky_between_routes(
     assert second.delivery_sort_order == 1
 
 
+def test_route_vydaj_can_be_switched(admin_authenticated_client):
+    """Výdaj sa prepína na trase — je to jediné miesto, kde sa nastavuje."""
+    block = DeliveryBlock.objects.create(name="Bežné trasy", sort_order=1)
+    route = DeliveryRoute.objects.create(block=block, name="Trasa 1", sort_order=1)
+    assert route.vydaj == "A"
+
+    response = admin_authenticated_client.patch(
+        f"/api/admin/delivery-routes/{route.id}/",
+        {"vydaj": "B"},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    route.refresh_from_db()
+    assert route.vydaj == "B"
+
+
 def test_route_can_be_moved_to_another_block(admin_authenticated_client):
     """Blok = výdajný bod kuchyne; trasa sa medzi bodmi musí dať presunúť."""
     bezne = DeliveryBlock.objects.create(name="Bežné trasy", sort_order=1)
@@ -114,16 +131,20 @@ def test_block_can_be_renamed(admin_authenticated_client):
     assert block.name == "Cluster 1"
 
 
-def test_gramage_dashboard_splits_one_route_between_vydaje():
-    """Výdaj je vlastnosť prevádzky — jedna trasa vie voziť do oboch bodov.
+def test_gramage_dashboard_splits_table_by_route_vydaj():
+    """Tabuľku riadia trasy: trasa výdaja A tvorí tabuľku A, trasa B tabuľku B.
 
-    Trasa sa preto objaví v oboch tabuľkách, zakaždým len so svojimi riadkami.
+    Prevádzka nemá vlastný výdaj — patrí do toho, v ktorého trase stojí.
     """
     block = DeliveryBlock.objects.create(name="Bežné trasy", sort_order=1)
-    route = DeliveryRoute.objects.create(block=block, name="Trasa 1", sort_order=1)
-    v_a = _prevadzka("A prevádzka", route=route, order=1)
-    v_b = _prevadzka("B prevádzka", route=route, order=2)
-    Prevadzka.objects.filter(pk=v_b.pk).update(vydaj="B")
+    route_a = DeliveryRoute.objects.create(
+        block=block, name="Trasa A", sort_order=1, vydaj="A"
+    )
+    route_b = DeliveryRoute.objects.create(
+        block=block, name="Trasa B", sort_order=2, vydaj="B"
+    )
+    v_a = _prevadzka("A prevádzka", route=route_a, order=1)
+    v_b = _prevadzka("B prevádzka", route=route_b, order=1)
 
     user = User.objects.create_user(
         username="vydaj@example.com", email="vydaj@example.com"
@@ -153,8 +174,10 @@ def test_gramage_dashboard_splits_one_route_between_vydaje():
     data = MealPlanService.gramage_dashboard(plan.date.isoformat())
 
     assert [vydaj["key"] for vydaj in data["vydaje"]] == ["A", "B"]
-    for vydaj, expected_client in zip(data["vydaje"], ["A prevádzka", "B prevádzka"]):
-        assert [route["name"] for route in vydaj["routes"]] == ["Trasa 1"]
+    for vydaj, expected_route, expected_client in zip(
+        data["vydaje"], ["Trasa A", "Trasa B"], ["A prevádzka", "B prevádzka"]
+    ):
+        assert [route["name"] for route in vydaj["routes"]] == [expected_route]
         assert [row["client"] for row in vydaj["routes"][0]["rows"]] == [
             expected_client
         ]

--- a/backend/tests/test_delivery_layout.py
+++ b/backend/tests/test_delivery_layout.py
@@ -82,6 +82,38 @@ def test_delivery_layout_reorder_moves_prevadzky_between_routes(
     assert second.delivery_sort_order == 1
 
 
+def test_route_can_be_moved_to_another_block(admin_authenticated_client):
+    """Blok = výdajný bod kuchyne; trasa sa medzi bodmi musí dať presunúť."""
+    bezne = DeliveryBlock.objects.create(name="Bežné trasy", sort_order=1)
+    extra = DeliveryBlock.objects.create(name="Trasa extra", sort_order=2)
+    route = DeliveryRoute.objects.create(block=bezne, name="Trasa 1", sort_order=1)
+
+    response = admin_authenticated_client.patch(
+        f"/api/admin/delivery-routes/{route.id}/",
+        {"block": extra.id, "sort_order": 1},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    route.refresh_from_db()
+    assert route.block_id == extra.id
+
+
+def test_block_can_be_renamed(admin_authenticated_client):
+    """Prevádzka si bloky pomenúva sama (napr. Cluster 1 / Cluster 2)."""
+    block = DeliveryBlock.objects.create(name="Bežné trasy", sort_order=1)
+
+    response = admin_authenticated_client.patch(
+        f"/api/admin/delivery-blocks/{block.id}/",
+        {"name": "Cluster 1"},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    block.refresh_from_db()
+    assert block.name == "Cluster 1"
+
+
 def test_gramage_dashboard_groups_rows_by_delivery_layout_order():
     block = DeliveryBlock.objects.create(name="Extra", sort_order=2)
     route = DeliveryRoute.objects.create(block=block, name="TRASA EXTRA", sort_order=3)

--- a/backend/tests/test_delivery_layout.py
+++ b/backend/tests/test_delivery_layout.py
@@ -114,6 +114,52 @@ def test_block_can_be_renamed(admin_authenticated_client):
     assert block.name == "Cluster 1"
 
 
+def test_gramage_dashboard_splits_one_route_between_vydaje():
+    """Výdaj je vlastnosť prevádzky — jedna trasa vie voziť do oboch bodov.
+
+    Trasa sa preto objaví v oboch tabuľkách, zakaždým len so svojimi riadkami.
+    """
+    block = DeliveryBlock.objects.create(name="Bežné trasy", sort_order=1)
+    route = DeliveryRoute.objects.create(block=block, name="Trasa 1", sort_order=1)
+    v_a = _prevadzka("A prevádzka", route=route, order=1)
+    v_b = _prevadzka("B prevádzka", route=route, order=2)
+    Prevadzka.objects.filter(pk=v_b.pk).update(vydaj="B")
+
+    user = User.objects.create_user(
+        username="vydaj@example.com", email="vydaj@example.com"
+    )
+    PortionType.objects.create(name="Škôlka", coefficient="1.0000", sort_order=1)
+    template = MealTemplate.objects.create(
+        category="main_course",
+        name="Rizoto",
+        weight_label="200g",
+        base_weight_grams="200.00",
+        components=[{"label": "Hlavná zložka", "grams": "200", "unit": "g"}],
+    )
+    plan = DailyMealPlan.objects.create(
+        date=datetime.date(2026, 7, 20), created_by=user
+    )
+    MealPlanItem.objects.create(
+        meal_plan=plan, template=template, category="main_course"
+    )
+    for prevadzka in (v_a, v_b):
+        DailyOrder.objects.create(
+            user=user,
+            prevadzka=prevadzka,
+            date=plan.date,
+            data={"lunch": {"Škôlka": {"menuCounts": {"A": 1}, "diets": {}}}},
+        )
+
+    data = MealPlanService.gramage_dashboard(plan.date.isoformat())
+
+    assert [vydaj["key"] for vydaj in data["vydaje"]] == ["A", "B"]
+    for vydaj, expected_client in zip(data["vydaje"], ["A prevádzka", "B prevádzka"]):
+        assert [route["name"] for route in vydaj["routes"]] == ["Trasa 1"]
+        assert [row["client"] for row in vydaj["routes"][0]["rows"]] == [
+            expected_client
+        ]
+
+
 def test_gramage_dashboard_groups_rows_by_delivery_layout_order():
     block = DeliveryBlock.objects.create(name="Extra", sort_order=2)
     route = DeliveryRoute.objects.create(block=block, name="TRASA EXTRA", sort_order=3)
@@ -153,9 +199,11 @@ def test_gramage_dashboard_groups_rows_by_delivery_layout_order():
     data = MealPlanService.gramage_dashboard(plan.date.isoformat())
 
     assert [row["client"] for row in data["rows"]] == ["A prevádzka", "B prevádzka"]
-    assert data["blocks"][0]["name"] == "Extra"
-    assert data["blocks"][0]["routes"][0]["name"] == "TRASA EXTRA"
-    assert [row["client"] for row in data["blocks"][0]["routes"][0]["rows"]] == [
+    # Najvyššia úroveň tabuľky je výdajný bod prevádzky (default „Výdaj A"),
+    # poradie vnútri neho ostáva rozvozové.
+    assert data["vydaje"][0]["name"] == "Výdaj A"
+    assert data["vydaje"][0]["routes"][0]["name"] == "TRASA EXTRA"
+    assert [row["client"] for row in data["vydaje"][0]["routes"][0]["rows"]] == [
         "A prevádzka",
         "B prevádzka",
     ]

--- a/backend/tests/test_exporters.py
+++ b/backend/tests/test_exporters.py
@@ -212,6 +212,8 @@ class TestGramageDashboardExports:
         )
         second_route = DeliveryRoute.objects.create(
             block=second_block,
+            # Druhý výdajný bod kuchyne — tabuľka sa delí podľa výdaja trasy.
+            vydaj="B",
             name="Druhá trasa",
             driver="Vodič 2",
             departure_time=datetime.time(8, 0),
@@ -232,8 +234,6 @@ class TestGramageDashboardExports:
                 nazov="Prevádzka 2",
                 delivery_route=second_route,
                 delivery_sort_order=1,
-                # Druhý výdajný bod kuchyne — tabuľka sa delí podľa neho.
-                vydaj="B",
             ),
             Prevadzka.objects.create(
                 celok=celok,

--- a/backend/tests/test_exporters.py
+++ b/backend/tests/test_exporters.py
@@ -160,7 +160,7 @@ class TestGramageDashboardExports:
         assert ("Bezlepková", "2") in rendered
         assert ("Vegan", "1") in rendered
 
-    def test_portion_summaries_export_per_delivery_block_and_globally(self):
+    def test_portion_summaries_export_per_vydaj_and_globally(self):
         user = User.objects.create_user(
             username="delivery-export@example.com",
             email="delivery-export@example.com",
@@ -232,6 +232,8 @@ class TestGramageDashboardExports:
                 nazov="Prevádzka 2",
                 delivery_route=second_route,
                 delivery_sort_order=1,
+                # Druhý výdajný bod kuchyne — tabuľka sa delí podľa neho.
+                vydaj="B",
             ),
             Prevadzka.objects.create(
                 celok=celok,
@@ -248,21 +250,21 @@ class TestGramageDashboardExports:
             )
 
         data = MealPlanService.gramage_dashboard(plan.date.isoformat())
-        assert len(data["blocks"]) == 2
+        assert len(data["vydaje"]) == 2
         assert len(data["unassigned_rows"]) == 1
         expected_summaries = [
             (
-                f"Súhrn porcií {block_index + 1}",
+                f"Súhrn porcií — {vydaj['name']}",
                 portion_summary(
                     data,
                     [
                         row
-                        for route in block.get("routes", [])
+                        for route in vydaj.get("routes", [])
                         for row in route.get("rows", [])
                     ],
                 ),
             )
-            for block_index, block in enumerate(data["blocks"])
+            for vydaj in data["vydaje"]
         ]
         expected_summaries.append(("Porcie celkom", portion_summary(data)))
 

--- a/docs/feedback-2026-08-17-stano.md
+++ b/docs/feedback-2026-08-17-stano.md
@@ -1,0 +1,50 @@
+# Spätná väzba z prevádzky — 17. 8. 2026 (Stanislav Šulc, ZP)
+
+Zdroj: WhatsApp konverzácia Stano Šulc ↔ Tomáš Magula, 17. 8. 2026.
+
+## Stav
+- Manuálne zadávanie počtov cez appku išlo **všetkým prevádzkam bez problémov**.
+- Jediný problém dňa: **Cvernička** — nová diéta z EduPage sa nenačítala, lebo v appke
+  nebola zadaná.
+- Stano pripravuje **zoznam škôlok na pozvanie do ďalšieho kola testovania** (čaká sa naň).
+
+## Požiadavky
+
+### 1. Rozdelenie tabuľky na 2 clustre (najväčšia vec)
+Kuchyňa teraz vydáva stravu **z dvoch výdajných bodov súčasne** — Cluster 1 a Cluster 2.
+Jedna veľká tabuľka sa má rozdeliť na dve samostatné tabuľky:
+- každý cluster má **svoje trasy vo vlastnom poradí**,
+- poradie škôlok v rámci clustera sa má dať nastaviť **manuálne**.
+
+**Ujasnené (Stano, 16:51):** existujúca trasa **„Extra“ = Cluster 2**. Čiže clustre sa
+mapujú na trasy, nie je to nová nezávislá dimenzia — treba len skupinu trás priradiť
+clusteru a tlačiť/zobrazovať per cluster.
+
+Poznámka Tomáša: karta na úpravu trás a poradia už existuje — otázka je, či stačí nad ňou
+postaviť priradenie do clusterov.
+
+### 2. Čitateľnosť tabuľky
+- Jasnejšie oddelenie trás: **väčšie písmo, celý riadok hlavičky trasy červený**.
+- Jasnejšie označiť/oddeliť **raňajky / obed / olovrant**.
+
+### 3. Tlač — výber čo sa tlačí
+Možnosť vybrať, čo ide do tlače: iba raňajky / iba obed / iba olovrant / iba menu B, …
+**Funkcia už existuje** (vyfiltruj v tabuľke → tlač vytlačí len to), ale treba ju spraviť
+**intuitívnejšou / viditeľnejšou** v UI.
+
+### 4. Konfigurovateľné názvy
+Možnosť **premenovať „hlavná zložka“** a podobné popisky stĺpcov/zložiek.
+
+### 5. Prázdny stĺpec „Poznámka“
+Pridať do tabuľky ešte jeden prázdny stĺpec „Poznámka“ (na ručné dopísanie pri tlači).
+
+### 6. Nové diéty z EduPage
+Cvernička načítala z EduPage diétu, ktorú appka nepozná.
+- Dnešný stav: **úpravy v EduPage sa musia dorobiť manuálne** → zmeny treba hlásiť čo najskôr.
+- Otvorená otázka od Stana: „ako to upravíme?“ → zvážiť aspoň **detekciu neznámej diéty
+  pri scrape + upozornenie**, aby to nezapadlo, namiesto tichého vynechania.
+
+## Otvorené / na doriešenie
+- Presná definícia clustra: stačí príznak na trase (cluster 1/2) + samostatná tlač?
+- Ako riešiť neznáme diéty z EduPage (upozornenie vs. auto-založenie).
+- Zoznam škôlok do ďalšieho testovania — čaká sa na Stana.

--- a/docs/feedback-2026-08-17-stano.md
+++ b/docs/feedback-2026-08-17-stano.md
@@ -44,6 +44,20 @@ Cvernička načítala z EduPage diétu, ktorú appka nepozná.
 - Otvorená otázka od Stana: „ako to upravíme?“ → zvážiť aspoň **detekciu neznámej diéty
   pri scrape + upozornenie**, aby to nezapadlo, namiesto tichého vynechania.
 
+## Stav riešenia (vetva `feat/edupage-neznama-dieta`)
+
+| Požiadavka | Stav |
+| --- | --- |
+| Neznáma diéta z EduPage | hotové — porcie sa započítajú, diéta sa flagne v admin prehľade, whitelist berie diéty z DB |
+| Tlač po výdajných bodoch (clustre) | hotové — filter „Výdajný bod" na obrazovke aj v PDF, každý blok v PDF na vlastnom liste |
+| Premenovanie blokov / presun trás medzi blokmi | hotové — v karte Rozvoz (Cluster 1 / Cluster 2 si vieš pomenovať sám) |
+| Poradie trás a škôlok | už existovalo v karte Rozvoz |
+| Červený riadok trasy, väčšie písmo | hotové |
+| Oddelenie raňajky / obed / olovrant | hotové — nadradený pás jedál v hlavičke + hrubší predel stĺpcov |
+| Výber čo tlačiť | hotové — filter je jedna karta (Jedlá / Výdajný bod) s vetou, čo pôjde do PDF |
+| Premenovanie „hlavná zložka" | hotové — Katalóg jedál → Upraviť |
+| Stĺpec „Poznámka" | hotové — prázdny stĺpec na konci tabuľky |
+
 ## Otvorené / na doriešenie
 - Presná definícia clustra: stačí príznak na trase (cluster 1/2) + samostatná tlač?
 - Ako riešiť neznáme diéty z EduPage (upozornenie vs. auto-založenie).

--- a/docs/feedback-2026-08-17-stano.md
+++ b/docs/feedback-2026-08-17-stano.md
@@ -60,6 +60,17 @@ Cvernička načítala z EduPage diétu, ktorú appka nepozná.
 | Stĺpec „Poznámka" | hotové — prázdny stĺpec na konci tabuľky |
 
 ## Otvorené / na doriešenie
-- Presná definícia clustra: stačí príznak na trase (cluster 1/2) + samostatná tlač?
-- Ako riešiť neznáme diéty z EduPage (upozornenie vs. auto-založenie).
-- Zoznam škôlok do ďalšieho testovania — čaká sa na Stana.
+- **Zoznam škôlok do ďalšieho testovania** — čaká sa na Stana.
+- **Pomenovanie výdajov**: dnes natvrdo „Výdaj A / B / C". Ak ich chce prevádzka volať
+  inak (napr. „Cluster 1"), treba z toho spraviť číselník s CRUD-om — teraz je to
+  zmena v kóde + migrácia.
+- **Neznáma diéta z EduPage** sa hlási, ale nezakladá sama. Ak sa ukáže, že hlásenie
+  nikto nečíta včas, ďalší krok je auto-založenie diéty ako neaktívnej + notifikácia.
+- **Prevádzka bez trasy** („Nepriradené prevádzky") nepatrí do žiadneho výdaja — v celej
+  tabuľke je vidieť na konci, pri tlači jedného výdaja sa nezobrazí. Ak by mali chodiť
+  aj do konkrétneho výdaja, treba im dať trasu.
+- **Bloky rozvozu** (Bežné trasy / Trasa extra) sú po zavedení výdajov už len
+  organizačné zoskupenie trás v karte Rozvoz; príznaky `include_in_*_summary` slúžia iba
+  na predvolený výdaj pri seedovaní novej trasy. Ak sa ukážu ako mätúce, dajú sa zrušiť.
+- **Denný report / e-mail** posiela celú tabuľku (každý výdaj na vlastnom liste), nie
+  samostatný súbor per výdaj — zatiaľ to nikto nežiadal.

--- a/docs/feedback-2026-08-17-stano.md
+++ b/docs/feedback-2026-08-17-stano.md
@@ -49,8 +49,8 @@ Cvernička načítala z EduPage diétu, ktorú appka nepozná.
 | Požiadavka | Stav |
 | --- | --- |
 | Neznáma diéta z EduPage | hotové — porcie sa započítajú, diéta sa flagne v admin prehľade, whitelist berie diéty z DB |
-| Rozdelenie na clustre (výdajné body) | hotové — **výdaj je vlastnosť prevádzky** (radio v jej nastaveniach: Výdaj A / B / C). Tabuľka sa podľa neho delí, v PDF ide každý výdaj na vlastný list. Migrácia hodila prevádzky z Trasy extra do Výdaja B. |
-| Výber clustra v prehľade a v trasách | hotové — dropdown „Výdaj" v Prehľade (platí aj pre tlač) a v karte Rozvoz (filter + prepnutie výdaja priamo pri prevádzke) |
+| Rozdelenie na clustre (výdajné body) | hotové — **výdaj je vlastnosť trasy** (select pri trase v karte Rozvoz: Výdaj A / B / C). Trasy výdaja A tvoria tabuľku A, trasy výdaja B tabuľku B; prevádzka patrí do výdaja svojej trasy. V PDF ide každý výdaj na vlastný list. Migrácia hodila trasy z bloku Trasa extra do Výdaja B. |
+| Výber clustra v prehľade a v trasách | hotové — dropdown „Výdaj" v Prehľade (platí aj pre tlač) a filter v karte Rozvoz |
 | Premenovanie blokov / presun trás medzi blokmi | hotové — v karte Rozvoz (bloky ostávajú organizačná vec rozvozu) |
 | Poradie trás a škôlok | už existovalo v karte Rozvoz |
 | Zvýraznenie trasy | hotové — jemný červený pás s pilulkou (prvá verzia bola príliš krikľavá, stlmené) |

--- a/docs/feedback-2026-08-17-stano.md
+++ b/docs/feedback-2026-08-17-stano.md
@@ -49,10 +49,11 @@ Cvernička načítala z EduPage diétu, ktorú appka nepozná.
 | Požiadavka | Stav |
 | --- | --- |
 | Neznáma diéta z EduPage | hotové — porcie sa započítajú, diéta sa flagne v admin prehľade, whitelist berie diéty z DB |
-| Tlač po výdajných bodoch (clustre) | hotové — filter „Výdajný bod" na obrazovke aj v PDF, každý blok v PDF na vlastnom liste |
-| Premenovanie blokov / presun trás medzi blokmi | hotové — v karte Rozvoz (Cluster 1 / Cluster 2 si vieš pomenovať sám) |
+| Rozdelenie na clustre (výdajné body) | hotové — **výdaj je vlastnosť prevádzky** (radio v jej nastaveniach: Výdaj A / B / C). Tabuľka sa podľa neho delí, v PDF ide každý výdaj na vlastný list. Migrácia hodila prevádzky z Trasy extra do Výdaja B. |
+| Výber clustra v prehľade a v trasách | hotové — dropdown „Výdaj" v Prehľade (platí aj pre tlač) a v karte Rozvoz (filter + prepnutie výdaja priamo pri prevádzke) |
+| Premenovanie blokov / presun trás medzi blokmi | hotové — v karte Rozvoz (bloky ostávajú organizačná vec rozvozu) |
 | Poradie trás a škôlok | už existovalo v karte Rozvoz |
-| Červený riadok trasy, väčšie písmo | hotové |
+| Zvýraznenie trasy | hotové — jemný červený pás s pilulkou (prvá verzia bola príliš krikľavá, stlmené) |
 | Oddelenie raňajky / obed / olovrant | hotové — nadradený pás jedál v hlavičke + hrubší predel stĺpcov |
 | Výber čo tlačiť | hotové — filter je jedna karta (Jedlá / Výdajný bod) s vetou, čo pôjde do PDF |
 | Premenovanie „hlavná zložka" | hotové — Katalóg jedál → Upraviť |

--- a/frontend/src/pages/admin/AdminDashboard.test.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.test.tsx
@@ -437,36 +437,34 @@ describe("Filter sekcií", () => {
     });
   });
 
-  it("prints a single dispatch point when a block chip is ticked off", async () => {
+  it("prints a single dispatch point when one is picked", async () => {
     // Kuchyňa vydáva z dvoch bodov naraz a chce tabuľku jedného z nich.
     mockDashboardRequests({
       ...GRAMAGE_WITH_ROWS,
       spec: {
         ...GRAMAGE_WITH_ROWS.spec,
-        blocks: [
-          { name: "Bežné trasy", selected: true },
-          { name: "Trasa extra", selected: true },
+        vydaje: [
+          { key: "A", name: "Výdaj A", selected: true },
+          { key: "B", name: "Výdaj B", selected: true },
         ],
       },
     });
     render(<AdminDashboard />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Trasa extra" }));
+    fireEvent.change(await screen.findByLabelText("Výdajný bod"), {
+      target: { value: "B" },
+    });
 
     await waitFor(() => {
       expect(mockApiFetch).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /gramage-dashboard\/\?date=[\d-]+&block=Be%C5%BEn%C3%A9%20trasy$/,
-        ),
+        expect.stringMatching(/gramage-dashboard\/\?date=[\d-]+&vydaj=B$/),
       );
     });
 
     fireEvent.click(screen.getByRole("button", { name: /stiahnuť pdf/i }));
     await waitFor(() => {
       expect(mockApiFetch).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /gramage-dashboard-pdf\/\?date=[\d-]+&block=Be%C5%BEn%C3%A9%20trasy$/,
-        ),
+        expect.stringMatching(/gramage-dashboard-pdf\/\?date=[\d-]+&vydaj=B$/),
       );
     });
   });

--- a/frontend/src/pages/admin/AdminDashboard.test.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.test.tsx
@@ -437,6 +437,40 @@ describe("Filter sekcií", () => {
     });
   });
 
+  it("prints a single dispatch point when a block chip is ticked off", async () => {
+    // Kuchyňa vydáva z dvoch bodov naraz a chce tabuľku jedného z nich.
+    mockDashboardRequests({
+      ...GRAMAGE_WITH_ROWS,
+      spec: {
+        ...GRAMAGE_WITH_ROWS.spec,
+        blocks: [
+          { name: "Bežné trasy", selected: true },
+          { name: "Trasa extra", selected: true },
+        ],
+      },
+    });
+    render(<AdminDashboard />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Trasa extra" }));
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /gramage-dashboard\/\?date=[\d-]+&block=Be%C5%BEn%C3%A9%20trasy$/,
+        ),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /stiahnuť pdf/i }));
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /gramage-dashboard-pdf\/\?date=[\d-]+&block=Be%C5%BEn%C3%A9%20trasy$/,
+        ),
+      );
+    });
+  });
+
   it("drops the filter entirely once everything is ticked again", async () => {
     mockDashboardRequests(GRAMAGE_WITH_ROWS);
     render(<AdminDashboard />);

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "../../context/auth";
 import { useToast } from "../../context/ToastContext";
 import { logger } from '../../lib/logger';
 import ConfirmationModal from "../client/components/ui/ConfirmationModal";
-import { PageHead, Button, Card, Badge, Empty } from "./ui";
+import { PageHead, Button, Card, Badge, Empty, Select } from "./ui";
 import { DietColorSwatch } from "./DietColorSwatch";
 
 const API = import.meta.env.VITE_API_URL || "/api";
@@ -127,7 +127,8 @@ interface SpecSection {
   selected: boolean;
 }
 
-interface SpecBlock {
+interface SpecVydaj {
+  key: string;
   name: string;
   selected: boolean;
 }
@@ -135,8 +136,8 @@ interface SpecBlock {
 interface TableSpec {
   total_columns: number;
   sections: SpecSection[];
-  /** Výdajné body kuchyne (clustre) — každý sa dá zobraziť a vytlačiť sám. */
-  blocks: SpecBlock[];
+  /** Výdajné body kuchyne — každý sa dá zobraziť a vytlačiť sám. */
+  vydaje: SpecVydaj[];
   header: {
     corner: string;
     /** Nadradený pás hlavičky: Raňajky / Obed / Olovrant. */
@@ -252,7 +253,8 @@ const AdminDashboard: React.FC = () => {
   const [unlocking, setUnlocking] = useState(false);
   const closedRequestId = useRef(0);
   const [sections, setSections] = useState<string[]>([]);
-  const [blocks, setBlocks] = useState<string[]>([]);
+  // Prázdny výber = všetky výdajné body; inak práve ten jeden vybratý.
+  const [vydaj, setVydaj] = useState<string>("");
 
   // Ktoré sekcie (raňajky / polievka / menu / olovrant) a ktoré výdajné body sa
   // zobrazujú. Prázdny výber = kompletná tabuľka. Rovnaký filter dostane
@@ -261,9 +263,9 @@ const AdminDashboard: React.FC = () => {
     () =>
       [
         ...sections.map((key) => `&section=${encodeURIComponent(key)}`),
-        ...blocks.map((name) => `&block=${encodeURIComponent(name)}`),
+        ...(vydaj ? [`&vydaj=${encodeURIComponent(vydaj)}`] : []),
       ].join(""),
-    [sections, blocks],
+    [sections, vydaj],
   );
 
   const fetchData = useCallback(async () => {
@@ -480,7 +482,8 @@ const AdminDashboard: React.FC = () => {
           <>
             <PrintFilter
               sections={data.spec.sections}
-              blocks={data.spec.blocks ?? []}
+              vydaje={data.spec.vydaje ?? []}
+              vydaj={vydaj}
               onToggleSection={(key) =>
                 setSections((current) =>
                   toggleSelection(
@@ -490,18 +493,10 @@ const AdminDashboard: React.FC = () => {
                   ),
                 )
               }
-              onToggleBlock={(name) =>
-                setBlocks((current) =>
-                  toggleSelection(
-                    current,
-                    name,
-                    (data.spec.blocks ?? []).map((block) => block.name),
-                  ),
-                )
-              }
+              onVydajChange={setVydaj}
               onReset={() => {
                 setSections([]);
-                setBlocks([]);
+                setVydaj("");
               }}
             />
             <GramageTable data={data} />
@@ -693,13 +688,13 @@ const FilterRow: React.FC<{
 
 const PrintFilter: React.FC<{
   sections: SpecSection[];
-  blocks: SpecBlock[];
+  vydaje: SpecVydaj[];
+  vydaj: string;
   onToggleSection: (key: string) => void;
-  onToggleBlock: (name: string) => void;
+  onVydajChange: (key: string) => void;
   onReset: () => void;
-}> = ({ sections, blocks, onToggleSection, onToggleBlock, onReset }) => {
-  const allSelected =
-    sections.every((section) => section.selected) && blocks.every((block) => block.selected);
+}> = ({ sections, vydaje, vydaj, onToggleSection, onVydajChange, onReset }) => {
+  const allSelected = sections.every((section) => section.selected) && !vydaj;
   return (
     <div className="zpa-section-filter">
       <FilterRow
@@ -707,16 +702,21 @@ const PrintFilter: React.FC<{
         items={sections.map((section) => ({ ...section, key: section.key }))}
         onToggle={onToggleSection}
       />
-      {blocks.length > 1 && (
-        <FilterRow
-          label="Výdajný bod"
-          items={blocks.map((block) => ({
-            key: block.name,
-            label: block.name,
-            selected: block.selected,
-          }))}
-          onToggle={onToggleBlock}
-        />
+      {vydaje.length > 1 && (
+        <div className="row">
+          <span className="lbl">Výdaj</span>
+          <Select
+            value={vydaj}
+            onChange={(e) => onVydajChange(e.target.value)}
+            style={{ width: "auto" }}
+            aria-label="Výdajný bod"
+          >
+            <option value="">Všetky výdaje</option>
+            {vydaje.map((item) => (
+              <option key={item.key} value={item.key}>{item.name}</option>
+            ))}
+          </Select>
+        </div>
       )}
       <div className="row">
         <span className="hint">

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -127,9 +127,16 @@ interface SpecSection {
   selected: boolean;
 }
 
+interface SpecBlock {
+  name: string;
+  selected: boolean;
+}
+
 interface TableSpec {
   total_columns: number;
   sections: SpecSection[];
+  /** Výdajné body kuchyne (clustre) — každý sa dá zobraziť a vytlačiť sám. */
+  blocks: SpecBlock[];
   header: {
     corner: string;
     /** Nadradený pás hlavičky: Raňajky / Obed / Olovrant. */
@@ -245,13 +252,18 @@ const AdminDashboard: React.FC = () => {
   const [unlocking, setUnlocking] = useState(false);
   const closedRequestId = useRef(0);
   const [sections, setSections] = useState<string[]>([]);
+  const [blocks, setBlocks] = useState<string[]>([]);
 
-  // Ktoré sekcie (raňajky / polievka / menu / olovrant) sa zobrazujú. Prázdny
-  // výber = kompletná tabuľka. Rovnaký filter dostane obrazovka aj PDF, takže
-  // vytlačíš presne to, čo vidíš.
+  // Ktoré sekcie (raňajky / polievka / menu / olovrant) a ktoré výdajné body sa
+  // zobrazujú. Prázdny výber = kompletná tabuľka. Rovnaký filter dostane
+  // obrazovka aj PDF, takže vytlačíš presne to, čo vidíš.
   const sectionQuery = useMemo(
-    () => sections.map((key) => `&section=${encodeURIComponent(key)}`).join(""),
-    [sections],
+    () =>
+      [
+        ...sections.map((key) => `&section=${encodeURIComponent(key)}`),
+        ...blocks.map((name) => `&block=${encodeURIComponent(name)}`),
+      ].join(""),
+    [sections, blocks],
   );
 
   const fetchData = useCallback(async () => {
@@ -466,22 +478,31 @@ const AdminDashboard: React.FC = () => {
 
         {!loading && data && hasData && (
           <>
-            <SectionFilter
+            <PrintFilter
               sections={data.spec.sections}
-              onToggle={(key) =>
-                setSections((current) => {
-                  // Prázdny výber znamená „všetko", takže prvé odkliknutie musí
-                  // vychádzať zo skutočne zobrazených sekcií, nie z prázdna.
-                  const base = current.length
-                    ? current
-                    : data.spec.sections.map((section) => section.key);
-                  const next = base.includes(key)
-                    ? base.filter((item) => item !== key)
-                    : [...base, key];
-                  return next.length === data.spec.sections.length ? [] : next;
-                })
+              blocks={data.spec.blocks ?? []}
+              onToggleSection={(key) =>
+                setSections((current) =>
+                  toggleSelection(
+                    current,
+                    key,
+                    data.spec.sections.map((section) => section.key),
+                  ),
+                )
               }
-              onReset={() => setSections([])}
+              onToggleBlock={(name) =>
+                setBlocks((current) =>
+                  toggleSelection(
+                    current,
+                    name,
+                    (data.spec.blocks ?? []).map((block) => block.name),
+                  ),
+                )
+              }
+              onReset={() => {
+                setSections([]);
+                setBlocks([]);
+              }}
             />
             <GramageTable data={data} />
           </>
@@ -635,34 +656,80 @@ const OrderCountsTable: React.FC<{ report: OrderReport }> = ({ report }) => {
   );
 };
 
-// ── Filter sekcií ─────────────────────────────────────────────────────────────
+// ── Filter zobrazenia a tlače ────────────────────────────────────────────────
 // Rovnaký výber ide na obrazovku aj do PDF — čo vidíš, to vytlačíš.
 
-const SectionFilter: React.FC<{
-  sections: SpecSection[];
+/**
+ * Prepnutie jednej položky vo filtri. Prázdny výber znamená „všetko", takže
+ * prvé odkliknutie musí vychádzať zo skutočne zobrazených položiek, nie z
+ * prázdna; a keď sú nakoniec vybraté všetky, vraciame sa na prázdno.
+ */
+const toggleSelection = (current: string[], value: string, all: string[]): string[] => {
+  const base = current.length ? current : all;
+  const next = base.includes(value) ? base.filter((item) => item !== value) : [...base, value];
+  return next.length === all.length ? [] : next;
+};
+
+const FilterRow: React.FC<{
+  label: string;
+  items: Array<{ key: string; label: string; selected: boolean }>;
   onToggle: (key: string) => void;
+}> = ({ label, items, onToggle }) => (
+  <div className="row">
+    <span className="lbl">{label}</span>
+    {items.map((item) => (
+      <button
+        key={item.key}
+        type="button"
+        className={`chip${item.selected ? " on" : ""}`}
+        aria-pressed={item.selected}
+        onClick={() => onToggle(item.key)}
+      >
+        {item.label}
+      </button>
+    ))}
+  </div>
+);
+
+const PrintFilter: React.FC<{
+  sections: SpecSection[];
+  blocks: SpecBlock[];
+  onToggleSection: (key: string) => void;
+  onToggleBlock: (name: string) => void;
   onReset: () => void;
-}> = ({ sections, onToggle, onReset }) => {
-  const allSelected = sections.every((section) => section.selected);
+}> = ({ sections, blocks, onToggleSection, onToggleBlock, onReset }) => {
+  const allSelected =
+    sections.every((section) => section.selected) && blocks.every((block) => block.selected);
   return (
     <div className="zpa-section-filter">
-      <span className="lbl">Zobraziť</span>
-      {sections.map((section) => (
-        <button
-          key={section.key}
-          type="button"
-          className={`chip${section.selected ? " on" : ""}`}
-          aria-pressed={section.selected}
-          onClick={() => onToggle(section.key)}
-        >
-          {section.label}
-        </button>
-      ))}
-      {!allSelected && (
-        <button type="button" className="reset" onClick={onReset}>
-          Zobraziť všetko
-        </button>
+      <FilterRow
+        label="Jedlá"
+        items={sections.map((section) => ({ ...section, key: section.key }))}
+        onToggle={onToggleSection}
+      />
+      {blocks.length > 1 && (
+        <FilterRow
+          label="Výdajný bod"
+          items={blocks.map((block) => ({
+            key: block.name,
+            label: block.name,
+            selected: block.selected,
+          }))}
+          onToggle={onToggleBlock}
+        />
       )}
+      <div className="row">
+        <span className="hint">
+          {allSelected
+            ? "Tlačí sa celá tabuľka. Odkliknutím vyberieš, čo sa má zobraziť aj vytlačiť."
+            : "Do PDF ide presne tento výber."}
+        </span>
+        {!allSelected && (
+          <button type="button" className="reset" onClick={onReset}>
+            Zobraziť všetko
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -132,6 +132,8 @@ interface TableSpec {
   sections: SpecSection[];
   header: {
     corner: string;
+    /** Nadradený pás hlavičky: Raňajky / Obed / Olovrant. */
+    meals?: Array<{ text: string; css: string; colspan: number }>;
     groups: Array<{ text: string; sub: string; css: string; colspan: number }>;
     components: Array<{ text: string; sub: string; css: string }>;
   };
@@ -760,6 +762,8 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
     );
   };
 
+  const mealBands = spec.header.meals ?? [];
+
   // Podriadky, poznámky a medzisúčty klienta sa ukazujú až po rozbalení.
   const visibleRows = spec.rows.filter(
     (row) => !row.collapsible || expandedClients.includes(row.group_id ?? ""),
@@ -770,8 +774,20 @@ const GramageTable: React.FC<{ data: GramageDashboard }> = ({ data }) => {
       <div className="zpa-table-wrap zpa-gram-wrap">
         <table className="zpa-gram">
           <thead>
+            {mealBands.length > 0 && (
+              <tr>
+                <th className="corner" rowSpan={3}>{spec.header.corner}</th>
+                {mealBands.map((band, index) => (
+                  <th key={index} className={band.css} colSpan={band.colspan}>
+                    {band.text}
+                  </th>
+                ))}
+              </tr>
+            )}
             <tr>
-              <th className="corner" rowSpan={2}>{spec.header.corner}</th>
+              {mealBands.length === 0 && (
+                <th className="corner" rowSpan={2}>{spec.header.corner}</th>
+              )}
               {spec.header.groups.map((group, index) => (
                 <th key={index} className={group.css} colSpan={group.colspan}>
                   {group.text}<small>{group.sub}</small>

--- a/frontend/src/pages/admin/ClientDetail.tsx
+++ b/frontend/src/pages/admin/ClientDetail.tsx
@@ -49,7 +49,6 @@ interface FacilityDetail {
   adresa: string;
   edupage_connection: number | null;
   edupage_match: string;
-  vydaj: string;
   report_alias: string;
   delivery_note: string;
   sort_order: number;
@@ -123,7 +122,6 @@ const ClientDetail: React.FC = () => {
     adresa: "",
     edupage_connection: null,
     edupage_match: "",
-    vydaj: "A",
     report_alias: "",
     delivery_note: "",
     sort_order: 0,
@@ -182,7 +180,6 @@ const ClientDetail: React.FC = () => {
       adresa: data.adresa || "",
       edupage_connection: data.edupage_connection ?? null,
       edupage_match: data.edupage_match || "",
-      vydaj: data.vydaj || "A",
       report_alias: data.report_alias || "",
       delivery_note: data.delivery_note || "",
       sort_order: data.sort_order || 0,

--- a/frontend/src/pages/admin/ClientDetail.tsx
+++ b/frontend/src/pages/admin/ClientDetail.tsx
@@ -49,6 +49,7 @@ interface FacilityDetail {
   adresa: string;
   edupage_connection: number | null;
   edupage_match: string;
+  vydaj: string;
   report_alias: string;
   delivery_note: string;
   sort_order: number;
@@ -122,6 +123,7 @@ const ClientDetail: React.FC = () => {
     adresa: "",
     edupage_connection: null,
     edupage_match: "",
+    vydaj: "A",
     report_alias: "",
     delivery_note: "",
     sort_order: 0,
@@ -180,6 +182,7 @@ const ClientDetail: React.FC = () => {
       adresa: data.adresa || "",
       edupage_connection: data.edupage_connection ?? null,
       edupage_match: data.edupage_match || "",
+      vydaj: data.vydaj || "A",
       report_alias: data.report_alias || "",
       delivery_note: data.delivery_note || "",
       sort_order: data.sort_order || 0,

--- a/frontend/src/pages/admin/DeliveryLayoutAdmin.tsx
+++ b/frontend/src/pages/admin/DeliveryLayoutAdmin.tsx
@@ -98,6 +98,12 @@ const DeliveryLayoutAdmin: React.FC = () => {
   const [editRouteName, setEditRouteName] = useState("");
   const [editRouteDriver, setEditRouteDriver] = useState("");
   const [editRouteTime, setEditRouteTime] = useState("");
+  // Blok je výdajný bod kuchyne (cluster) — trasa sa medzi nimi musí dať
+  // presunúť a blok premenovať, inak sa rozdelenie na dva body dá nastaviť len
+  // zakladaním trás nanovo (spätná väzba 17. 8. 2026).
+  const [editRouteBlock, setEditRouteBlock] = useState<number | null>(null);
+  const [editBlock, setEditBlock] = useState<DeliveryBlock | null>(null);
+  const [editBlockName, setEditBlockName] = useState("");
   const [dragging, setDragging] = useState<DragState | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState | null>(null);
   const [confirmBusy, setConfirmBusy] = useState(false);
@@ -377,11 +383,46 @@ const DeliveryLayoutAdmin: React.FC = () => {
     }
   };
 
+  /**
+   * Presun trasy do iného bloku ju zaradí na konec cieľového bloku. Bez toho by
+   * si ponechala pôvodné `sort_order` a v novom bloku by skočila doprostred —
+   * poradie trás si prevádzka nastavuje ručne a takýto skok je preň chyba.
+   */
+  const blockMovePatch = (route: DeliveryRoute, targetBlockId: number | null) => {
+    const target = targetBlockId ?? route.block;
+    if (target === route.block) return { block: target };
+    const siblings = layout.blocks.find((block) => block.id === target)?.routes ?? [];
+    return { block: target, sort_order: siblings.length + 1 };
+  };
+
   const openEditRoute = (route: DeliveryRoute) => {
     setEditRoute(route);
     setEditRouteName(route.name);
     setEditRouteDriver(route.driver || "");
     setEditRouteTime(route.departure_time?.slice(0, 5) || "");
+    setEditRouteBlock(route.block);
+  };
+
+  const openEditBlock = (block: DeliveryBlock) => {
+    setEditBlock(block);
+    setEditBlockName(block.name);
+  };
+
+  const updateBlock = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editBlock || !editBlockName.trim()) return;
+    const res = await apiFetch(`${API}/admin/delivery-blocks/${editBlock.id}/`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: editBlockName.trim() }),
+    });
+    if (res.ok) {
+      setEditBlock(null);
+      await fetchLayout();
+      success("Blok bol premenovaný.");
+    } else {
+      toastError("Nepodarilo sa premenovať blok.");
+    }
   };
 
   const updateRoute = async (e: React.FormEvent) => {
@@ -394,6 +435,7 @@ const DeliveryLayoutAdmin: React.FC = () => {
         name: editRouteName.trim(),
         driver: editRouteDriver.trim(),
         departure_time: editRouteTime || null,
+        ...blockMovePatch(editRoute, editRouteBlock),
       }),
     });
     if (res.ok) {
@@ -475,6 +517,9 @@ const DeliveryLayoutAdmin: React.FC = () => {
                   <p>{block.routes.length} trás</p>
                 </div>
                 <div className="actions">
+                  <Button sm variant="ghost" onClick={() => openEditBlock(block)}>
+                    Premenovať
+                  </Button>
                   <IconButton onClick={() => moveBlock(block.id, -1)} disabled={blockIndex === 0} title="Vyššie" aria-label="Vyššie">
                     <ArrowUp />
                   </IconButton>
@@ -722,6 +767,35 @@ const DeliveryLayoutAdmin: React.FC = () => {
                 <Input type="time" value={editRouteTime} onChange={(e) => setEditRouteTime(e.target.value)} />
               </Field>
             </div>
+            <Field label="Blok (výdajný bod)">
+              <Select
+                value={String(editRouteBlock ?? editRoute.block)}
+                onChange={(e) => setEditRouteBlock(Number(e.target.value))}
+              >
+                {layout.blocks.map((block) => (
+                  <option key={block.id} value={block.id}>{block.name}</option>
+                ))}
+              </Select>
+            </Field>
+          </form>
+        </Modal>
+      )}
+
+      {editBlock && (
+        <Modal
+          title="Premenovať blok"
+          onClose={() => setEditBlock(null)}
+          foot={
+            <>
+              <Button variant="ghost" onClick={() => setEditBlock(null)}>Zrušiť</Button>
+              <Button type="submit" form="edit-block-form">Uložiť</Button>
+            </>
+          }
+        >
+          <form id="edit-block-form" onSubmit={updateBlock}>
+            <Field label="Názov bloku" req>
+              <Input required value={editBlockName} onChange={(e) => setEditBlockName(e.target.value)} />
+            </Field>
           </form>
         </Modal>
       )}

--- a/frontend/src/pages/admin/DeliveryLayoutAdmin.tsx
+++ b/frontend/src/pages/admin/DeliveryLayoutAdmin.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../../context/auth";
 import { useToast } from "../../context/ToastContext";
 import { logger } from "../../lib/logger";
 import { Badge, Button, Card, Empty, Field, IconButton, Input, Modal, PageHead, Select, TableWrap } from "./ui";
+import { VYDAJE } from "./facility/PrevadzkaFields";
 
 const API = import.meta.env.VITE_API_URL || "/api";
 
@@ -13,6 +14,8 @@ interface DeliveryPrevadzka {
   report_alias: string;
   adresa: string;
   celok: string;
+  /** Výdajný bod kuchyne (`api.models.Vydaj`) — podľa neho sa delí tabuľka. */
+  vydaj: string;
   delivery_route: number | null;
   delivery_sort_order: number;
   delivery_note: string;
@@ -104,6 +107,9 @@ const DeliveryLayoutAdmin: React.FC = () => {
   const [editRouteBlock, setEditRouteBlock] = useState<number | null>(null);
   const [editBlock, setEditBlock] = useState<DeliveryBlock | null>(null);
   const [editBlockName, setEditBlockName] = useState("");
+  // Prázdne = všetky výdajné body. Kuchyňa si tak vie pozrieť trasy len toho
+  // bodu, z ktorého práve vydáva.
+  const [vydajFilter, setVydajFilter] = useState("");
   const [dragging, setDragging] = useState<DragState | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState | null>(null);
   const [confirmBusy, setConfirmBusy] = useState(false);
@@ -403,6 +409,23 @@ const DeliveryLayoutAdmin: React.FC = () => {
     setEditRouteBlock(route.block);
   };
 
+  const vydajLabel = (key: string) =>
+    VYDAJE.find((item) => item.key === key)?.label ?? key;
+
+  const setPrevadzkaVydaj = async (prevadzka: DeliveryPrevadzka, vydaj: string) => {
+    const res = await apiFetch(`${API}/admin/prevadzky-delivery/${prevadzka.id}/`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ vydaj }),
+    });
+    if (res.ok) {
+      await fetchLayout();
+      success(`${prevadzka.report_alias || prevadzka.nazov} → ${vydajLabel(vydaj)}`);
+    } else {
+      toastError("Nepodarilo sa zmeniť výdaj prevádzky.");
+    }
+  };
+
   const openEditBlock = (block: DeliveryBlock) => {
     setEditBlock(block);
     setEditBlockName(block.name);
@@ -487,9 +510,20 @@ const DeliveryLayoutAdmin: React.FC = () => {
       <PageHead
         eyebrow="Rozvoz"
         title="Poradie a trasy"
-        desc="Rozdelenie prevádzok do blokov a trás pre admin Prehľad."
+        desc="Rozdelenie prevádzok do blokov a trás. Výdaj (bod kuchyne) sa nastavuje pri prevádzke a delí gramážovú tabuľku."
         actions={
           <>
+            <Select
+              value={vydajFilter}
+              onChange={(e) => setVydajFilter(e.target.value)}
+              style={{ width: "auto" }}
+              aria-label="Výdajný bod"
+            >
+              <option value="">Všetky výdaje</option>
+              {VYDAJE.map((item) => (
+                <option key={item.key} value={item.key}>{item.label}</option>
+              ))}
+            </Select>
             <Button variant="secondary" onClick={() => setShowBlockModal(true)}>
               <Plus /> Blok
             </Button>
@@ -532,7 +566,14 @@ const DeliveryLayoutAdmin: React.FC = () => {
                 </div>
               </div>
 
-              {block.routes.map((route) => (
+              {block.routes.map((route) => {
+                // Pri zapnutom filtri trasa ukáže len prevádzky daného výdaja;
+                // trasa, ktorá doň nevozí, sa nevykresľuje vôbec.
+                const visiblePrevadzky = route.prevadzky.filter(
+                  (prevadzka) => !vydajFilter || (prevadzka.vydaj || "A") === vydajFilter,
+                );
+                if (vydajFilter && visiblePrevadzky.length === 0) return null;
+                return (
                 <div
                   key={route.id}
                   style={{ borderBottom: "1px solid var(--line-soft)" }}
@@ -566,10 +607,10 @@ const DeliveryLayoutAdmin: React.FC = () => {
                   >
                     <table className="zpa-table">
                       <tbody>
-                        {route.prevadzky.length === 0 ? (
+                        {visiblePrevadzky.length === 0 ? (
                           <tr><td style={{ color: "var(--ink-mute)" }}>Žiadne prevádzky v trase.</td></tr>
                         ) : (
-                          route.prevadzky.map((prevadzka, prevadzkaIndex) => (
+                          visiblePrevadzky.map((prevadzka, prevadzkaIndex) => (
                             <tr
                               key={prevadzka.id}
                               className={`zpa-draggable-row${dragging?.type === "prevadzka" && dragging.prevadzkaId === prevadzka.id ? " is-dragging" : ""}`}
@@ -593,6 +634,17 @@ const DeliveryLayoutAdmin: React.FC = () => {
                               <td>
                                 <div style={{ fontFamily: "var(--font-display)", fontWeight: 600, color: "var(--green-900)" }}>{prevadzka.report_alias || prevadzka.nazov}</div>
                                 <div style={{ fontSize: 12, color: "var(--ink-3)" }}>{prevadzka.celok}{prevadzka.adresa ? ` · ${prevadzka.adresa}` : ""}</div>
+                              </td>
+                              <td style={{ width: 130 }}>
+                                <Select
+                                  value={prevadzka.vydaj || "A"}
+                                  onChange={(e) => void setPrevadzkaVydaj(prevadzka, e.target.value)}
+                                  aria-label={`Výdaj — ${prevadzka.report_alias || prevadzka.nazov}`}
+                                >
+                                  {VYDAJE.map((item) => (
+                                    <option key={item.key} value={item.key}>{item.label}</option>
+                                  ))}
+                                </Select>
                               </td>
                               <td className="r">
                                 <div className="zpa-rowactions">
@@ -628,7 +680,8 @@ const DeliveryLayoutAdmin: React.FC = () => {
                     </table>
                   </TableWrap>
                 </div>
-              ))}
+                );
+              })}
             </Card>
           ))}
 

--- a/frontend/src/pages/admin/DeliveryLayoutAdmin.tsx
+++ b/frontend/src/pages/admin/DeliveryLayoutAdmin.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "../../context/auth";
 import { useToast } from "../../context/ToastContext";
 import { logger } from "../../lib/logger";
 import { Badge, Button, Card, Empty, Field, IconButton, Input, Modal, PageHead, Select, TableWrap } from "./ui";
-import { VYDAJE } from "./facility/PrevadzkaFields";
+import { VYDAJE } from "./facility/constants";
 
 const API = import.meta.env.VITE_API_URL || "/api";
 
@@ -14,8 +14,6 @@ interface DeliveryPrevadzka {
   report_alias: string;
   adresa: string;
   celok: string;
-  /** Výdajný bod kuchyne (`api.models.Vydaj`) — podľa neho sa delí tabuľka. */
-  vydaj: string;
   delivery_route: number | null;
   delivery_sort_order: number;
   delivery_note: string;
@@ -25,6 +23,8 @@ interface DeliveryPrevadzka {
 interface DeliveryRoute {
   id: number;
   block: number;
+  /** Výdajný bod (`api.models.Vydaj`) — trasy výdaja A tvoria tabuľku A. */
+  vydaj: string;
   name: string;
   driver: string;
   departure_time: string | null;
@@ -97,6 +97,7 @@ const DeliveryLayoutAdmin: React.FC = () => {
   const [newRouteName, setNewRouteName] = useState("");
   const [newRouteDriver, setNewRouteDriver] = useState("");
   const [newRouteTime, setNewRouteTime] = useState("");
+  const [newRouteVydaj, setNewRouteVydaj] = useState("A");
   const [editRoute, setEditRoute] = useState<DeliveryRoute | null>(null);
   const [editRouteName, setEditRouteName] = useState("");
   const [editRouteDriver, setEditRouteDriver] = useState("");
@@ -374,6 +375,7 @@ const DeliveryLayoutAdmin: React.FC = () => {
         name: newRouteName.trim(),
         driver: newRouteDriver.trim(),
         departure_time: newRouteTime || null,
+        vydaj: newRouteVydaj,
         sort_order: showRouteModalFor.routes.length + 1,
       }),
     });
@@ -381,6 +383,7 @@ const DeliveryLayoutAdmin: React.FC = () => {
       setNewRouteName("");
       setNewRouteDriver("");
       setNewRouteTime("");
+      setNewRouteVydaj("A");
       setShowRouteModalFor(null);
       await fetchLayout();
       success("Trasa bola pridaná.");
@@ -412,17 +415,17 @@ const DeliveryLayoutAdmin: React.FC = () => {
   const vydajLabel = (key: string) =>
     VYDAJE.find((item) => item.key === key)?.label ?? key;
 
-  const setPrevadzkaVydaj = async (prevadzka: DeliveryPrevadzka, vydaj: string) => {
-    const res = await apiFetch(`${API}/admin/prevadzky-delivery/${prevadzka.id}/`, {
+  const setRouteVydaj = async (route: DeliveryRoute, vydaj: string) => {
+    const res = await apiFetch(`${API}/admin/delivery-routes/${route.id}/`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ vydaj }),
     });
     if (res.ok) {
       await fetchLayout();
-      success(`${prevadzka.report_alias || prevadzka.nazov} → ${vydajLabel(vydaj)}`);
+      success(`${route.name} → ${vydajLabel(vydaj)}`);
     } else {
-      toastError("Nepodarilo sa zmeniť výdaj prevádzky.");
+      toastError("Nepodarilo sa zmeniť výdaj trasy.");
     }
   };
 
@@ -510,7 +513,7 @@ const DeliveryLayoutAdmin: React.FC = () => {
       <PageHead
         eyebrow="Rozvoz"
         title="Poradie a trasy"
-        desc="Rozdelenie prevádzok do blokov a trás. Výdaj (bod kuchyne) sa nastavuje pri prevádzke a delí gramážovú tabuľku."
+        desc="Rozdelenie prevádzok do blokov a trás. Výdaj sa nastavuje na trase — trasy výdaja A tvoria tabuľku A, trasy výdaja B tabuľku B."
         actions={
           <>
             <Select
@@ -567,12 +570,9 @@ const DeliveryLayoutAdmin: React.FC = () => {
               </div>
 
               {block.routes.map((route) => {
-                // Pri zapnutom filtri trasa ukáže len prevádzky daného výdaja;
-                // trasa, ktorá doň nevozí, sa nevykresľuje vôbec.
-                const visiblePrevadzky = route.prevadzky.filter(
-                  (prevadzka) => !vydajFilter || (prevadzka.vydaj || "A") === vydajFilter,
-                );
-                if (vydajFilter && visiblePrevadzky.length === 0) return null;
+                // Výdaj je na trase, takže filter skryje celú trasu aj s jej
+                // prevádzkami — presne to, čo uvidíš v tabuľke daného výdaja.
+                if (vydajFilter && (route.vydaj || "A") !== vydajFilter) return null;
                 return (
                 <div
                   key={route.id}
@@ -587,7 +587,17 @@ const DeliveryLayoutAdmin: React.FC = () => {
                         </div>
                       </div>
                     </div>
-                    <div style={{ display: "inline-flex", gap: 4 }}>
+                    <div style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                      <Select
+                        value={route.vydaj || "A"}
+                        onChange={(e) => void setRouteVydaj(route, e.target.value)}
+                        style={{ width: "auto" }}
+                        aria-label={`Výdaj — ${route.name}`}
+                      >
+                        {VYDAJE.map((item) => (
+                          <option key={item.key} value={item.key}>{item.label}</option>
+                        ))}
+                      </Select>
                       <IconButton onClick={() => openEditRoute(route)} title="Upraviť trasu" aria-label="Upraviť trasu">
                         <Pencil />
                       </IconButton>
@@ -607,10 +617,10 @@ const DeliveryLayoutAdmin: React.FC = () => {
                   >
                     <table className="zpa-table">
                       <tbody>
-                        {visiblePrevadzky.length === 0 ? (
+                        {route.prevadzky.length === 0 ? (
                           <tr><td style={{ color: "var(--ink-mute)" }}>Žiadne prevádzky v trase.</td></tr>
                         ) : (
-                          visiblePrevadzky.map((prevadzka, prevadzkaIndex) => (
+                          route.prevadzky.map((prevadzka, prevadzkaIndex) => (
                             <tr
                               key={prevadzka.id}
                               className={`zpa-draggable-row${dragging?.type === "prevadzka" && dragging.prevadzkaId === prevadzka.id ? " is-dragging" : ""}`}
@@ -634,17 +644,6 @@ const DeliveryLayoutAdmin: React.FC = () => {
                               <td>
                                 <div style={{ fontFamily: "var(--font-display)", fontWeight: 600, color: "var(--green-900)" }}>{prevadzka.report_alias || prevadzka.nazov}</div>
                                 <div style={{ fontSize: 12, color: "var(--ink-3)" }}>{prevadzka.celok}{prevadzka.adresa ? ` · ${prevadzka.adresa}` : ""}</div>
-                              </td>
-                              <td style={{ width: 130 }}>
-                                <Select
-                                  value={prevadzka.vydaj || "A"}
-                                  onChange={(e) => void setPrevadzkaVydaj(prevadzka, e.target.value)}
-                                  aria-label={`Výdaj — ${prevadzka.report_alias || prevadzka.nazov}`}
-                                >
-                                  {VYDAJE.map((item) => (
-                                    <option key={item.key} value={item.key}>{item.label}</option>
-                                  ))}
-                                </Select>
                               </td>
                               <td className="r">
                                 <div className="zpa-rowactions">
@@ -793,6 +792,13 @@ const DeliveryLayoutAdmin: React.FC = () => {
                 <Input type="time" value={newRouteTime} onChange={(e) => setNewRouteTime(e.target.value)} />
               </Field>
             </div>
+            <Field label="Výdaj" hint="(ktorá tabuľka trasu obsahuje)">
+              <Select value={newRouteVydaj} onChange={(e) => setNewRouteVydaj(e.target.value)}>
+                {VYDAJE.map((item) => (
+                  <option key={item.key} value={item.key}>{item.label}</option>
+                ))}
+              </Select>
+            </Field>
           </form>
         </Modal>
       )}

--- a/frontend/src/pages/admin/MealCatalogAdmin.tsx
+++ b/frontend/src/pages/admin/MealCatalogAdmin.tsx
@@ -51,6 +51,38 @@ interface MealTemplate {
 
 const emptyComponent = (): Component => ({ label: "", grams: "", unit: "g" });
 
+/**
+ * Editor zložiek — zdieľaný formulárom na pridanie aj na úpravu, aby sa názvy
+ * zložiek („Hlavná zložka" …) dali prepísať tam aj tam rovnako.
+ */
+const ComponentRows: React.FC<{
+  components: Component[];
+  onChange: (index: number, patch: Partial<Component>) => void;
+  onAdd: () => void;
+  onRemove: (index: number) => void;
+}> = ({ components, onChange, onAdd, onRemove }) => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+    <span className="zpa-label">Zložky</span>
+    {components.map((c, i) => (
+      <div key={i} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Input placeholder="Názov zložky (napr. Hlavná zložka)" value={c.label} onChange={(e) => onChange(i, { label: e.target.value })} />
+        <Input placeholder="Množstvo" value={c.grams} onChange={(e) => onChange(i, { grams: e.target.value })} style={{ width: 110 }} />
+        <Select value={c.unit} onChange={(e) => onChange(i, { unit: e.target.value as Component["unit"] })} style={{ width: "auto" }}>
+          <option value="g">g</option>
+          <option value="ml">ml</option>
+          <option value="text">text</option>
+        </Select>
+        <button className="zpa-iconbtn" onClick={() => onRemove(i)} disabled={components.length === 1} aria-label="Odstrániť zložku">
+          <X />
+        </button>
+      </div>
+    ))}
+    <button className="zpa-btn zpa-btn--ghost zpa-btn--sm" style={{ alignSelf: "flex-start", paddingLeft: 0 }} onClick={onAdd}>
+      <Plus /> Pridať zložku
+    </button>
+  </div>
+);
+
 const emptyNewTemplate = (category: MealCategory) => ({
   category,
   name: "",
@@ -74,6 +106,13 @@ const MealCatalogAdmin: React.FC = () => {
   const [addingCategory, setAddingCategory] = useState<MealCategory | null>(null);
   const [newTemplate, setNewTemplate] = useState(emptyNewTemplate("soup"));
   const [saving, setSaving] = useState(false);
+  // Úprava existujúceho rozloženia — názov a zložky (kuchyňa si chcela prepísať
+  // „Hlavná zložka" na vlastné pomenovanie, spätná väzba 17. 8. 2026).
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState<{ name: string; components: Component[] }>({
+    name: "",
+    components: [],
+  });
 
   const fetchPortionTypes = useCallback(async () => {
     try {
@@ -238,6 +277,63 @@ const MealCatalogAdmin: React.FC = () => {
     }
   };
 
+  const openEditForm = (tpl: MealTemplate) => {
+    setEditingId(tpl.id);
+    setEditDraft({
+      name: tpl.name,
+      components: tpl.components.length ? tpl.components.map((c) => ({ ...c })) : [emptyComponent()],
+    });
+  };
+
+  const updateEditComponent = (index: number, patch: Partial<Component>) => {
+    setEditDraft((d) => ({
+      ...d,
+      components: d.components.map((c, i) => (i === index ? { ...c, ...patch } : c)),
+    }));
+  };
+
+  const handleSaveTemplate = async (tpl: MealTemplate) => {
+    if (!editDraft.name.trim()) {
+      error("Zadajte názov rozloženia");
+      return;
+    }
+    const components = editDraft.components
+      .filter((c) => c.label.trim() && c.grams.trim())
+      .map((c) => ({ label: c.label.trim(), grams: c.grams.trim(), unit: c.unit }));
+    if (components.length === 0) {
+      error("Nechajte aspoň jednu zložku s gramážou");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      // `weight_label` a `base_weight_grams` zámerne neposielame — backend si ich
+      // zo zložiek prepočíta sám, inak by v katalógu ostal starý popis váhy.
+      const res = await apiFetch(`${API}/admin/meal-templates/${tpl.id}/`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: editDraft.name.trim(), components }),
+      });
+      if (res.ok) {
+        success("Rozloženie bolo upravené");
+        setEditingId(null);
+        fetchTemplates();
+      } else {
+        const payload = await res.json().catch(() => null);
+        error(
+          payload && typeof payload === "object"
+            ? JSON.stringify(payload)
+            : "Nepodarilo sa upraviť rozloženie",
+        );
+      }
+    } catch (e) {
+      logger.error(e);
+      error("Chyba pri ukladaní rozloženia");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const templatesByCategory = (category: MealCategory) =>
     templates.filter((t) => t.category === category);
 
@@ -290,14 +386,50 @@ const MealCatalogAdmin: React.FC = () => {
 
               <div style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 8 }}>
                 {templatesByCategory(category).map((tpl) => (
-                  <div key={tpl.id} className="zpa-tplrow" style={tpl.is_active ? undefined : { opacity: 0.5 }}>
-                    <div>
-                      <span className="nm">{tpl.name}</span>
-                      <span className={`wl${tpl.unit_exception ? " exc" : ""}`}>{tpl.weight_label}</span>
+                  <div key={tpl.id}>
+                    <div className="zpa-tplrow" style={tpl.is_active ? undefined : { opacity: 0.5 }}>
+                      <div>
+                        <span className="nm">{tpl.name}</span>
+                        <span className={`wl${tpl.unit_exception ? " exc" : ""}`}>{tpl.weight_label}</span>
+                      </div>
+                      <div style={{ display: "flex", gap: 4 }}>
+                        <Button variant="ghost" sm onClick={() => (editingId === tpl.id ? setEditingId(null) : openEditForm(tpl))}>
+                          {editingId === tpl.id ? "Zavrieť" : "Upraviť"}
+                        </Button>
+                        <Button variant="ghost" sm onClick={() => toggleTemplateActive(tpl)}>
+                          {tpl.is_active ? "Deaktivovať" : "Aktivovať"}
+                        </Button>
+                      </div>
                     </div>
-                    <Button variant="ghost" sm onClick={() => toggleTemplateActive(tpl)}>
-                      {tpl.is_active ? "Deaktivovať" : "Aktivovať"}
-                    </Button>
+                    {editingId === tpl.id && (
+                      <div style={{ display: "flex", flexDirection: "column", gap: 12, padding: "12px 0 4px" }}>
+                        <Input
+                          placeholder="Názov rozloženia"
+                          value={editDraft.name}
+                          onChange={(e) => setEditDraft((d) => ({ ...d, name: e.target.value }))}
+                        />
+                        <ComponentRows
+                          components={editDraft.components}
+                          onChange={updateEditComponent}
+                          onAdd={() => setEditDraft((d) => ({ ...d, components: [...d.components, emptyComponent()] }))}
+                          onRemove={(index) =>
+                            setEditDraft((d) => ({ ...d, components: d.components.filter((_, i) => i !== index) }))
+                          }
+                        />
+                        {tpl.unit_exception && (
+                          <p style={{ fontSize: 13, color: "var(--ink-3)", margin: 0 }}>
+                            Zložka „{tpl.unit_exception.component_label}" má pevný počet kusov podľa vekovej
+                            skupiny — tú tu neupravíš, ostáva nezmenená.
+                          </p>
+                        )}
+                        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+                          <Button variant="ghost" onClick={() => setEditingId(null)}>Zrušiť</Button>
+                          <Button onClick={() => handleSaveTemplate(tpl)} disabled={saving}>
+                            {saving ? "Ukladám…" : "Uložiť zmeny"}
+                          </Button>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 ))}
                 {templatesByCategory(category).length === 0 && (
@@ -313,26 +445,12 @@ const MealCatalogAdmin: React.FC = () => {
                     onChange={(e) => setNewTemplate((t) => ({ ...t, name: e.target.value }))}
                   />
 
-                  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    <span className="zpa-label">Zložky</span>
-                    {newTemplate.components.map((c, i) => (
-                      <div key={i} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                        <Input placeholder="Názov zložky (napr. Hlavná zložka)" value={c.label} onChange={(e) => updateComponent(i, { label: e.target.value })} />
-                        <Input placeholder="Množstvo" value={c.grams} onChange={(e) => updateComponent(i, { grams: e.target.value })} style={{ width: 110 }} />
-                        <Select value={c.unit} onChange={(e) => updateComponent(i, { unit: e.target.value as Component["unit"] })} style={{ width: "auto" }}>
-                          <option value="g">g</option>
-                          <option value="ml">ml</option>
-                          <option value="text">text</option>
-                        </Select>
-                        <button className="zpa-iconbtn" onClick={() => removeComponentRow(i)} disabled={newTemplate.components.length === 1} aria-label="Odstrániť zložku">
-                          <X />
-                        </button>
-                      </div>
-                    ))}
-                    <button className="zpa-btn zpa-btn--ghost zpa-btn--sm" style={{ alignSelf: "flex-start", paddingLeft: 0 }} onClick={addComponentRow}>
-                      <Plus /> Pridať zložku
-                    </button>
-                  </div>
+                  <ComponentRows
+                    components={newTemplate.components}
+                    onChange={updateComponent}
+                    onAdd={addComponentRow}
+                    onRemove={removeComponentRow}
+                  />
 
                   <Checkbox on={newTemplate.hasException} onChange={(v) => setNewTemplate((t) => ({ ...t, hasException: v }))}>
                     Táto zložka má pevný počet kusov podľa vekovej skupiny (napr. vajce)

--- a/frontend/src/pages/admin/PrevadzkaOverview.tsx
+++ b/frontend/src/pages/admin/PrevadzkaOverview.tsx
@@ -24,7 +24,7 @@ interface OverviewRow {
   delivered: boolean;
   delivery_status?: "missing" | "manual_zero" | "auto" | "manual";
   counts: OverviewCounts;
-  flags: { attention: string[]; config_notes: string[] };
+  flags: { attention: string[]; config_notes: string[]; unmapped_diets?: string[] };
   has_warning: boolean;
 }
 
@@ -78,7 +78,10 @@ const StatusDot: React.FC<{ row: OverviewRow; source: "edupage" | "app" }> = ({ 
     );
   }
   if (row.has_warning) {
-    const notes = [...row.flags.config_notes, ...row.flags.attention].join("\n");
+    const unmapped = (row.flags.unmapped_diets ?? []).map(
+      (d) => `neznáma diéta z EduPage: ${d} — založ ju v appke`,
+    );
+    const notes = [...row.flags.config_notes, ...row.flags.attention, ...unmapped].join("\n");
     return (
       <span className="zpa-statusdot warn" title={`Dodané, ale skontroluj:\n${notes}`}>
         <AlertTriangle />

--- a/frontend/src/pages/admin/admin.css
+++ b/frontend/src/pages/admin/admin.css
@@ -925,13 +925,20 @@
  * Filter sekcií gramáže (raňajky / polievka / menu / olovrant)
  * ========================================================== */
 .zpa-section-filter {
-    display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+    display: flex; flex-direction: column; gap: 8px;
     margin-bottom: 14px;
 }
+/* Jeden rad filtra = jedna otázka (ktoré jedlá / ktorý výdajný bod). Pod nimi
+ * veta, čo pôjde do tlače — predtým sa dalo len tušiť, že PDF kopíruje výber. */
+.zpa-section-filter .row {
+    display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+}
+.zpa-section-filter .hint { font-size: 12px; color: var(--ink-3); }
 .zpa-section-filter .lbl {
     font-family: var(--font-display); font-weight: 700; font-size: 11px;
     text-transform: uppercase; letter-spacing: var(--tracking-caps);
     color: var(--ink-3); margin-right: 4px;
+    min-width: 84px;
 }
 .zpa-section-filter .chip {
     padding: 6px 14px; border-radius: var(--radius-pill); cursor: pointer;

--- a/frontend/src/pages/admin/facility/PrevadzkaFields.tsx
+++ b/frontend/src/pages/admin/facility/PrevadzkaFields.tsx
@@ -1,6 +1,17 @@
 import React from "react";
 import { Field, Input, Select, Textarea, Toggle } from "../ui";
 
+/**
+ * Výdajný bod kuchyne, z ktorého sa prevádzka vydáva. Podľa neho sa delí
+ * gramážová tabuľka aj tlač — trasa rozvozu je na tom nezávislá.
+ * Kľúče musia sedieť s `api.models.Vydaj`.
+ */
+export const VYDAJE = [
+  { key: "A", label: "Výdaj A" },
+  { key: "B", label: "Výdaj B" },
+  { key: "C", label: "Výdaj C" },
+] as const;
+
 export interface Prevadzka {
   id: number;
   celok: number;
@@ -10,6 +21,7 @@ export interface Prevadzka {
   edupage_connection: number | null;
   edupage_connection_name: string | null;
   edupage_match: string;
+  vydaj: string;
   report_alias: string;
   delivery_note: string;
   sort_order: number;
@@ -24,6 +36,7 @@ export interface PrevadzkaForm {
   adresa: string;
   edupage_connection: number | null;
   edupage_match: string;
+  vydaj: string;
   report_alias: string;
   delivery_note: string;
   sort_order: number;
@@ -66,6 +79,22 @@ export const PrevadzkaFields: React.FC<{
     )}
     <Field label="Edupage match" hint="(prefix; ; oddeľuje viac)">
       <Input placeholder="napr. Les alebo mšHey; mšMal,Hey" value={form.edupage_match} onChange={(e) => setForm((current) => ({ ...current, edupage_match: e.target.value }))} />
+    </Field>
+    <Field label="Výdaj" hint="(z ktorého bodu kuchyne sa vydáva)">
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 16 }}>
+        {VYDAJE.map((vydaj) => (
+          <label key={vydaj.key} style={{ display: "inline-flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
+            <input
+              type="radio"
+              name="prevadzka-vydaj"
+              value={vydaj.key}
+              checked={(form.vydaj || "A") === vydaj.key}
+              onChange={() => setForm((current) => ({ ...current, vydaj: vydaj.key }))}
+            />
+            {vydaj.label}
+          </label>
+        ))}
+      </div>
     </Field>
     <Field label="Report alias" hint="(názov vo výkazoch)">
       <Input value={form.report_alias} onChange={(e) => setForm((current) => ({ ...current, report_alias: e.target.value }))} />

--- a/frontend/src/pages/admin/facility/PrevadzkaFields.tsx
+++ b/frontend/src/pages/admin/facility/PrevadzkaFields.tsx
@@ -1,17 +1,6 @@
 import React from "react";
 import { Field, Input, Select, Textarea, Toggle } from "../ui";
 
-/**
- * Výdajný bod kuchyne, z ktorého sa prevádzka vydáva. Podľa neho sa delí
- * gramážová tabuľka aj tlač — trasa rozvozu je na tom nezávislá.
- * Kľúče musia sedieť s `api.models.Vydaj`.
- */
-export const VYDAJE = [
-  { key: "A", label: "Výdaj A" },
-  { key: "B", label: "Výdaj B" },
-  { key: "C", label: "Výdaj C" },
-] as const;
-
 export interface Prevadzka {
   id: number;
   celok: number;
@@ -21,7 +10,6 @@ export interface Prevadzka {
   edupage_connection: number | null;
   edupage_connection_name: string | null;
   edupage_match: string;
-  vydaj: string;
   report_alias: string;
   delivery_note: string;
   sort_order: number;
@@ -36,7 +24,6 @@ export interface PrevadzkaForm {
   adresa: string;
   edupage_connection: number | null;
   edupage_match: string;
-  vydaj: string;
   report_alias: string;
   delivery_note: string;
   sort_order: number;
@@ -79,22 +66,6 @@ export const PrevadzkaFields: React.FC<{
     )}
     <Field label="Edupage match" hint="(prefix; ; oddeľuje viac)">
       <Input placeholder="napr. Les alebo mšHey; mšMal,Hey" value={form.edupage_match} onChange={(e) => setForm((current) => ({ ...current, edupage_match: e.target.value }))} />
-    </Field>
-    <Field label="Výdaj" hint="(z ktorého bodu kuchyne sa vydáva)">
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 16 }}>
-        {VYDAJE.map((vydaj) => (
-          <label key={vydaj.key} style={{ display: "inline-flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
-            <input
-              type="radio"
-              name="prevadzka-vydaj"
-              value={vydaj.key}
-              checked={(form.vydaj || "A") === vydaj.key}
-              onChange={() => setForm((current) => ({ ...current, vydaj: vydaj.key }))}
-            />
-            {vydaj.label}
-          </label>
-        ))}
-      </div>
     </Field>
     <Field label="Report alias" hint="(názov vo výkazoch)">
       <Input value={form.report_alias} onChange={(e) => setForm((current) => ({ ...current, report_alias: e.target.value }))} />

--- a/frontend/src/pages/admin/facility/constants.ts
+++ b/frontend/src/pages/admin/facility/constants.ts
@@ -14,6 +14,7 @@ export const EMPTY_PREVADZKA: PrevadzkaForm = {
   adresa: "",
   edupage_connection: null,
   edupage_match: "",
+  vydaj: "A",
   report_alias: "",
   delivery_note: "",
   sort_order: 0,

--- a/frontend/src/pages/admin/facility/constants.ts
+++ b/frontend/src/pages/admin/facility/constants.ts
@@ -14,9 +14,19 @@ export const EMPTY_PREVADZKA: PrevadzkaForm = {
   adresa: "",
   edupage_connection: null,
   edupage_match: "",
-  vydaj: "A",
   report_alias: "",
   delivery_note: "",
   sort_order: 0,
   is_active: true,
 };
+
+/**
+ * Výdajné body kuchyne. Výdaj sa nastavuje na TRASE a podľa neho sa delí
+ * gramážová tabuľka aj tlač — prevádzka patrí do výdaja svojej trasy.
+ * Kľúče musia sedieť s `api.models.Vydaj`.
+ */
+export const VYDAJE = [
+  { key: "A", label: "Výdaj A" },
+  { key: "B", label: "Výdaj B" },
+  { key: "C", label: "Výdaj C" },
+] as const;

--- a/frontend/src/pages/admin/gramage-table.css
+++ b/frontend/src/pages/admin/gramage-table.css
@@ -73,41 +73,39 @@
     text-transform: uppercase; letter-spacing: var(--tracking-caps);
     padding: 9px 16px;
 }
-/* Blok = výdajný bod kuchyne (cluster). Musí byť vidieť na prvý pohľad, že tu
- * začína druhá tabuľka — v tlači ide navyše na vlastný list. */
+/* Výdajný bod kuchyne. Vidieť, že tu začína druhá tabuľka (v tlači aj druhý
+ * list), ale bez krikľavého pásu — stačí tmavý pruh a tenká červená linka. */
 .zpa-gram tbody .block-band td {
     background: var(--green-900); color: #fff;
-    font-size: 15px; letter-spacing: 0.1em;
-    padding: 14px 16px;
-    border-top: 4px solid var(--coral-600);
+    font-size: 12px; letter-spacing: var(--tracking-caps);
+    padding: 10px 16px;
+    border-top: 2px solid var(--coral-600);
 }
-/* Trasa — celý riadok červený a o poschodie väčšie písmo. Zelený pás sa v
- * hustej tabuľke strácal a rozvoz nevedel, kde jedna trasa končí (17. 8. 2026). */
+/* Trasa — jemný červený pás. Musí byť vidieť, kde trasa začína, ale nesmie
+ * prekričať dáta: sýta výplň cez celý riadok bola priveľká (17. 8. 2026). */
 .zpa-gram .route-row td {
-    min-width: 0; padding: 10px 16px;
-    background: var(--coral-600);
-    border-top: 3px solid var(--coral-logo);
-    border-bottom: 2px solid var(--coral-logo);
+    min-width: 0; padding: 7px 16px;
+    background: rgba(201,46,82,0.07);
+    border-top: 1px solid rgba(201,46,82,0.35);
+    border-bottom: 1px solid rgba(201,46,82,0.16);
 }
 .zpa-gram .route-pill {
-    display: inline-flex; align-items: center; gap: 10px; max-width: 100%;
-    padding: 6px 12px; border-radius: var(--radius-pill);
+    display: inline-flex; align-items: center; gap: 8px; max-width: 100%;
+    padding: 3px 10px; border-radius: var(--radius-pill);
     background: #fff; color: var(--coral-600);
-    border: 1px solid rgba(255,255,255,0.9);
-    box-shadow: 0 1px 0 rgba(23,53,5,0.08);
-    font-family: var(--font-display); font-weight: 700; font-size: 15px;
-    text-transform: uppercase; letter-spacing: 0.02em;
+    border: 1px solid rgba(201,46,82,0.30);
+    font-family: var(--font-display); font-weight: 700; font-size: 13px;
 }
 .zpa-gram .route-pill::before {
-    content: ""; width: 8px; height: 8px; border-radius: 999px;
+    content: ""; width: 6px; height: 6px; border-radius: 999px;
     background: var(--coral-600); flex: 0 0 auto;
 }
 .zpa-gram .route-pill > span {
     min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .zpa-gram .route-pill small {
-    flex: 0 0 auto; color: var(--coral-600);
-    font-family: var(--font-sans); font-size: 12px; font-weight: 600;
+    flex: 0 0 auto; color: var(--ink-3);
+    font-family: var(--font-sans); font-size: 11px; font-weight: 600;
 }
 .zpa-gram .portion-summary-band td {
     background: rgba(255,201,92,0.18); color: var(--mustard-700);

--- a/frontend/src/pages/admin/gramage-table.css
+++ b/frontend/src/pages/admin/gramage-table.css
@@ -34,13 +34,28 @@
     box-shadow: 0 1px 0 rgba(23,53,5,0.16);
 }
 .zpa-gram thead th { background-clip: padding-box; }
-.zpa-gram .meal-sep { box-shadow: inset 1px 0 rgba(23,53,5,0.22); }
-.zpa-gram thead .meal-sep { box-shadow: inset 1px 0 rgba(255,255,255,0.32); }
+/* Predel medzi jedlami je hrubší než mriežka riadkov — kuchyňa v tabuľke
+ * hľadala, kde končia raňajky a začína obed (spätná väzba 17. 8. 2026). */
+.zpa-gram .meal-sep { box-shadow: inset 3px 0 rgba(23,53,5,0.38); }
+.zpa-gram thead .meal-sep { box-shadow: inset 3px 0 rgba(255,255,255,0.55); }
 .zpa-gram thead .grp { color: #fff; text-align: center; font-family: var(--font-display); font-weight: 700; font-size: 12.5px; }
 .zpa-gram thead .grp small { display: block; max-width: 128px; margin: 0 auto; font-weight: 400; font-size: 10px; opacity: 0.8; text-transform: none; letter-spacing: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .zpa-gram thead .comp { color: #fff; text-align: center; font-size: 11px; font-weight: 500; }
 .zpa-gram thead .comp small { display: block; font-size: 9.5px; opacity: 0.7; white-space: nowrap; }
 .zpa-gram .corner { background: var(--green-900); color: var(--bg-cream); text-align: left; font-family: var(--font-display); font-weight: 700; font-size: 12px; position: sticky; left: 0; z-index: 7; }
+/* Nadradený pás hlavičky — jedno políčko na jedlo (Raňajky / Obed / Olovrant). */
+.zpa-gram thead .mealband {
+    color: #fff; text-align: center;
+    font-family: var(--font-display); font-weight: 700; font-size: 13px;
+    text-transform: uppercase; letter-spacing: var(--tracking-caps);
+    padding: 8px;
+}
+.zpa-gram thead .mb-break { background: #8A5709; }
+.zpa-gram thead .mb-lunch { background: #24310E; }
+.zpa-gram thead .mb-snack { background: #63283F; }
+.zpa-gram thead .mb-other { background: var(--green-800); }
+.zpa-gram thead .mb-note { background: var(--green-900); }
+
 /* meal hues */
 /* meal hues — seven visually distinct families (raňajky ≠ olovrant;
  * Menu A/B/C/V each its own colour). -1 header, -2 sub-header, -cell tint. */
@@ -58,30 +73,41 @@
     text-transform: uppercase; letter-spacing: var(--tracking-caps);
     padding: 9px 16px;
 }
+/* Blok = výdajný bod kuchyne (cluster). Musí byť vidieť na prvý pohľad, že tu
+ * začína druhá tabuľka — v tlači ide navyše na vlastný list. */
+.zpa-gram tbody .block-band td {
+    background: var(--green-900); color: #fff;
+    font-size: 15px; letter-spacing: 0.1em;
+    padding: 14px 16px;
+    border-top: 4px solid var(--coral-600);
+}
+/* Trasa — celý riadok červený a o poschodie väčšie písmo. Zelený pás sa v
+ * hustej tabuľke strácal a rozvoz nevedel, kde jedna trasa končí (17. 8. 2026). */
 .zpa-gram .route-row td {
-    min-width: 0; padding: 12px 16px 7px;
-    background: linear-gradient(180deg, rgba(114,136,75,0.08), rgba(114,136,75,0.03));
-    border-top: 2px solid rgba(114,136,75,0.28);
-    border-bottom: 1px solid rgba(114,136,75,0.14);
+    min-width: 0; padding: 10px 16px;
+    background: var(--coral-600);
+    border-top: 3px solid var(--coral-logo);
+    border-bottom: 2px solid var(--coral-logo);
 }
 .zpa-gram .route-pill {
     display: inline-flex; align-items: center; gap: 10px; max-width: 100%;
-    padding: 6px 10px 6px 12px; border-radius: var(--radius-pill);
-    background: #fff; color: var(--green-900);
-    border: 1px solid rgba(114,136,75,0.28);
-    box-shadow: 0 1px 0 rgba(23,53,5,0.04);
-    font-family: var(--font-display); font-weight: 700; font-size: 12.5px;
+    padding: 6px 12px; border-radius: var(--radius-pill);
+    background: #fff; color: var(--coral-600);
+    border: 1px solid rgba(255,255,255,0.9);
+    box-shadow: 0 1px 0 rgba(23,53,5,0.08);
+    font-family: var(--font-display); font-weight: 700; font-size: 15px;
+    text-transform: uppercase; letter-spacing: 0.02em;
 }
 .zpa-gram .route-pill::before {
-    content: ""; width: 7px; height: 7px; border-radius: 999px;
-    background: var(--green-600); flex: 0 0 auto;
+    content: ""; width: 8px; height: 8px; border-radius: 999px;
+    background: var(--coral-600); flex: 0 0 auto;
 }
 .zpa-gram .route-pill > span {
     min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .zpa-gram .route-pill small {
-    flex: 0 0 auto; color: var(--ink-3);
-    font-family: var(--font-sans); font-size: 11px; font-weight: 600;
+    flex: 0 0 auto; color: var(--coral-600);
+    font-family: var(--font-sans); font-size: 12px; font-weight: 600;
 }
 .zpa-gram .portion-summary-band td {
     background: rgba(255,201,92,0.18); color: var(--mustard-700);
@@ -147,6 +173,12 @@
 .zpa-gram .note-delivery td { background: rgba(255,201,92,0.14); color: var(--mustard-700); }
 .zpa-gram .note-admin strong,
 .zpa-gram .note-delivery strong { font-family: var(--font-display); }
+
+/* Prázdny stĺpec „Poznámka" — kuchyňa doň píše rukou do vytlačenej tabuľky,
+ * na obrazovke ostáva prázdny. */
+.zpa-gram .cell-note { background: rgba(255,255,255,0.55); min-width: 120px; }
+.zpa-gram thead .grp-note,
+.zpa-gram thead .comp-note { background: var(--green-900); }
 
 /* Farebná bodka pred názvom diéty. Na obrazovke ju kreslí DietColorSwatch,
  * v PDF gramage_table_html._swatch — obe len dosadia `background`. */


### PR DESCRIPTION
Spätná väzba z prevádzky zo 17. 8. 2026 (Stanislav Šulc) — zápis je v
`docs/feedback-2026-08-17-stano.md`, vrátane toho, čo ostáva otvorené.

## EduPage: neznáma diéta už nezhltne porcie
Cvernička pridala do EduPage novú diétu, ktorú appka nepoznala. Scraper taký
riadok zahodil celý — teda aj počet porcií — a nahlásil to len do
`unmapped_letters`, ktoré sa logovali iba pri úplne prázdnom výsledku. Kuchyňa
mala tichý podstav a nikto o tom nevedel.

- `allowed_diet_names()`: povolené diéty = aktívne `Diet` z DB ∪ zabudovaný
  zoznam, takže novú diétu stačí založiť v appke a nečaká na nasadenie.
- Neznáma diéta sa už nezahadzuje: porcie sa započítajú pod názvom z EduPage a
  názov ide do `DailyOrder.scrape_flags["unmapped_diets"]` → admin prehľad ho
  ukáže ako upozornenie, task loguje warning.
- Manuálny `scrape-now` kvôli nej zápis nepreskočí — blokujú ho len štrukturálne
  warningy.

## Výdajné body (clustre) — tabuľku riadia trasy
Kuchyňa vydáva stravu z dvoch miest súčasne a každé chce vlastnú tabuľku.

- `DeliveryRoute.vydaj` (Výdaj A / B / C). Trasy výdaja A tvoria tabuľku A,
  trasy výdaja B tabuľku B; prevádzka patrí do výdaja svojej trasy, takže sa to
  nastavuje na jednom mieste a nemá si ako protirečiť.
- Migrácia hodí do výdaja B trasy z blokov s `include_in_extra_summary` — teda
  dnešnú Trasu extra.
- Prehľad má dropdown „Výdaj“ (`?vydaj=A`), ktorý platí aj pre PDF; v tlači ide
  každý výdaj na vlastný list. Pri filtrovanom výdaji sa pätka prepočíta z jeho
  vlastných riadkov (predpočítané `totals` platia pre celý deň).
- Karta Rozvoz: select „Výdaj“ pri každej trase aj pri zakladaní novej, filter
  v hlavičke, premenovanie bloku a presun trasy medzi blokmi.

## Čitateľnosť tabuľky
- Hlavička má nadradený pás jedál (Raňajky / Obed / Olovrant), polievka a menu
  sa zlievajú do jedného „Obed“; predel medzi jedlami je hrubší než mriežka.
- Trasa je jemný červený pás s pilulkou (prvá verzia bola príliš krikľavá).
- Nový prázdny stĺpec „Poznámka“ na konci každého dátového riadku.
- Filter tlače je jedna karta (Jedlá / Výdaj) s vetou, čo presne pôjde do PDF.

## Katalóg jedál
Rozloženie sa dá upraviť, nielen pridať a (de)aktivovať — vrátane názvov zložiek
(„Hlavná zložka“ → vlastné pomenovanie). `weight_label` a `base_weight_grams` si
prepočíta serializer.

## Prvý e-mail prevádzke
Pred odkaz na nastavenie hesla pribudol úvodný list klienta (časy uzávierok,
prosba hlásiť nové diéty, kontakt). Prevádzka dostane jediný e-mail, takže
vysvetlenie „prečo“ nemá kam inam ísť.

## Testovanie
- Backend: 1085 passed (`pytest --no-cov -q`), `manage.py check` OK.
- Lint ako v CI: `black --check`, `isort --check-only`, `flake8`, `mypy api`.
- Frontend: `tsc --noEmit`, `eslint`, 240 vitest testov.
- PDF vygenerované a vizuálne skontrolované (dva výdaje → dva listy).
