### PR TITLE
fix: oddeľovacia čiara aj medzi Olovrantom a Poznámkou

### DIFF
--- a/backend/api/exporters/gramage_table_spec.py
+++ b/backend/api/exporters/gramage_table_spec.py
@@ -112,9 +112,11 @@ def _filter_col_groups(col_groups: list[dict], sections: list[str] | None) -> li
 
 def _note_cell() -> dict:
     """Prázdna bunka posledného stĺpca — miesto na ručnú poznámku vo vytlačenej
-    tabuľke. Vracia sa nová inštancia, nie zdieľaný dict, nech si ju renderer
-    nemôže omylom premutovať naprieč riadkami."""
-    return {"text": "", "css": "cell-note"}
+    tabuľke. Nesie `meal-sep`, rovnako ako hlavička nad ňou (`grp-note`/`comp-note`)
+    — inak by oddeľovacia čiara medzi posledným jedlom a Poznámkou chýbala, hoci
+    medzi všetkými ostatnými jedlami je. Vracia sa nová inštancia, nie zdieľaný
+    dict, nech si ju renderer nemôže omylom premutovať naprieč riadkami."""
+    return {"text": "", "css": "cell-note meal-sep"}
 
 
 def _gram_cells(col_grams: list, groups: list[dict], hues: list[str]) -> list[dict]:

--- a/backend/api/tests/test_gramage_table_spec.py
+++ b/backend/api/tests/test_gramage_table_spec.py
@@ -268,7 +268,7 @@ def test_totals_row_uses_a_dash_for_empty_columns():
     spec = build_table_spec(_payload())
 
     # Posledná bunka je prázdna „Poznámka"; gramáž je tá pred ňou.
-    assert spec["footer"][-1]["cells"][-1]["css"] == "cell-note"
+    assert spec["footer"][-1]["cells"][-1]["css"] == "cell-note meal-sep"
     assert spec["footer"][-1]["cells"][-2]["text"] == "—"
 
 
@@ -446,7 +446,12 @@ def test_a_diet_absent_from_the_visible_sections_is_not_summarised():
 
 
 def test_note_column_is_empty_on_every_data_row():
-    """Prázdny stĺpec na ručné poznámky do vytlačenej tabuľky."""
+    """Prázdny stĺpec na ručné poznámky do vytlačenej tabuľky.
+
+    `meal-sep` na poslednom stĺpci je zámerne rovnaké ako medzi ostatnými
+    jedlami — bez neho by čiara medzi posledným jedlom (napr. Olovrant) a
+    Poznámkou chýbala, hoci medzi Raňajkami/Obedom/Olovrantom je.
+    """
     spec = build_table_spec(_payload())
 
     assert spec["header"]["groups"][-1]["text"] == "Poznámka"
@@ -459,7 +464,7 @@ def test_note_column_is_empty_on_every_data_row():
     ]
     assert data_rows
     for row in data_rows:
-        assert row["cells"][-1] == {"text": "", "css": "cell-note"}
+        assert row["cells"][-1] == {"text": "", "css": "cell-note meal-sep"}
 
 
 def test_meal_band_merges_soup_with_main_course():


### PR DESCRIPTION
Hlavička stĺpca „Poznámka" mala `meal-sep`, dátové bunky nie — čiara chýbala presne tam, kde sa oddeľuje posledné jedlo od stĺpca Poznámka. Opravené v `_note_cell()`, test `test_note_column_is_empty_on_every_data_row` zamyká očakávaný CSS.

Testy: 1085 passed, black/isort/flake8/mypy zelené.