### PR TITLE
fix(edupage): flaguj neisté fuzzy priradenie diéty, zobraz ho v prehľade (#527, #528)

### DIFF
--- a/backend/api/edupage_scraper.py
+++ b/backend/api/edupage_scraper.py
@@ -100,6 +100,7 @@ _SKRATKA_MAP: dict[str, str] = {
     "NOM": "NO MILK",
     "NG": "NO GLUTEN",
     "NOG": "NO GLUTEN",
+    "NOGLUTEN": "NO GLUTEN",  # MŠ Dobrého Pastiera píše skratku vypísanú celú
     "NGNM": "NO MILK/NO GLUTEN",
     "NMNG": "NO MILK/NO GLUTEN",
     "NMG": "NO MILK/NO GLUTEN",
@@ -118,9 +119,11 @@ _SKRATKA_MAP: dict[str, str] = {
     "NMNO": "NO MILK",
     "NMZ": "NO MILK",
     "NMZD": "NO MILK",
+    "PNM": "NO MILK",  # MŠ Edulienka: "PnM" (Palisády no Milk)
     "V": "VEGGIE",
     "VEG": "VEGGIE",
     "VE": "VEGGIE",
+    "VEGE": "VEGGIE",  # British School píše po anglicky "Vege"
     "PV": "VEGGIE",
     "SV": "VEGGIE",
     "VEGETAR": "VEGGIE",
@@ -297,6 +300,13 @@ class ScrapeResult:
     # `unmapped_letters` rozpadnuté podľa prevádzky, do ktorej porcie padli.
     # Prázdne pri jedno-prevádzkovom scrape (vtedy platí `unmapped_letters`).
     unmapped_by_prevadzka: dict[str, list[str]] = field(default_factory=dict)
+    # Diéty, ktoré appka rozpoznala len heuristikou (fuzzy suffix/keyword scan, nie
+    # exaktnou skratkou zo `_SKRATKA_MAP`), aj keď výsledný názov je medzi povolenými.
+    # Počty a priradenie sa NEMENIA — je to len signál pre admina na kontrolu, nie
+    # signál zlyhania (nesmie sa miešať do `warnings`/`unmapped_letters`).
+    uncertain_letters: list[str] = field(default_factory=list)
+    # `uncertain_letters` rozpadnuté podľa prevádzky, analogicky k `unmapped_by_prevadzka`.
+    uncertain_by_prevadzka: dict[str, list[str]] = field(default_factory=dict)
     # Scrape zlyhal štrukturálne — volajúci z toho robí "neimportuj nič".
     warnings: list[str] = field(default_factory=list)
     # Scrape prebehol, ale per-prevádzka config nesedí s realitou (škola zmenila
@@ -535,45 +545,65 @@ class EdupageScraper:
         1. Known skratka (abbreviation) exact match
         2. Keyword scan on normalised nazov
         3. Fallback: return nazov as-is (stored under that name in diets)
+
+        Tenký wrapper nad `_resolve_diet_name_with_confidence` — vracia len názov,
+        bez confidence flagu. Signatúra/návratový typ zostávajú nezmenené zámerne,
+        volá sa priamo z testov (`TestResolveDietName`).
+        """
+        name, _ = EdupageScraper._resolve_diet_name_with_confidence(skratka, nazov)
+        return name
+
+    @staticmethod
+    def _resolve_diet_name_with_confidence(
+        skratka: str, nazov: str
+    ) -> tuple[str, bool]:
+        """Ako `resolve_diet_name`, ale aj s flagom, či sme si istí.
+
+        `is_exact=True` len pre presnú zhodu v `_SKRATKA_MAP` — všetko ostatné (suffix
+        heuristiky, keyword scan, fallback echo) je fuzzy odhad. `is_exact=False`
+        neznamená, že výsledok je zlý (fuzzy matching bežne funguje správne), len že
+        appka si nie je istá a admin by ho mal vedieť skontrolovať (viď #527: nová/
+        nezvyčajná diéta môže zdieľať fragment s existujúcou skratkou a tíško sa
+        priradiť nesprávne).
         """
         sk = skratka.strip().upper()
         if sk in _SKRATKA_MAP:
-            return _SKRATKA_MAP[sk]
+            return _SKRATKA_MAP[sk], True
 
         compact_sk = _normalise_key(skratka)
         if any(fragment in compact_sk for fragment in ("nmng", "ngnm", "bmbg")):
-            return "NO MILK/NO GLUTEN"
+            return "NO MILK/NO GLUTEN", False
         if compact_sk.endswith("nmg") or compact_sk.endswith("ngm"):
-            return "NO MILK/NO GLUTEN"
+            return "NO MILK/NO GLUTEN", False
         if compact_sk.endswith("ngh"):
-            return "NO GLUTEN"
+            return "NO GLUTEN", False
         if compact_sk.endswith("nnn") or "nonono" in compact_sk:
-            return "NONONO"
+            return "NONONO", False
         if compact_sk.endswith("hit") or compact_sk.endswith("his"):
-            return "HISTAMIN"
+            return "HISTAMIN", False
         if compact_sk.endswith("ng") or compact_sk.endswith("nog"):
-            return "NO GLUTEN"
+            return "NO GLUTEN", False
         if compact_sk.endswith("nm") or compact_sk.endswith("nom"):
-            return "NO MILK"
+            return "NO MILK", False
         if compact_sk.endswith("nomo"):
-            return "NO MILK"
+            return "NO MILK", False
         if compact_sk.endswith("ne") or compact_sk.startswith("ne"):
-            return "NO EGG"
+            return "NO EGG", False
         if compact_sk.endswith("h") and re.search(r"(?:^|\s)H\s*$", nazov):
-            return "HISTAMIN"
+            return "HISTAMIN", False
 
         key = _normalise_key(f"{skratka} {nazov}")
 
         if sk.endswith("V") and re.search(r"(?:^|\s)V\s*$", nazov, re.IGNORECASE):
-            return "VEGGIE"
+            return "VEGGIE", False
 
         for fragment, diet_name in sorted(
             _NAZOV_KEYWORD_MAP.items(), key=lambda item: len(item[0]), reverse=True
         ):
             if fragment in key:
-                return diet_name
+                return diet_name, False
 
-        return nazov.strip() or skratka.strip()
+        return nazov.strip() or skratka.strip(), False
 
     @staticmethod
     def resolve_payer_portion_name(nazov: str, portion_code: str) -> str:
@@ -648,6 +678,7 @@ class EdupageScraper:
 
         warnings: list[str] = []
         unmapped: list[str] = []
+        uncertain: list[str] = []
         attention: list[str] = []
         # Normalizovaný index, aby `no milk` z EduPage sadlo na našu `NO MILK` a
         # nezaložilo druhú, len inak písanú diétu.
@@ -683,6 +714,8 @@ class EdupageScraper:
         attention_buckets: dict[str, set[str]] = {}
         # to isté pre neznáme diéty (`unmapped`)
         unmapped_buckets: dict[str, set[str]] = {}
+        # to isté pre neisto (fuzzy) namatchnuté diéty (`uncertain`)
+        uncertain_buckets: dict[str, set[str]] = {}
 
         date_key = target_date.isoformat()
         day_data = prehlad.get(date_key, {})
@@ -710,6 +743,7 @@ class EdupageScraper:
 
                 flag_label: str | None = None
                 unmapped_label: str | None = None
+                uncertain_label: str | None = None
                 if rule is not None and (rule.menu or rule.diet):
                     menu_variant = rule.menu
                     diet_name = rule.diet
@@ -720,12 +754,19 @@ class EdupageScraper:
                     menu_variant = self.resolve_menu_variant(skratka, nazov)
                     diet_name = None
                     if menu_variant is None:
-                        diet_name = self.resolve_diet_name(skratka, nazov)
+                        diet_name, diet_is_exact = (
+                            self._resolve_diet_name_with_confidence(skratka, nazov)
+                        )
                         canonical = allowed_by_key.get(_normalise_key(diet_name))
                         if canonical is not None:
                             diet_name = canonical
                             if diet_name == letter and letter not in nazov_menu:
                                 unmapped_label = letter
+                            elif not diet_is_exact:
+                                # Fuzzy match (nie exaktná skratka) padol medzi povolené
+                                # diéty — počty ostávajú, ale appka si nie je istá, tak
+                                # to nahlási na kontrolu namiesto tichej istoty (#527).
+                                uncertain_label = f"{letter}:{skratka}→{diet_name}"
                         else:
                             # Neznámu diétu NEZAHADZUJEME: skorší `continue` tu zmazal
                             # celý riadok vrátane počtu porcií, takže kuchyni chýbali
@@ -735,6 +776,8 @@ class EdupageScraper:
                             unmapped_label = f"{letter}:{diet_name}"
                         if unmapped_label is not None:
                             unmapped.append(unmapped_label)
+                        if uncertain_label is not None:
+                            uncertain.append(uncertain_label)
 
                 tp = letter_data.get("typ_platitela", {})
                 if not isinstance(tp, dict):
@@ -792,6 +835,10 @@ class EdupageScraper:
                             unmapped_buckets.setdefault(bucket, set()).add(
                                 unmapped_label
                             )
+                        if uncertain_label is not None:
+                            uncertain_buckets.setdefault(bucket, set()).add(
+                                uncertain_label
+                            )
 
                         counts_by_meal = counts.setdefault(bucket, {})
                         meal_counts = counts_by_meal.setdefault(meal_key, {})
@@ -841,6 +888,12 @@ class EdupageScraper:
             unmapped_by_prevadzka={
                 bucket: sorted(labels)
                 for bucket, labels in unmapped_buckets.items()
+                if bucket and labels
+            },
+            uncertain_letters=sorted(set(uncertain)),
+            uncertain_by_prevadzka={
+                bucket: sorted(labels)
+                for bucket, labels in uncertain_buckets.items()
                 if bucket and labels
             },
             warnings=warnings,

--- a/backend/api/migrations/0080_alter_dailyorder_scrape_flags.py
+++ b/backend/api/migrations/0080_alter_dailyorder_scrape_flags.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Len `help_text`: `scrape_flags` odteraz nesie aj `uncertain_diets`."""
+
+    dependencies = [
+        ("api", "0079_alter_deliveryroute_vydaj"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="dailyorder",
+            name="scrape_flags",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text=(
+                    "Poznámky z posledného EduPage scrapu tejto objednávky, napr. "
+                    "{'attention': [...], 'config_notes': [...], "
+                    "'unmapped_diets': [...], 'uncertain_diets': [...]}. "
+                    "Prázdne pri ručných objednávkach a pri scrape bez upozornení."
+                ),
+            ),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -82,8 +82,9 @@ class DailyOrder(models.Model):
         blank=True,
         help_text=(
             "Poznámky z posledného EduPage scrapu tejto objednávky, napr. "
-            "{'attention': [...], 'config_notes': [...], 'unmapped_diets': [...]}. "
-            "Prázdne pri ručných objednávkach a pri scrape bez upozornení."
+            "{'attention': [...], 'config_notes': [...], 'unmapped_diets': [...], "
+            "'uncertain_diets': [...]}. Prázdne pri ručných objednávkach a "
+            "pri scrape bez upozornení."
         ),
     )
     is_auto = models.BooleanField(

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -786,9 +786,13 @@ def scrape_edupage_orders_task(
                         unmapped_for_prevadzka = result.unmapped_by_prevadzka.get(
                             nazov, []
                         )
+                        uncertain_for_prevadzka = result.uncertain_by_prevadzka.get(
+                            nazov, []
+                        )
                     else:
                         attention_for_prevadzka = result.attention
                         unmapped_for_prevadzka = result.unmapped_letters
+                        uncertain_for_prevadzka = result.uncertain_letters
 
                     nested_order_data = nest_order_data_by_category(
                         data_by_nazov.get(nazov, {}), nazov
@@ -803,6 +807,8 @@ def scrape_edupage_orders_task(
                     # Skutočné zlyhanie scrapu (chýbajúci/pokazený prehlad blok,
                     # nezmapované písmeno, riadok bez prevádzky) - neprepisujeme
                     # existujúce dáta prázdnom, mohli by sme zmazať platné počty.
+                    # `uncertain_letters` sem zámerne nepatrí — je to len "over ma"
+                    # signál (ako `config_notes`), nie signál zlyhania scrapu.
                     if not imported_data and (
                         result.warnings or result.unmapped_letters
                     ):
@@ -838,6 +844,7 @@ def scrape_edupage_orders_task(
                             "attention": list(attention_for_prevadzka),
                             "config_notes": list(result.config_notes),
                             "unmapped_diets": list(unmapped_for_prevadzka),
+                            "uncertain_diets": list(uncertain_for_prevadzka),
                         }
                         order.save(update_fields=["data", "scrape_flags", "updated_at"])
                     scraped += 1

--- a/backend/api/tests/test_edupage_scrape_task.py
+++ b/backend/api/tests/test_edupage_scrape_task.py
@@ -170,6 +170,7 @@ def test_edupage_scrape_persists_attention_flags(edupage_user, monkeypatch):
         "attention": ["A:KZ?"],
         "config_notes": ["olovrant chýba"],
         "unmapped_diets": [],
+        "uncertain_diets": [],
     }
 
     def clean_scrape(
@@ -187,6 +188,7 @@ def test_edupage_scrape_persists_attention_flags(edupage_user, monkeypatch):
         "attention": [],
         "config_notes": [],
         "unmapped_diets": [],
+        "uncertain_diets": [],
     }
 
 
@@ -240,6 +242,8 @@ def test_edupage_scrape_splits_attention_flags_per_prevadzka(monkeypatch):
             attention_by_prevadzka={"Jolly 1": ["A:ZD?"]},
             unmapped_letters=["Z:Nová diéta"],
             unmapped_by_prevadzka={"Jolly 1": ["Z:Nová diéta"]},
+            uncertain_letters=["Y:XY→NO MILK"],
+            uncertain_by_prevadzka={"Jolly 2": ["Y:XY→NO MILK"]},
             config_notes=["olovrant chýba"],
             warnings=[],
         )
@@ -253,12 +257,15 @@ def test_edupage_scrape_splits_attention_flags_per_prevadzka(monkeypatch):
         "attention": ["A:ZD?"],
         "config_notes": ["olovrant chýba"],
         "unmapped_diets": ["Z:Nová diéta"],
+        "uncertain_diets": [],
     }
-    # Jolly 2 nemá flag, ale zdieľané config_notes áno.
+    # Jolly 2 nemá attention/unmapped flag, ale má svoj uncertain flag a
+    # zdieľané config_notes.
     assert o2.scrape_flags == {
         "attention": [],
         "config_notes": ["olovrant chýba"],
         "unmapped_diets": [],
+        "uncertain_diets": ["Y:XY→NO MILK"],
     }
 
 
@@ -375,6 +382,40 @@ def test_edupage_scrape_skips_without_recording_on_unmapped_letters(
     assert not DailyOrder.objects.filter(user=edupage_user, date=target_date).exists()
     assert result["scraped"] == 0
     assert result["skipped"] == 1
+
+
+@pytest.mark.django_db
+def test_edupage_scrape_saves_normally_despite_uncertain_diets(
+    edupage_user, monkeypatch
+):
+    """#527: `uncertain_letters` je len informačný "over ma" flag (ako
+    `config_notes`), nie signál zlyhania — nesmie spustiť skip-on-failure guard
+    (na rozdiel od `unmapped_letters`, viď test vyššie)."""
+    GlobalSettings.objects.create(
+        pk=1,
+        deadline_breakfast=datetime.time(18, 0),
+        deadline_lunch=datetime.time(9, 0),
+        deadline_olovrant=datetime.time(10, 0),
+    )
+    target_date = datetime.date(2026, 6, 30)
+
+    def fake_scrape(self, url, scrape_date, prevadzka_matches=None, allowed_diets=None):
+        return _scrape_result(
+            order_data={"lunch": {"menuCounts": {"A": 5}, "diets": {"NO MILK": 5}}},
+            warnings=[],
+            unmapped_letters=[],
+            uncertain_letters=["A:XY→NO MILK"],
+        )
+
+    monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", fake_scrape)
+
+    result = scrape_edupage_orders_task.run(date_str=target_date.isoformat())
+
+    order = DailyOrder.objects.get(user=edupage_user, date=target_date)
+    assert order.data
+    assert order.scrape_flags["uncertain_diets"] == ["A:XY→NO MILK"]
+    assert result["scraped"] == 1
+    assert result["skipped"] == 0
 
 
 @pytest.mark.django_db

--- a/backend/api/tests/test_edupage_scraper.py
+++ b/backend/api/tests/test_edupage_scraper.py
@@ -89,6 +89,56 @@ class TestResolveDietName(unittest.TestCase):
     def test_unknown_fallback_empty_nazov_returns_skratka(self):
         self.assertEqual(self._r("XZ", ""), "XZ")
 
+    def test_real_edupage_aliases_promoted_to_exact_skratka(self):
+        """Bezpečné fuzzy matche pozorované na reálnom EduPage (over_edupage
+        check, 26. 8. 2026) — školy ich píšu takto konzistentne, tak sú
+        povýšené na exaktnú `_SKRATKA_MAP` zhodu (žiadny `uncertain` šum)."""
+        cases = [
+            ("NoGluten", "NoGluten", "NO GLUTEN"),  # MŠ Dobrého Pastiera
+            ("PnM", "Palisády nM", "NO MILK"),  # MŠ Edulienka
+            ("Vege", "Vege", "VEGGIE"),  # British School
+        ]
+        for skratka, nazov, expected in cases:
+            with self.subTest(skratka=skratka, nazov=nazov):
+                name, is_exact = EdupageScraper._resolve_diet_name_with_confidence(
+                    skratka, nazov
+                )
+                self.assertEqual(name, expected)
+                self.assertTrue(is_exact)
+
+    def test_confidence_exact_skratka_is_exact(self):
+        name, is_exact = EdupageScraper._resolve_diet_name_with_confidence(
+            "NM", "NoMilk"
+        )
+        self.assertEqual(name, "NO MILK")
+        self.assertTrue(is_exact)
+
+    def test_confidence_fuzzy_keyword_is_not_exact(self):
+        name, is_exact = EdupageScraper._resolve_diet_name_with_confidence(
+            "XYZ", "NoMilk"
+        )
+        self.assertEqual(name, "NO MILK")
+        self.assertFalse(is_exact)
+
+    def test_confidence_fuzzy_suffix_is_not_exact(self):
+        name, is_exact = EdupageScraper._resolve_diet_name_with_confidence(
+            "PnMG", "Palisády nMG"
+        )
+        self.assertEqual(name, "NO MILK/NO GLUTEN")
+        self.assertFalse(is_exact)
+
+    def test_confidence_fallback_is_not_exact(self):
+        name, is_exact = EdupageScraper._resolve_diet_name_with_confidence(
+            "ABC", "menu A"
+        )
+        self.assertEqual(name, "menu A")
+        self.assertFalse(is_exact)
+
+    def test_resolve_diet_name_unaffected_by_confidence_split(self):
+        # `resolve_diet_name` musí byť naďalej tenký string-only wrapper.
+        self.assertEqual(self._r("NM", "NoMilk"), "NO MILK")
+        self.assertEqual(self._r("XYZ", "NoMilk"), "NO MILK")
+
     def test_real_edupage_prefixed_no_milk_aliases(self):
         cases = [
             ("BM", "Bruško bezMliečne"),
@@ -781,6 +831,70 @@ class TestParse(unittest.TestCase):
             znama.order_data,
             {"lunch": {"Škôlka": {"menuCounts": {"A": 4}, "diets": {"NO KAKAO": 4}}}},
         )
+
+    def test_fuzzy_matched_diet_is_uncertain_but_counted_normally(self):
+        """#527: skratka mimo `_SKRATKA_MAP`, ktorá fuzzy-matchne na povolenú diétu,
+        sa počíta rovnako ako doteraz (žiadny unmapped flag), ale appka si to
+        poznamená ako neisté na kontrolu — namiesto tichej istoty."""
+        prehlad = {
+            "prehlad": {
+                self.DATE_STR: {
+                    "2": {
+                        "Z": {
+                            "typ_platitela": {"1": {"o": 2}},
+                            "porcia": {},
+                            "v_skupina": {},
+                        },
+                    }
+                }
+            },
+            "mamUnknown": False,
+            "unknownTypyIDS": [],
+        }
+        # "XYZ" nie je v `_SKRATKA_MAP`, ale nazov obsahuje "NoMilk" → fuzzy hit.
+        nazov_menu = {"Z": {"skratka": "XYZ", "nazov": "NoMilk"}}
+        html = _make_html(
+            prehlad,
+            nazov_menu,
+            [],
+            self._typy([(1, "MŠ Klasik", 0)]),
+            self.DATE_STR,
+        )
+        result = self._scrape_html(html)
+
+        self.assertEqual(result.unmapped_letters, [])
+        self.assertEqual(result.uncertain_letters, ["Z:XYZ→NO MILK"])
+        self.assertEqual(
+            result.order_data,
+            {"lunch": {"Škôlka": {"menuCounts": {"A": 2}, "diets": {"NO MILK": 2}}}},
+        )
+
+    def test_exact_skratka_match_is_not_uncertain(self):
+        prehlad = {
+            "prehlad": {
+                self.DATE_STR: {
+                    "2": {
+                        "A": {
+                            "typ_platitela": {"1": {"o": 2}},
+                            "porcia": {},
+                            "v_skupina": {},
+                        },
+                    }
+                }
+            },
+            "mamUnknown": False,
+            "unknownTypyIDS": [],
+        }
+        nazov_menu = {"A": {"skratka": "NM", "nazov": "NoMilk"}}
+        html = _make_html(
+            prehlad,
+            nazov_menu,
+            [],
+            self._typy([(1, "MŠ Klasik", 0)]),
+            self.DATE_STR,
+        )
+        result = self._scrape_html(html)
+        self.assertEqual(result.uncertain_letters, [])
 
 
 class TestFetchError(unittest.TestCase):

--- a/backend/api/views/report_views.py
+++ b/backend/api/views/report_views.py
@@ -41,7 +41,12 @@ def build_prevadzka_overview(target_date):
         is_edupage = prevadzka.celok.zdroj_objednavok == Celok.ZdrojObjednavok.EDUPAGE
         order = orders_by_prevadzka.get(prevadzka.id)
         data = {}
-        flags = {"attention": [], "config_notes": [], "unmapped_diets": []}
+        flags = {
+            "attention": [],
+            "config_notes": [],
+            "unmapped_diets": [],
+            "uncertain_diets": [],
+        }
         counts = meal_counts(data)
         delivery_status = "missing"
         if order is not None:
@@ -59,6 +64,8 @@ def build_prevadzka_overview(target_date):
                     "config_notes": order.scrape_flags.get("config_notes", []) or [],
                     "unmapped_diets": order.scrape_flags.get("unmapped_diets", [])
                     or [],
+                    "uncertain_diets": order.scrape_flags.get("uncertain_diets", [])
+                    or [],
                 }
 
         row = {
@@ -70,7 +77,10 @@ def build_prevadzka_overview(target_date):
             "counts": counts,
             "flags": flags,
             "has_warning": bool(
-                flags["attention"] or flags["config_notes"] or flags["unmapped_diets"]
+                flags["attention"]
+                or flags["config_notes"]
+                or flags["unmapped_diets"]
+                or flags["uncertain_diets"]
             ),
         }
         (edupage_rows if is_edupage else app_rows).append(row)

--- a/frontend/src/pages/admin/PrevadzkaOverview.test.tsx
+++ b/frontend/src/pages/admin/PrevadzkaOverview.test.tsx
@@ -41,4 +41,83 @@ describe("PrevadzkaOverview", () => {
     expect(weekday).not.toBe(0);
     expect(weekday).not.toBe(6);
   });
+
+  const baseRow = {
+    prevadzka_id: 1,
+    nazov: "MŠ Testovacia",
+    celok: "MŠ Testovacia",
+    delivered: true,
+    delivery_status: "manual" as const,
+    counts: { breakfast: 0, lunch: 5, olovrant: 0, total: 5 },
+    has_warning: true,
+  };
+
+  it("shows unmapped diets inline, not just in a hover tooltip", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        date: "2026-08-10",
+        edupage: [
+          {
+            ...baseRow,
+            flags: { attention: [], config_notes: [], unmapped_diets: ["N:NO KAKAO"] },
+          },
+        ],
+        app: [],
+      }),
+    });
+
+    render(<PrevadzkaOverview />);
+
+    await screen.findByText("Kontrola objednávok");
+    expect(screen.getByText(/NO KAKAO/)).toBeInTheDocument();
+  });
+
+  it("shows uncertain (fuzzy-matched) diets inline", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        date: "2026-08-10",
+        edupage: [
+          {
+            ...baseRow,
+            flags: {
+              attention: [],
+              config_notes: [],
+              unmapped_diets: [],
+              uncertain_diets: ["Z:XYZ→NO MILK"],
+            },
+          },
+        ],
+        app: [],
+      }),
+    });
+
+    render(<PrevadzkaOverview />);
+
+    await screen.findByText("Kontrola objednávok");
+    expect(screen.getByText(/XYZ→NO MILK/)).toBeInTheDocument();
+  });
+
+  it("does not render an extra warning line when there are no diet flags", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        date: "2026-08-10",
+        edupage: [
+          {
+            ...baseRow,
+            has_warning: false,
+            flags: { attention: [], config_notes: [], unmapped_diets: [], uncertain_diets: [] },
+          },
+        ],
+        app: [],
+      }),
+    });
+
+    render(<PrevadzkaOverview />);
+
+    await screen.findByText("MŠ Testovacia");
+    expect(screen.queryByText(/→/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/admin/PrevadzkaOverview.tsx
+++ b/frontend/src/pages/admin/PrevadzkaOverview.tsx
@@ -24,7 +24,12 @@ interface OverviewRow {
   delivered: boolean;
   delivery_status?: "missing" | "manual_zero" | "auto" | "manual";
   counts: OverviewCounts;
-  flags: { attention: string[]; config_notes: string[]; unmapped_diets?: string[] };
+  flags: {
+    attention: string[];
+    config_notes: string[];
+    unmapped_diets?: string[];
+    uncertain_diets?: string[];
+  };
   has_warning: boolean;
 }
 
@@ -81,7 +86,15 @@ const StatusDot: React.FC<{ row: OverviewRow; source: "edupage" | "app" }> = ({ 
     const unmapped = (row.flags.unmapped_diets ?? []).map(
       (d) => `neznáma diéta z EduPage: ${d} — založ ju v appke`,
     );
-    const notes = [...row.flags.config_notes, ...row.flags.attention, ...unmapped].join("\n");
+    const uncertain = (row.flags.uncertain_diets ?? []).map(
+      (d) => `neistá zhoda diéty z EduPage: ${d} — over, či je správne priradená`,
+    );
+    const notes = [
+      ...row.flags.config_notes,
+      ...row.flags.attention,
+      ...unmapped,
+      ...uncertain,
+    ].join("\n");
     return (
       <span className="zpa-statusdot warn" title={`Dodané, ale skontroluj:\n${notes}`}>
         <AlertTriangle />
@@ -104,12 +117,21 @@ const MealCount: React.FC<{ label: string; value: number; strong?: boolean }> = 
 
 const OverviewRowItem: React.FC<{ row: OverviewRow; source: "edupage" | "app" }> = ({ row, source }) => {
   const showCelok = row.celok && row.celok !== row.nazov;
+  const dietWarnings = [
+    ...(row.flags.unmapped_diets ?? []),
+    ...(row.flags.uncertain_diets ?? []),
+  ];
   return (
     <div className="zpa-ovrow">
       <StatusDot row={row} source={source} />
       <div style={{ minWidth: 0, flex: 1 }}>
         <div className="nm">{row.nazov}</div>
         {showCelok && <div className="sub">{row.celok}</div>}
+        {dietWarnings.length > 0 && (
+          <div className="sub" style={{ color: "var(--mustard-700)" }}>
+            {dietWarnings.join(", ")}
+          </div>
+        )}
       </div>
       <div className="zpa-ovcounts">
         <MealCount label="R" value={row.counts.breakfast} />


### PR DESCRIPTION
## Čo rieši

- **#527** — `resolve_diet_name()` mal fuzzy vrstvu (suffix heuristiky + `_NAZOV_KEYWORD_MAP`), ktorá pri zhode s povolenou diétou nikdy nenahlásila neistotu — aj keď išlo len o odhad, nie o exaktnú zhodu skratky. Riziko: nová/nezvyčajná diéta zdieľajúca fragment s existujúcou skratkou sa ticho priradí nesprávne (stalo sa pri Cverničke).
- **#528** — jediné miesto, kde bolo vidno `unmapped_diets`, bol natívny `title` hover tooltip na ikonke — ľahko sa prehliadne pri dennej kontrole.

## Riešenie

- `resolve_diet_name` rozdelený na `_resolve_diet_name_with_confidence` (vracia `(názov, is_exact)`) + tenký string-only wrapper (zachováva kontrakt s ~15 existujúcimi testami).
- Fuzzy match, ktorý padne medzi povolené diéty, sa **naďalej počíta rovnako ako doteraz** — žiadna zmena counts/priradenia. Navyše sa zapíše do nového `scrape_flags["uncertain_diets"]`, nech to admin vidí a overí.
- `PrevadzkaOverview` zobrazuje `unmapped_diets`/`uncertain_diets` ako viditeľný riadok pod prevádzkou (nie len v tooltipe).
- Pridané bezpečné aliasy do `_SKRATKA_MAP` (`NOGLUTEN`, `PNM`, `VEGE`) — overené priamo proti reálnym EduPage dátam, kde spôsobovali zbytočný `uncertain` šum bez reálneho rizika.

## Overenie proti reálnemu EduPage

Spustil som scraper (s týmto fixom) proti verejným mealsGuest stránkam všetkých 18 pripojených škôl za posledných 10 dní (read-only HTTP GET, žiadny zápis). Po pridaní aliasov ostávajú flagnuté len skutočne rizikové zložené skratky:
- Cvernička: `nMnČnJ→NO MILK/NO GLUTEN`, `nMnOnJnPnČnŠnZEL→NO MILK/NO GLUTEN` (viac obmedzení zbalených do jednej diéty)
- Zdravé Brúško: `dsbNMNE→NO EGG` (stráca NM časť)
- MŠ Felix Karlovská: `NE bez O,A,S,S→NO EGG`

British School (`VEGE`), MŠ Dobrého Pastiera (`NoGluten`) a MŠ Edulienka (`PnM`) sú po pridaní aliasov čisté — žiadny falošný poplach.

## Testy

- Backend: 1287/1287 (`pytest --no-cov -q`), `manage.py check`, `black`/`isort`/`mypy` čisto.
- Frontend: 289/289 (`vitest run`), `tsc --noEmit`, `eslint` čisto.
- Overené v izolovanom docker stacku vetvenom z `develop` (nie zdieľané kontajnery iných session).