### PR TITLE
feat(dev): prihlásenie jedným klikom za každú rolu

### DIFF
--- a/backend/api/management/commands/init_roles.py
+++ b/backend/api/management/commands/init_roles.py
@@ -10,6 +10,8 @@ DEMO_ADMIN_PASSWORD = "admin"
 DEMO_OPERATION_EMAIL = "prevadzka@example.com"
 DEMO_OPERATION_PASSWORD = "prevadzka"
 DEMO_OPERATION_CELOK = "Demo prevádzka"
+DEMO_SPRAVCA_EMAIL = "spravca@example.com"
+DEMO_SPRAVCA_PASSWORD = "spravca"
 DEMO_KUCHYNA_EMAIL = "kuchyna@example.com"
 DEMO_KUCHYNA_PASSWORD = "kuchyna"
 # Demo login je zámerne viac-prevádzkový: jedno-prevádzkový celok nikdy
@@ -128,7 +130,44 @@ class Command(BaseCommand):
         else:
             self.stdout.write(f'Operation user "{DEMO_OPERATION_EMAIL}" already exists')
 
+        self._ensure_demo_spravca()
         self._ensure_demo_kuchyna()
+
+    def _ensure_demo_spravca(self) -> None:
+        """Demo login pre rolu Admin (#483).
+
+        Bez neho sa nedá vyskúšať okresanie práv: `admin@example.com` je
+        superadmin, takže vidí všetko a rozdiel oproti adminovi nie je vidieť.
+        """
+        from api.models import UserProfile
+
+        user, created = self._get_or_create_demo_user(
+            email=DEMO_SPRAVCA_EMAIL,
+            legacy_username="spravca",
+            is_staff=True,
+            is_superuser=False,
+        )
+        user.is_staff = True
+        user.is_superuser = False
+        user.set_password(DEMO_SPRAVCA_PASSWORD)
+        user.save()
+
+        profile = getattr(user, "profile", None)
+        if profile is None:
+            profile = UserProfile(user=user, company_name="Demo admin")
+            profile.role = UserProfile.Role.ADMIN
+            profile._skip_default_facility = True
+            profile.save()
+        elif profile.role != UserProfile.Role.ADMIN:
+            profile.role = UserProfile.Role.ADMIN
+            profile.save(update_fields=["role"])
+
+        if created:
+            self.stdout.write(
+                self.style.SUCCESS(f'Created admin user "{DEMO_SPRAVCA_EMAIL}"')
+            )
+        else:
+            self.stdout.write(f'Admin user "{DEMO_SPRAVCA_EMAIL}" already exists')
 
     def _ensure_demo_kuchyna(self) -> None:
         """Demo login pre rolu Kuchyňa (#486).

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -7,8 +7,12 @@ import { isAdminOrAbove, isKuchyna } from "../lib/roles";
 import { Eye, EyeOff } from "lucide-react";
 
 const API_URL = import.meta.env.VITE_API_URL || "/api";
+// Po jednom logine na rolu — rozdiely v oprávneniach sa inak nedajú
+// preklikať (`admin@example.com` je superadmin, nie obyčajný admin).
 const DEV_LOGIN_USERS = [
-  { label: "Admin", email: "admin@example.com", password: "admin" },
+  { label: "Superadmin", email: "admin@example.com", password: "admin" },
+  { label: "Admin", email: "spravca@example.com", password: "spravca" },
+  { label: "Kuchyňa", email: "kuchyna@example.com", password: "kuchyna" },
   { label: "Prevádzka", email: "prevadzka@example.com", password: "prevadzka" },
 ];
 


### PR DESCRIPTION
Dev prihlásenie ponúkalo len Admina a Prevádzku, pričom `admin@example.com` je v skutočnosti superadmin — rozdiel medzi ním a obyčajným adminom sa tak nedal preklikať.

Pribúda demo login `spravca@example.com` s rolou `admin`; tlačidlá teraz pokrývajú všetky štyri role: Superadmin / Admin / Kuchyňa / Prevádzka.

`init_roles` ho zakladá rovnako ako ostatné demo účty, teda mimo produkcie.

Overené: každé tlačidlo prihlási a presmeruje na správnu cestu (`/admin`, `/admin`, `/kuchyna`, `/home`).