### PR TITLE
fix(edupage): cron skip má sledovať cieľový dátum jedla, nie dnešok

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -632,6 +632,7 @@ def scrape_edupage_orders_task(
                 return {"error": "invalid_meal_type", "meal_types": meal_types}
 
         date_to_meals: dict[datetime.date, list[str] | None]
+        skipped_meals: list[str] = []
         if date_str:
             target_date = datetime.date.fromisoformat(date_str)
             date_to_meals = {target_date: meal_types}
@@ -659,19 +660,28 @@ def scrape_edupage_orders_task(
                     "disabled": True,
                 }
 
-            if (reason := _cron_skip_check("scrape_edupage_orders_task")) is not None:
-                return {
-                    "scraped": 0,
-                    "errors": 0,
-                    "skipped": 0,
-                    "dates": [],
-                    "meal_types": meal_types,
-                    "skipped_run": True,
-                    "reason": reason,
-                }
+            from api.scheduling import day_off_reason
 
             today = timezone.localdate()
+
+            # The skip decision must be per meal's *target* date, not "today":
+            # a day-before meal (e.g. breakfast scraped Sunday evening for
+            # Monday) is scheduled to fire exactly on days today is a
+            # weekend — checking today here would silently kill every
+            # day-before scrape (found live on 2026-08-23, olovrant/breakfast
+            # never scraped for the following Monday).
             if meal_types is None:
+                if (reason := day_off_reason(today)) is not None:
+                    _log_cron_skip_event("scrape_edupage_orders_task", reason, today)
+                    return {
+                        "scraped": 0,
+                        "errors": 0,
+                        "skipped": 0,
+                        "dates": [],
+                        "meal_types": meal_types,
+                        "skipped_run": True,
+                        "reason": reason,
+                    }
                 date_to_meals = {today: None}
             else:
                 date_to_meals = {}
@@ -680,9 +690,27 @@ def scrape_edupage_orders_task(
                         gs, f"deadline_{meal_type}_is_day_before", False
                     )
                     target_date = _next_workday(today) if is_day_before else today
+                    if day_off_reason(target_date) is not None:
+                        skipped_meals.append(meal_type)
+                        continue
                     target_meals = date_to_meals.setdefault(target_date, [])
                     assert target_meals is not None
                     target_meals.append(meal_type)
+
+                if not date_to_meals:
+                    # Every meal's target date is a day off — a genuine full
+                    # skip, same as the meal_types=None case.
+                    reason = day_off_reason(today) or "configured_day_off"
+                    _log_cron_skip_event("scrape_edupage_orders_task", reason, today)
+                    return {
+                        "scraped": 0,
+                        "errors": 0,
+                        "skipped": 0,
+                        "dates": [],
+                        "meal_types": meal_types,
+                        "skipped_run": True,
+                        "reason": reason,
+                    }
 
         scraper = EdupageScraper()
         # Whitelist diét sa číta raz za beh — je rovnaký pre všetky prevádzky.
@@ -849,6 +877,8 @@ def scrape_edupage_orders_task(
             "dates": [str(target_date) for target_date in date_to_meals],
             "meal_types": meal_types,
         }
+        if skipped_meals:
+            summary["skipped_meals"] = skipped_meals
         dispatched = _dispatch_chained_reports(
             chained_reports,
             [str(target_date) for target_date in date_to_meals],

--- a/backend/api/tests/test_edupage_scrape_task.py
+++ b/backend/api/tests/test_edupage_scrape_task.py
@@ -141,6 +141,81 @@ def test_edupage_scrape_uses_next_workday_for_day_before_meal(
 
 
 @pytest.mark.django_db
+def test_edupage_scrape_day_before_meal_runs_on_a_weekend_evening(
+    edupage_user, monkeypatch
+):
+    """Found live on 2026-08-23: a day-before meal (breakfast/olovrant) fires
+    Sunday evening to import Monday's orders — Celery Beat's crontab (see
+    `_day_of_week` in api/signals.py) deliberately schedules it on Sun–Thu
+    for exactly this reason. The skip check must look at the *target* date
+    (Monday, a workday), not "today" (Sunday, a weekend) — else this run
+    would be silently dropped every single week."""
+    GlobalSettings.objects.create(
+        pk=1,
+        deadline_breakfast=datetime.time(21, 0),
+        deadline_breakfast_is_day_before=True,
+        deadline_lunch=datetime.time(9, 0),
+        deadline_olovrant=datetime.time(10, 0),
+    )
+    sunday = datetime.date(2026, 8, 23)
+    monday = datetime.date(2026, 8, 24)
+    seen_dates = []
+
+    def fake_scrape(self, url, target_date, prevadzka_matches=None, allowed_diets=None):
+        seen_dates.append(target_date)
+        return _scrape_result(
+            order_data={"breakfast": {"menuCounts": {"A": 3}, "diets": {}}},
+            warnings=[],
+        )
+
+    monkeypatch.setattr(timezone, "localdate", lambda: sunday)
+    monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", fake_scrape)
+
+    result = scrape_edupage_orders_task.run(meal_types=["breakfast"])
+
+    assert result.get("skipped_run") is not True
+    assert result["dates"] == [str(monday)]
+    assert seen_dates == [monday]
+    assert DailyOrder.objects.filter(user=edupage_user, date=monday).exists()
+
+
+@pytest.mark.django_db
+def test_edupage_scrape_skips_only_the_meal_whose_target_is_a_day_off(
+    edupage_user, monkeypatch
+):
+    """Mixed run: a day-before meal targeting Monday must scrape, while a
+    same-day meal targeting Sunday itself must be skipped — per meal, not
+    for the whole task."""
+    GlobalSettings.objects.create(
+        pk=1,
+        deadline_breakfast=datetime.time(21, 0),
+        deadline_breakfast_is_day_before=True,
+        deadline_lunch=datetime.time(9, 0),
+        deadline_olovrant=datetime.time(10, 0),
+    )
+    sunday = datetime.date(2026, 8, 23)
+    monday = datetime.date(2026, 8, 24)
+    seen_dates = []
+
+    def fake_scrape(self, url, target_date, prevadzka_matches=None, allowed_diets=None):
+        seen_dates.append(target_date)
+        return _scrape_result(
+            order_data={"breakfast": {"menuCounts": {"A": 3}, "diets": {}}},
+            warnings=[],
+        )
+
+    monkeypatch.setattr(timezone, "localdate", lambda: sunday)
+    monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", fake_scrape)
+
+    result = scrape_edupage_orders_task.run(meal_types=["breakfast", "lunch"])
+
+    assert result.get("skipped_run") is not True
+    assert result["dates"] == [str(monday)]
+    assert seen_dates == [monday]
+    assert result["skipped_meals"] == ["lunch"]
+
+
+@pytest.mark.django_db
 def test_edupage_scrape_persists_attention_flags(edupage_user, monkeypatch):
     """Upozornenia scrapu sa uložia do DailyOrder.scrape_flags a pri čistom
     behu sa vyčistia, nech admin prehľad nezobrazuje starý výkričník."""

--- a/backend/api/tests/test_report_chained_after_scrape.py
+++ b/backend/api/tests/test_report_chained_after_scrape.py
@@ -136,7 +136,8 @@ class TestChainedReportDispatch:
         """Víkend/sviatok — scrape sa preskočí, report nemá čo hlásiť."""
         _settings()
         _stub_scrape(monkeypatch)
-        monkeypatch.setattr("api.tasks._cron_skip_check", lambda name: "weekend")
+        saturday = datetime.date(2026, 8, 8)
+        monkeypatch.setattr(timezone, "localdate", lambda: saturday)
 
         with patch("api.tasks.send_daily_report_task.apply_async") as apply_async:
             result = scrape_edupage_orders_task.run(


### PR DESCRIPTION
## Bug

`scrape_edupage_orders_task` skipoval celý beh, keď bolo **DNES** víkend — aj keď day-before jedlo (raňajky/olovrant s `deadline_..._is_day_before=True`) beží zámerne v nedeľu večer, aby stiahlo objednávky **na pondelok** (Celery Beat crontab má pre tieto úlohy masku Ne–Št, viď `_day_of_week` v `api/signals.py`).

Skip check (`_cron_skip_check`) sa pýtal na `timezone.localdate()` (dnešok), nie na cieľový dátum jedla — takže večerný day-before scrape sa nikdy nevykonal. Nájdené naživo 23. 8. 2026 (EventLog: `CRON_SKIPPED`, reason `weekend`, hoci cieľom bol pondelok — pracovný deň).

## Fix

Skip sa teraz vyhodnocuje **per meal_type podľa jeho cieľového dátumu**:
- `meal_types=None` (default beat run bez explicitných jedál): skip len keď je voľno dnes (nezmenené správanie).
- `meal_types=[...]`: skip len tie jedlá, ktorých cieľový dátum je voľno; ak majú voľno všetky, celý beh sa preskočí ako predtým (rovnaký `CRON_SKIPPED` log).

Pridané testy:
- day-before jedlo v nedeľu večer beží (cieľ pondelok) namiesto tichého skipu
- zmiešaný beh: day-before jedlo beží, same-day jedlo sa preskočí — len ono, nie celý beh

## Testing
- `pytest --no-cov -q` (celá sada): 1267 passed
- `black --check`, `isort --check-only`, `mypy api` cez pre-commit hook: passed
- `manage.py check`: no issues