### PR TITLE
feat: British School vlastný scrape 12:15 + farby/čiary v tabuľke gramáže

### DIFF
--- a/backend/api/exporters/assets/gramage-pdf.css
+++ b/backend/api/exporters/assets/gramage-pdf.css
@@ -77,6 +77,13 @@ h1 small {
  * gramáže. */
 .zpa-gram th,
 .zpa-gram td { min-width: 0; padding: 1mm 1.2mm; }
+/* Čiary medzi každými dvoma bunkami (#536) — bez farebného podkladu
+ * (čiernobiela tlač, iné DPI ako na obrazovke) sa v tabuľke bez mriežky
+ * strácala orientácia medzi bunkami. `meal-sep`, hlavička a pásy majú
+ * vlastné, výraznejšie čiary — tie prebijú túto len tam, kde treba. */
+.zpa-gram th,
+.zpa-gram td { border: 0.5pt solid rgba(23, 53, 5, 0.25); }
+.zpa-gram thead th { border-color: rgba(255, 255, 255, 0.28); }
 .zpa-gram th:first-child,
 .zpa-gram td:first-child { width: 42mm; min-width: 0; max-width: none; }
 /* Názov riadku sa v úzkom stĺpci musí zalomiť. Obrazovka ho skracuje „…"-om a
@@ -139,7 +146,9 @@ h1 small {
 .zpa-gram .mh-menuC-cell,
 .zpa-gram .mh-menuV-cell,
 .zpa-gram .mh-snack-cell { background: transparent; }
-.zpa-gram .sub-row.zebra td { background: #EDEDEA; }
+/* Diétny riadok má vlastné podfarbenie podľa (kombinovanej) diéty (#536) —
+ * pruh by ho na papieri prekryl neutrálnou sivou, tak sa mu vyhýba. */
+.zpa-gram .sub-row.zebra:not(.diet) td { background: #EDEDEA; }
 
 /* Každý výdajný bod (blok) začína na vlastnom liste — kuchyňa vydáva z dvoch
  * miest naraz a každé chce svoju tabuľku, nie polovicu spoločnej strany. */

--- a/backend/api/exporters/gramage_table_html.py
+++ b/backend/api/exporters/gramage_table_html.py
@@ -111,11 +111,14 @@ def _cell(cell: dict) -> str:
 def _row(row: dict) -> str:
     kind = row.get("kind")
     cells = row.get("cells") or []
-    style = (
-        f' style="color: {escape(str(row["color"]), quote=True)}"'
-        if row.get("color")
-        else ""
-    )
+    style_parts = []
+    if row.get("color"):
+        style_parts.append(f"color: {escape(str(row['color']), quote=True)}")
+    if row.get("background"):
+        style_parts.append(
+            f"background-color: {escape(str(row['background']), quote=True)}"
+        )
+    style = f' style="{"; ".join(style_parts)}"' if style_parts else ""
     attrs = _attrs(**{"class": row.get("css")})
 
     if kind == "client":

--- a/backend/api/exporters/gramage_table_spec.py
+++ b/backend/api/exporters/gramage_table_spec.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 
 from .gramage_dashboard_export import (
+    blend_with_white,
     component_subtitle,
     diet_color,
     group_label,
@@ -26,6 +27,11 @@ from .gramage_dashboard_export import (
 )
 
 EMPTY = "—"
+
+# Podfarbenie riadku, keď je diéta zložená z 3+ diét naraz (#536) — v takom
+# prípade podfarbenie podľa jednej konkrétnej zložky pôsobilo náhodne, tak má
+# pevnú, na kombinácii nezávislú farbu. Text riadku ostáva farbou prvej diéty.
+COMBO_DIET_FALLBACK_BACKGROUND = "F97316"
 
 # Prázdny stĺpec na ručné poznámky pri tlači (požiadavka prevádzky 17. 8. 2026).
 NOTE_COLUMN_LABEL = "Poznámka"
@@ -162,6 +168,29 @@ def _label_cell(text: str, count: object, css: str = "lbl", **extra) -> dict:
     cell = {"text": text, "css": css, "count": format_count(count)}
     cell.update(extra)
     return cell
+
+
+def _diet_text_and_background(data: dict, row_like: dict) -> tuple[str, str]:
+    """Farba textu a podfarbenie riadku diéty (#536).
+
+    Jedna diéta: obe farbou tej diéty. Kombinácia dvoch: text hlavnej
+    (prvej), podfarbenie sekundárnej. Kombinácia troch a viac: text prvej,
+    podfarbenie pevnou oranžovou — farba jednej z troch a viac zložiek by
+    pôsobila náhodne, nič konkrétne by neoznačovala.
+    """
+    base_colors = [
+        str(color).lstrip("#").upper()
+        for color in (
+            row_like.get("diet_base_colors") or row_like.get("base_colors") or []
+        )
+        if color
+    ]
+    if len(base_colors) >= 3:
+        return base_colors[0], COMBO_DIET_FALLBACK_BACKGROUND
+    if len(base_colors) == 2:
+        return base_colors[0], base_colors[1]
+    own = diet_color(data, row_like)
+    return own, own
 
 
 def _filter_vydaje(all_vydaje: list[dict], selected: list[str] | None) -> list[int]:
@@ -559,7 +588,9 @@ def _client_rows(
             f"↳ {label}" if is_diet else label,
             sub_row.get("count"),
         )
+        text_hex = background_hex = None
         if is_diet:
+            text_hex, background_hex = _diet_text_and_background(data, sub_row)
             cell["swatch"] = {
                 "color": f"#{diet_color(data, sub_row)}",
                 "base_colors": sub_row.get("diet_base_colors") or [],
@@ -570,10 +601,9 @@ def _client_rows(
                 "css": ("sub-row diet" if is_diet else "sub-row") + zebra,
                 "group_id": key,
                 "collapsible": True,
-                "color": (
-                    f"#{readable_text_color(diet_color(data, sub_row))}"
-                    if is_diet
-                    else None
+                "color": f"#{readable_text_color(text_hex)}" if is_diet else None,
+                "background": (
+                    f"#{blend_with_white(background_hex)}" if is_diet else None
                 ),
                 "cells": [cell] + gram_cells,
             }
@@ -618,11 +648,13 @@ def _client_rows(
         if name not in diet_counts:
             continue
         hex_color = diet_color(data, diet)
+        text_hex, background_hex = _diet_text_and_background(data, diet)
         out.append(
             {
                 "kind": "summary-diet",
                 "css": "summ-diet",
-                "color": f"#{readable_text_color(hex_color)}",
+                "color": f"#{readable_text_color(text_hex)}",
+                "background": f"#{blend_with_white(background_hex)}",
                 "cells": [
                     _label_cell(
                         name,

--- a/backend/api/management/commands/sync_periodic_tasks.py
+++ b/backend/api/management/commands/sync_periodic_tasks.py
@@ -439,8 +439,11 @@ class Command(BaseCommand):
             )
         else:
             for task in tasks:
+                # Väčšina scrape úloh beží Po–Pi; British School (#535) má
+                # vlastný crontab Ne–Št (deň pred pracovným dňom).
+                days = "Ne–Št" if "british-school" in task.name else "Po–Pi"
                 schedule = (
-                    f"{_format_crontab_time(task.crontab)} Mon–Fri"
+                    f"{_format_crontab_time(task.crontab)} {days}"
                     f" (tz: {task.crontab.timezone})"
                     if task.crontab
                     else "no schedule"
@@ -453,11 +456,18 @@ class Command(BaseCommand):
                 self.stdout.write(f"  {status} {task.name} → {schedule}")
 
     def _sync_edupage_scrape_tasks(self, gs):
-        from api.signals import _sync_edupage_scrape_schedule
+        from api.signals import (
+            _sync_british_school_scrape_schedule,
+            _sync_edupage_scrape_schedule,
+        )
 
         self.stdout.write("\n--- Syncing Edupage Scrape Tasks ---")
         try:
             _sync_edupage_scrape_schedule(gs)
+            # Musí ísť po `_sync_edupage_scrape_schedule` — tá skladá
+            # `exclude_connection_ids` podľa toho, či British School
+            # pripojenie už existuje (#535).
+            _sync_british_school_scrape_schedule(gs)
             self.stdout.write(self.style.SUCCESS("✓ Edupage scrape tasks synced!"))
             self._verify_edupage_scrape_tasks()
         except Exception as exc:

--- a/backend/api/signals.py
+++ b/backend/api/signals.py
@@ -44,6 +44,17 @@ WEEKLY_REMINDER_TASK_NAME = "weekly-order-reminder-sunday"
 
 EDUPAGE_SCRAPE_TASK_PREFIX = "edupage-scrape-"
 
+# British School (#535): its own EduPage connection is scraped on a dedicated
+# crontab, entirely separate from the shared GlobalSettings meal deadlines
+# every other celok uses — 12:15 the day before, so its dashboard row is ready
+# well ahead of the (much later) generic deadlines. Name matches
+# `seed_british_school_2026_08.BRITISH_SCHOOL_NAME`; kept as a local literal
+# rather than importing a management command module here.
+BRITISH_SCHOOL_CONNECTION_NAME = "British School"
+BRITISH_SCHOOL_SCRAPE_TASK_NAME = f"{EDUPAGE_SCRAPE_TASK_PREFIX}british-school"
+BRITISH_SCHOOL_SCRAPE_HOUR = 12
+BRITISH_SCHOOL_SCRAPE_MINUTE = 15
+
 # Cron musí bežať v ten deň, na ktorý je úloha nastavená — nie v ten, ktorého sa
 # týka jedlo. Úloha so `is_day_before` deadlinom obsluhuje NASLEDUJÚCI pracovný
 # deň (`_next_workday`), takže musí bežať v jeho predvečer: pre pondelok je to
@@ -424,6 +435,18 @@ def _sync_push_reminder_schedule(settings_instance) -> None:
         _capture_signal_failure(exc, "push_reminder_schedule")
 
 
+def _british_school_connection_id() -> int | None:
+    from api.models import EdupageConnection
+
+    return (
+        EdupageConnection.objects.filter(
+            name=BRITISH_SCHOOL_CONNECTION_NAME, is_active=True
+        )
+        .values_list("pk", flat=True)
+        .first()
+    )
+
+
 def _sync_edupage_scrape_schedule(settings_instance) -> None:
     """
     Create or update Celery Beat PeriodicTasks that fire exactly at each distinct
@@ -459,6 +482,11 @@ def _sync_edupage_scrape_schedule(settings_instance) -> None:
             return
 
         all_meal_types = ["breakfast", "lunch", "olovrant"]
+
+        # British School has its own dedicated scrape (12:15 the day before,
+        # see `_sync_british_school_scrape_schedule`) — exclude it here so it
+        # isn't scraped a second time at the shared deadlines below.
+        british_school_connection_id = _british_school_connection_id()
 
         # Group meal types by deadline time and target-day rule.
         groups: dict[tuple[datetime.time, bool], list[str]] = {}
@@ -506,6 +534,11 @@ def _sync_edupage_scrape_schedule(settings_instance) -> None:
                         {
                             "meal_types": sorted(meal_types_group),
                             "chained_reports": chained_reports,
+                            "exclude_connection_ids": (
+                                [british_school_connection_id]
+                                if british_school_connection_id
+                                else None
+                            ),
                         }
                     ),
                     "enabled": True,
@@ -541,6 +574,78 @@ def _sync_edupage_scrape_schedule(settings_instance) -> None:
     except Exception as exc:
         logger.exception("Failed to sync edupage scrape periodic tasks: %s", exc)
         _capture_signal_failure(exc, "edupage_scrape_schedule")
+
+
+def _sync_british_school_scrape_schedule(settings_instance) -> None:
+    """British School (#535): scraped daily at 12:15 the day before, Sun–Thu,
+    on its own crontab — independent of the shared GlobalSettings meal
+    deadlines every other celok uses (`_sync_edupage_scrape_schedule`).
+
+    A no-op (task deleted, if present) while the British School EduPage
+    connection doesn't exist yet or automatic scraping is switched off.
+    """
+    try:
+        from django.conf import settings
+        from django_celery_beat.models import CrontabSchedule, PeriodicTask
+    except ImportError:
+        logger.warning(
+            "django_celery_beat not installed – skipping British School scrape schedule sync."
+        )
+        return
+
+    try:
+        connection_id = _british_school_connection_id()
+        auto_scrape_enabled = getattr(
+            settings_instance, "edupage_auto_scrape_enabled", True
+        )
+        if connection_id is None or not auto_scrape_enabled:
+            deleted_count, _ = PeriodicTask.objects.filter(
+                name=BRITISH_SCHOOL_SCRAPE_TASK_NAME
+            ).delete()
+            if deleted_count:
+                logger.info(
+                    "British School scrape task removed (connection missing or "
+                    "auto-scrape disabled)"
+                )
+            return
+
+        schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=BRITISH_SCHOOL_SCRAPE_MINUTE,
+            hour=BRITISH_SCHOOL_SCRAPE_HOUR,
+            day_of_week=DAY_OF_WEEK_DAY_BEFORE,
+            day_of_month="*",
+            month_of_year="*",
+            timezone=settings.TIME_ZONE,
+        )
+        PeriodicTask.objects.update_or_create(
+            name=BRITISH_SCHOOL_SCRAPE_TASK_NAME,
+            defaults={
+                "task": "api.tasks.scrape_edupage_orders_task",
+                "crontab": schedule,
+                "args": json.dumps([]),
+                "kwargs": json.dumps(
+                    {
+                        "connection_id": connection_id,
+                        "target_next_workday": True,
+                    }
+                ),
+                "enabled": True,
+                "description": (
+                    "British School EduPage scrape: fires 12:15 the day before "
+                    "(Sun–Thu), importing the next workday's orders."
+                ),
+            },
+        )
+        logger.info(
+            "British School scrape task synced: %02d:%02d Sun-Thu (tz: %s)",
+            BRITISH_SCHOOL_SCRAPE_HOUR,
+            BRITISH_SCHOOL_SCRAPE_MINUTE,
+            settings.TIME_ZONE,
+        )
+
+    except Exception as exc:
+        logger.exception("Failed to sync British School scrape periodic task: %s", exc)
+        _capture_signal_failure(exc, "british_school_scrape_schedule")
 
 
 def _sync_weekly_reminder_schedule() -> None:
@@ -597,6 +702,7 @@ def on_global_settings_saved(sender, instance, created=False, **kwargs):
         _sync_push_reminder_schedule(instance)
         _sync_weekly_reminder_schedule()
         _sync_edupage_scrape_schedule(instance)
+        _sync_british_school_scrape_schedule(instance)
 
         # Invalidate GlobalSettings cache
         from api.cache_service import clear_global_settings_cache

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -508,7 +508,11 @@ def _dispatch_chained_reports(
     return dispatched
 
 
-def _scrape_target_dates(date_str: str | None, meal_types: list[str] | None):
+def _scrape_target_dates(
+    date_str: str | None,
+    meal_types: list[str] | None,
+    target_next_workday: bool = False,
+):
     """Best-effort resolution of the dates a scrape run targets.
 
     Used on the give-up path, where the run blew up before (or while) computing
@@ -518,11 +522,17 @@ def _scrape_target_dates(date_str: str | None, meal_types: list[str] | None):
 
     from django.utils import timezone
 
-    from api.models import GlobalSettings
     from api.services import _next_workday
 
     if date_str:
         return [date_str]
+
+    today = timezone.localdate()
+    if not meal_types:
+        target: datetime.date = _next_workday(today) if target_next_workday else today
+        return [target.isoformat()]
+
+    from api.models import GlobalSettings
 
     try:
         gs = GlobalSettings.objects.get(pk=1)
@@ -530,14 +540,10 @@ def _scrape_target_dates(date_str: str | None, meal_types: list[str] | None):
         logger.exception("Cannot resolve scrape target dates without GlobalSettings")
         return []
 
-    today = timezone.localdate()
-    if not meal_types:
-        return [today.isoformat()]
-
     dates = set()
     for meal_type in meal_types:
         is_day_before = getattr(gs, f"deadline_{meal_type}_is_day_before", False)
-        target: datetime.date = _next_workday(today) if is_day_before else today
+        target = _next_workday(today) if is_day_before else today
         dates.add(target.isoformat())
     return sorted(dates)
 
@@ -547,12 +553,13 @@ def _handle_scrape_give_up(
     date_str: str | None,
     meal_types: list[str] | None,
     chained_reports: list[list[str]] | None,
+    target_next_workday: bool = False,
 ) -> None:
     """Record an exhausted scrape and still send its chained reports, flagged."""
     from api.models import EventLog
     from api.services.event_log_service import log_event
 
-    date_strs = _scrape_target_dates(date_str, meal_types)
+    date_strs = _scrape_target_dates(date_str, meal_types, target_next_workday)
 
     try:
         # CRON_FAILED, nie CRON_SKIPPED: preskočenie znamená „víkend alebo voľný
@@ -585,6 +592,9 @@ def scrape_edupage_orders_task(
     date_str: str | None = None,
     meal_types: list[str] | None = None,
     chained_reports: list[list[str]] | None = None,
+    connection_id: int | None = None,
+    exclude_connection_ids: list[int] | None = None,
+    target_next_workday: bool = False,
 ):
     """
     Scrape mealsGuest HTML for all Edupage operations and upsert DailyOrder records.
@@ -599,6 +609,15 @@ def scrape_edupage_orders_task(
     leave with counts the import had not written yet. Each report is dispatched
     for the exact date(s) this run imported, so the report can no longer describe
     a different day than the one that was just scraped.
+
+    ``connection_id`` / ``exclude_connection_ids`` scope the run to (or away
+    from) one `EdupageConnection` — used by the British School dedicated
+    schedule (#535), which scrapes on its own crontab (12:15 the day before)
+    separate from the shared GlobalSettings meal deadlines, so it must be
+    excluded from the deadline-derived runs to avoid a redundant second scrape.
+    ``target_next_workday`` mirrors a `deadline_*_is_day_before` meal (target =
+    the next workday, not today) for a run that has no `meal_types` of its own
+    to read that flag from.
     """
     try:
         import datetime
@@ -672,7 +691,8 @@ def scrape_edupage_orders_task(
 
             today = timezone.localdate()
             if meal_types is None:
-                date_to_meals = {today: None}
+                target_date = _next_workday(today) if target_next_workday else today
+                date_to_meals = {target_date: None}
             else:
                 date_to_meals = {}
                 for meal_type in meal_types:
@@ -689,7 +709,15 @@ def scrape_edupage_orders_task(
         allowed_diets = allowed_diet_names()
         scraped = errors = skipped = 0
 
-        for operation in edupage_operations():
+        operations = edupage_operations(connection_id=connection_id)
+        if exclude_connection_ids:
+            operations = [
+                operation
+                for operation in operations
+                if operation["connection_id"] not in exclude_connection_ids
+            ]
+
+        for operation in operations:
             prevadzky = list(operation["prevadzky"])
             if not prevadzky:
                 logger.warning(
@@ -881,7 +909,9 @@ def scrape_edupage_orders_task(
             # Retries are spent. The kitchen still needs numbers, so the chained
             # report goes out — but explicitly marked as possibly not final,
             # instead of quietly looking like a normal day (issue #474).
-            _handle_scrape_give_up(exc, date_str, meal_types, chained_reports)
+            _handle_scrape_give_up(
+                exc, date_str, meal_types, chained_reports, target_next_workday
+            )
             raise
 
 

--- a/backend/api/tests/test_edupage_scrape_task.py
+++ b/backend/api/tests/test_edupage_scrape_task.py
@@ -16,7 +16,12 @@ from api.models import (
     ProfileCelokAccess,
     UserProfile,
 )
-from api.signals import EDUPAGE_SCRAPE_TASK_PREFIX, _sync_edupage_scrape_schedule
+from api.signals import (
+    BRITISH_SCHOOL_SCRAPE_TASK_NAME,
+    EDUPAGE_SCRAPE_TASK_PREFIX,
+    _sync_british_school_scrape_schedule,
+    _sync_edupage_scrape_schedule,
+)
 from api.tasks import scrape_edupage_orders_task
 
 
@@ -588,3 +593,153 @@ def test_only_deadline_derived_scrape_tasks_are_scheduled():
         name__startswith=EDUPAGE_SCRAPE_TASK_PREFIX
     ):
         assert json.loads(task.kwargs)["meal_types"]
+
+
+@pytest.mark.django_db
+def test_british_school_scrape_schedule_is_noop_without_connection():
+    """Bez British School EduPage pripojenia sa vlastný scrape nezaloží — inak
+    by čakal na dáta, ktoré nikdy neprídu."""
+    settings_instance = GlobalSettings.objects.create(pk=1)
+
+    _sync_british_school_scrape_schedule(settings_instance)
+
+    assert not PeriodicTask.objects.filter(
+        name=BRITISH_SCHOOL_SCRAPE_TASK_NAME
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_british_school_scrape_schedule_fires_1215_day_before():
+    """British School (#535): 12:15 Ne–Št, cieli na nasledujúci pracovný deň —
+    nezávisle od GlobalSettings deadlinov ostatných celkov."""
+    connection = EdupageConnection.objects.create(
+        name="British School",
+        mealsguest_url="https://zdravyprojekt.edupage.org/menu/mealsGuest?id=Dr8kS45",
+    )
+    settings_instance = GlobalSettings.objects.create(pk=1)
+
+    _sync_british_school_scrape_schedule(settings_instance)
+
+    task = PeriodicTask.objects.get(name=BRITISH_SCHOOL_SCRAPE_TASK_NAME)
+    assert task.crontab.hour == "12"
+    assert task.crontab.minute == "15"
+    assert task.crontab.day_of_week == "0-4"  # Ne–Št
+    kwargs = json.loads(task.kwargs)
+    assert kwargs == {"connection_id": connection.pk, "target_next_workday": True}
+
+
+@pytest.mark.django_db
+def test_british_school_scrape_schedule_removed_when_auto_scrape_disabled():
+    EdupageConnection.objects.create(
+        name="British School",
+        mealsguest_url="https://zdravyprojekt.edupage.org/menu/mealsGuest?id=Dr8kS45",
+    )
+    settings_instance = GlobalSettings.objects.create(pk=1)
+    _sync_british_school_scrape_schedule(settings_instance)
+    assert PeriodicTask.objects.filter(name=BRITISH_SCHOOL_SCRAPE_TASK_NAME).exists()
+
+    settings_instance.edupage_auto_scrape_enabled = False
+    settings_instance.save()
+
+    assert not PeriodicTask.objects.filter(
+        name=BRITISH_SCHOOL_SCRAPE_TASK_NAME
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_deadline_derived_scrape_tasks_exclude_british_school():
+    """British School sa scrapuje len na svojom 12:15 cronte — nie aj na
+    generických deadlinoch ostatných celkov (zdvojený scrape)."""
+    EdupageConnection.objects.create(
+        name="British School",
+        mealsguest_url="https://zdravyprojekt.edupage.org/menu/mealsGuest?id=Dr8kS45",
+    )
+    settings_instance = GlobalSettings.objects.create(
+        pk=1,
+        deadline_breakfast=datetime.time(18, 0),
+        deadline_lunch=datetime.time(21, 0),
+        deadline_olovrant=datetime.time(10, 0),
+    )
+
+    _sync_edupage_scrape_schedule(settings_instance)
+
+    british_school_id = EdupageConnection.objects.get(name="British School").pk
+    for task in PeriodicTask.objects.filter(
+        name__startswith=EDUPAGE_SCRAPE_TASK_PREFIX
+    ).exclude(name=BRITISH_SCHOOL_SCRAPE_TASK_NAME):
+        assert json.loads(task.kwargs)["exclude_connection_ids"] == [british_school_id]
+
+
+@pytest.mark.django_db
+def test_scrape_task_connection_id_scopes_to_one_operation(edupage_user, monkeypatch):
+    """`connection_id` obmedzí scrape na jedno EduPage pripojenie (British
+    School dedikovaný cron, #535) bez toho, aby sa dotkol ostatných."""
+    other_connection = EdupageConnection.objects.create(
+        name="Other school",
+        mealsguest_url="https://other.edupage.org/menu/mealsGuest?id=OTHER",
+    )
+    other_user = User.objects.create_user(
+        username="other@example.com", email="other@example.com"
+    )
+    other_profile = UserProfile.objects.create(
+        user=other_user, company_name="Other school"
+    )
+    other_celok = other_profile.primary_celok()
+    other_celok.zdroj_objednavok = Celok.ZdrojObjednavok.EDUPAGE
+    other_celok.save(update_fields=["zdroj_objednavok"])
+    other_profile.dostupne_prevadzky().update(edupage_connection=other_connection)
+
+    scraped_urls = []
+
+    def fake_scrape(self, url, target_date, prevadzka_matches=None, allowed_diets=None):
+        scraped_urls.append(url)
+        return _scrape_result()
+
+    monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", fake_scrape)
+
+    scrape_edupage_orders_task.run(
+        date_str="2026-06-30", connection_id=other_connection.pk
+    )
+
+    assert scraped_urls == [other_connection.mealsguest_url]
+
+
+@pytest.mark.django_db
+def test_scrape_task_exclude_connection_ids_skips_operation(edupage_user, monkeypatch):
+    connection = EdupageConnection.objects.get(name="Edupage school")
+
+    scraped_urls = []
+
+    def fake_scrape(self, url, target_date, prevadzka_matches=None, allowed_diets=None):
+        scraped_urls.append(url)
+        return _scrape_result()
+
+    monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", fake_scrape)
+
+    scrape_edupage_orders_task.run(
+        date_str="2026-06-30", exclude_connection_ids=[connection.pk]
+    )
+
+    assert scraped_urls == []
+
+
+@pytest.mark.django_db
+def test_scrape_task_target_next_workday_without_meal_types(edupage_user, monkeypatch):
+    """`target_next_workday` funguje aj bez `meal_types` (British School beh
+    nemá per-jedlo deadline, len jeden denný scrape na zajtra)."""
+    GlobalSettings.objects.create(pk=1)
+    today = datetime.date(2026, 6, 29)  # Monday
+    seen_dates = []
+
+    def fake_scrape(self, url, target_date, prevadzka_matches=None, allowed_diets=None):
+        seen_dates.append(target_date)
+        return _scrape_result()
+
+    monkeypatch.setattr(timezone, "localdate", lambda: today)
+    monkeypatch.setattr("api.edupage_scraper.EdupageScraper.scrape", fake_scrape)
+
+    result = scrape_edupage_orders_task.run(target_next_workday=True)
+
+    tomorrow = datetime.date(2026, 6, 30)
+    assert result["dates"] == [str(tomorrow)]
+    assert seen_dates == [tomorrow]

--- a/backend/api/tests/test_gramage_table_html.py
+++ b/backend/api/tests/test_gramage_table_html.py
@@ -1,0 +1,36 @@
+"""`gramage_table_html._row` prekladá spec do značiek — testy zamykajú, že farba
+textu a podfarbenie diétneho riadku (#536) obe skončia v jednom `style` atribúte,
+nie že sa navzájom prepíšu."""
+
+from api.exporters.gramage_table_html import _row
+
+
+def test_row_renders_both_colour_and_background():
+    html = _row(
+        {
+            "kind": "sub-row",
+            "css": "sub-row diet",
+            "color": "#966107",
+            "background": "#FDF0D9",
+            "cells": [{"text": "No Milk"}],
+        }
+    )
+    assert 'style="color: #966107; background-color: #FDF0D9"' in html
+
+
+def test_row_without_background_only_sets_colour():
+    html = _row(
+        {
+            "kind": "sub-row",
+            "css": "sub-row",
+            "color": "#425422",
+            "cells": [{"text": "Menu A"}],
+        }
+    )
+    assert 'style="color: #425422"' in html
+    assert "background-color" not in html
+
+
+def test_row_without_colour_or_background_has_no_style_attribute():
+    html = _row({"kind": "sub-row", "css": "sub-row", "cells": [{"text": "Menu A"}]})
+    assert " style=" not in html

--- a/backend/api/tests/test_gramage_table_spec.py
+++ b/backend/api/tests/test_gramage_table_spec.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 import pytest
 
+from api.exporters.gramage_dashboard_export import blend_with_white, readable_text_color
 from api.exporters.gramage_table_spec import build_table_spec, format_count, format_gram
 
 GRAMS = {"label": "Mäso", "base_grams": "300", "unit": "g"}
@@ -281,6 +282,42 @@ def test_diet_rows_get_a_readable_font_colour_and_a_swatch():
     # Swatch drží pôvodnú farbu diéty, text stmavenú (čitateľnú) verziu.
     assert diet["cells"][0]["swatch"]["color"] == "#F59E0B"
     assert diet["color"] == "#966107"
+    # Jedna diéta (bez kombinácie): podfarbenie je odtieň tej istej farby (#536).
+    assert diet["background"] == f"#{blend_with_white('F59E0B')}"
+
+
+def test_combined_diet_of_two_colours_by_main_and_secondary():
+    """Kombinovaná diéta z dvoch: text farbou hlavnej, podfarbenie vedľajšej (#536)."""
+    payload = _payload()
+    payload["rows"][0]["diet_summary_rows"][0]["base_colors"] = ["#F59E0B", "#EF4444"]
+    payload["rows"][0]["sub_rows"][1]["diet_base_colors"] = ["#F59E0B", "#EF4444"]
+
+    spec = build_table_spec(payload)
+
+    summary = next(r for r in spec["rows"] if r["kind"] == "summary-diet")
+    assert summary["color"] == f"#{readable_text_color('F59E0B')}"
+    assert summary["background"] == f"#{blend_with_white('EF4444')}"
+
+    sub_row = next(
+        r for r in spec["rows"] if r["kind"] == "sub-row" and "diet" in r["css"]
+    )
+    assert sub_row["color"] == f"#{readable_text_color('F59E0B')}"
+    assert sub_row["background"] == f"#{blend_with_white('EF4444')}"
+
+
+def test_combined_diet_of_three_or_more_uses_fixed_orange_background():
+    """Kombinácia troch a viac diét: text prvej, podfarbenie pevnou oranžovou,
+    lebo farba jednej z troch a viac zložiek by pôsobila náhodne (#536)."""
+    payload = _payload()
+    colors = ["#F59E0B", "#EF4444", "#16A34A"]
+    payload["rows"][0]["diet_summary_rows"][0]["base_colors"] = colors
+    payload["rows"][0]["sub_rows"][1]["diet_base_colors"] = colors
+
+    spec = build_table_spec(payload)
+
+    summary = next(r for r in spec["rows"] if r["kind"] == "summary-diet")
+    assert summary["color"] == f"#{readable_text_color('F59E0B')}"
+    assert summary["background"] == f"#{blend_with_white('F97316')}"
 
 
 def test_footer_is_the_portion_summary_plus_the_grand_total():

--- a/frontend/src/lib/businessDay.test.ts
+++ b/frontend/src/lib/businessDay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   businessDays,
+  dashboardMaxDate,
   dayOffReason,
   isDayOff,
   nextBusinessDay,
@@ -13,6 +14,11 @@ import {
 const monday = () => new Date(2026, 7, 10);
 const saturday = () => new Date(2026, 7, 8);
 const sunday = () => new Date(2026, 7, 9);
+const atHour = (date: Date, hour: number) => {
+  const result = new Date(date);
+  result.setHours(hour, 0, 0, 0);
+  return result;
+};
 
 describe("previousBusinessDay", () => {
   it("leaves a weekday unchanged", () => {
@@ -75,5 +81,35 @@ describe("businessDays", () => {
       closures: new Set(["2026-08-12"]),
     });
     expect(days.map(toDateKey)).toEqual(["2026-08-10", "2026-08-13", "2026-08-14"]);
+  });
+});
+
+// #535 — British School sa scrapuje 12:15 deň vopred, dashboard preto
+// odomyká zajtrajšok o 12:00, pokiaľ samo zajtra nie je voľno.
+describe("dashboardMaxDate", () => {
+  it("stays on today before noon", () => {
+    expect(dashboardMaxDate(atHour(monday(), 11))).toBe("2026-08-10");
+  });
+
+  it("unlocks tomorrow from noon on a weekday whose tomorrow is a workday", () => {
+    expect(dashboardMaxDate(atHour(monday(), 12))).toBe("2026-08-11");
+  });
+
+  it("does not unlock past a weekend — Friday noon stays on Friday", () => {
+    const friday = new Date(2026, 7, 7);
+    expect(dashboardMaxDate(atHour(friday, 12))).toBe("2026-08-07");
+  });
+
+  it("unlocks Monday from Sunday noon, matching the Sun–Thu scrape crontab", () => {
+    expect(dashboardMaxDate(atHour(sunday(), 12))).toBe("2026-08-10");
+  });
+
+  it("does not unlock a tomorrow that is a holiday", () => {
+    const holidays = new Set(["2026-08-11"]);
+    expect(dashboardMaxDate(atHour(monday(), 12), { holidays })).toBe("2026-08-10");
+  });
+
+  it("saturday noon stays on the last business day (Friday)", () => {
+    expect(dashboardMaxDate(atHour(saturday(), 12))).toBe("2026-08-07");
   });
 });

--- a/frontend/src/lib/businessDay.ts
+++ b/frontend/src/lib/businessDay.ts
@@ -137,6 +137,33 @@ export function lastWeekdayToday(sets: DayOffSets = {}): string {
   return toDateKey(previousBusinessDay(new Date(), sets));
 }
 
+/** Od ktorej hodiny sa v dashboard tabuľke odomkne zajtrajší deň (#535).
+ * British School sa scrapuje o 12:15 predošlý deň, takže admin/kuchyňa
+ * potrebuje zajtrajšok vedieť otvoriť ešte pred tým, než dáta pribudnú. */
+const DASHBOARD_NEXT_DAY_UNLOCK_HOUR = 12;
+
+/**
+ * Najneskorší deň, ktorý smie dashboard tabuľka (admin Prehľad, kuchyňa)
+ * zobraziť. Za bežných okolností je to `lastWeekdayToday` — dnešok, alebo
+ * posledný pracovný deň pred víkendom/sviatkom.
+ *
+ * Od `DASHBOARD_NEXT_DAY_UNLOCK_HOUR` (12:00) sa navyše odomkne aj
+ * nasledujúci kalendárny deň, pokiaľ sám nie je voľno — presne v čase, keď sa
+ * pre British School spúšťa jej vlastný scrape (12:15 deň vopred, #535).
+ * Mimo tohto okna (napr. piatok poobede, keď je „zajtra" sobota) ostáva
+ * `lastWeekdayToday` bez zmeny.
+ */
+export function dashboardMaxDate(now: Date = new Date(), sets: DayOffSets = {}): string {
+  if (now.getHours() >= DASHBOARD_NEXT_DAY_UNLOCK_HOUR) {
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (!isDayOff(tomorrow, sets)) {
+      return toDateKey(tomorrow);
+    }
+  }
+  return toDateKey(previousBusinessDay(now, sets));
+}
+
 export function formatDay(key: string): string {
   return fromDateKey(key).toLocaleDateString('sk-SK', {
     weekday: 'long',

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -9,7 +9,7 @@ import GramageTable, { type TableSpec, type SpecSection, type SpecVydaj } from "
 import {
   prevWeekday,
   nextWeekday,
-  lastWeekdayToday,
+  dashboardMaxDate,
   toDateString,
   isWeekday,
   formatDay as formatDate,
@@ -167,7 +167,9 @@ interface ClosedDayResponse {
 const AdminDashboard: React.FC = () => {
   const { apiFetch } = useAuth();
   const { error: toastError, success: toastSuccess } = useToast();
-  const maxDate = useMemo(() => lastWeekdayToday(), []);
+  // Od 12:00 sa odomkne aj zajtrajšok — British School sa scrapuje o 12:15
+  // deň vopred, tak jej riadok potrebuje byť vidno ešte pred tým (#535).
+  const maxDate = useMemo(() => dashboardMaxDate(), []);
   const actualToday = useMemo(() => toDateString(new Date()), []);
   const [date, setDate] = useState(maxDate);
   const [data, setData] = useState<GramageDashboard | null>(null);
@@ -381,7 +383,12 @@ const AdminDashboard: React.FC = () => {
                 style={{ width: "auto" }}
               />
               {date === actualToday && <Badge tone="orange">Dnes</Badge>}
-              {date === maxDate && date !== actualToday && <Badge tone="gray">Posledný pracovný deň</Badge>}
+              {date === maxDate && date !== actualToday && date > actualToday && (
+                <Badge tone="orange">Zajtra</Badge>
+              )}
+              {date === maxDate && date !== actualToday && date < actualToday && (
+                <Badge tone="gray">Posledný pracovný deň</Badge>
+              )}
             </div>
             <button
               className="zpa-navchip"

--- a/frontend/src/pages/admin/GramageTable.tsx
+++ b/frontend/src/pages/admin/GramageTable.tsx
@@ -30,6 +30,8 @@ export interface SpecRow {
   group_id?: string;
   collapsible?: boolean;
   color?: string | null;
+  /** Podfarbenie riadku diéty — hlavná/vedľajšia farba kombinovanej diéty (#536). */
+  background?: string | null;
   /** Len na riadkoch `kind: "client"` — cieľ odklikávania naloženia (#487). */
   prevadzka_id?: number | null;
 }
@@ -110,7 +112,10 @@ const GramageTable: React.FC<GramageTableProps> = ({ spec, className, renderClie
   // Riadok si nesie triedy aj farbu zo spec-u — tu sa už nič nerozhoduje,
   // len prekladá na značky (viď backend/api/exporters/gramage_table_spec.py).
   const renderRow = (row: SpecRow, index: number) => {
-    const style = row.color ? { color: row.color } : undefined;
+    const style =
+      row.color || row.background
+        ? { color: row.color ?? undefined, backgroundColor: row.background ?? undefined }
+        : undefined;
 
     if (row.kind === "client") {
       const cell = row.cells[0];

--- a/frontend/src/pages/kuchyna/KuchynaOverview.tsx
+++ b/frontend/src/pages/kuchyna/KuchynaOverview.tsx
@@ -20,7 +20,8 @@ import { plural } from '../../lib/plural';
 import {
     prevWeekday,
     nextWeekday,
-    lastWeekdayToday,
+    dashboardMaxDate,
+    toDateString,
     formatDay,
 } from '../../lib/businessDay';
 import GramageTable, { type TableSpec } from '../admin/GramageTable';
@@ -57,7 +58,10 @@ interface LoadingOverview {
 const KuchynaOverview: React.FC = () => {
     const { apiFetch } = useAuth();
     const { error: toastError, success: toastSuccess } = useToast();
-    const maxDate = useMemo(() => lastWeekdayToday(), []);
+    // Od 12:00 sa odomkne aj zajtrajšok — British School sa scrapuje o 12:15
+    // deň vopred, tak jej riadok potrebuje byť vidno ešte pred tým (#535).
+    const maxDate = useMemo(() => dashboardMaxDate(), []);
+    const actualToday = useMemo(() => toDateString(new Date()), []);
     const [date, setDate] = useState(maxDate);
     const [data, setData] = useState<DashboardResponse | null>(null);
     const [loading, setLoading] = useState(false);
@@ -220,7 +224,9 @@ const KuchynaOverview: React.FC = () => {
                     <span className="zpk-day-label">{formatDay(date)}</span>
                     {date !== maxDate && (
                         <button type="button" className="zpk-today" onClick={() => setDate(maxDate)}>
-                            Späť na dnešok
+                            {/* Po 12:00 je maxDate zajtrajšok (British School, #535) —
+                                tlačidlo vtedy nesmie tvrdiť, že vedie „na dnešok". */}
+                            {maxDate === actualToday ? 'Späť na dnešok' : 'Späť na najnovší deň'}
                         </button>
                     )}
                 </div>


### PR DESCRIPTION
Rieši #535 a #536.

## #535 — British School: vlastný scrape 12:15 deň vopred, dashboard preview od 12:00

- `scrape_edupage_orders_task` dostal `connection_id` / `exclude_connection_ids` (obmedzenie na jedno EduPage pripojenie) a `target_next_workday` (deň vopred bez potreby `meal_types`, ktoré si dnes nesú vlastný `is_day_before` flag).
- Nový `_sync_british_school_scrape_schedule` (`signals.py`): vlastný crontab **12:15 Ne–Št**, cieli na nasledujúci pracovný deň. No-op, kým British School EduPage pripojenie neexistuje alebo je automatický scrape vypnutý.
- `_sync_edupage_scrape_schedule` vylučuje British School pripojenie z bežných deadline-derived scrape úloh (`exclude_connection_ids`), aby sa nescrapovalo dvakrát.
- `sync_periodic_tasks` volá nový sync a vo verify výpise rozlišuje Po–Pi / Ne–Št.
- Dashboard (admin Prehľad aj kuchyňa): nová `dashboardMaxDate()` (`frontend/src/lib/businessDay.ts`) odomkne zajtrajšok od 12:00, pokiaľ ono samo nie je voľno — presne v okne, kedy British School scrape beží. Badge/tlačidlo v UI rozlišuje „Zajtra" od „Posledný pracovný deň" / „dnešok", aby nič netvrdilo niečo iné, než sa reálne zobrazuje.

## #536 — Gramáž tabuľka: čiary v tlači + farby diétnych riadkov

- Diétny riadok (sub-row aj summary-diet) dostal okrem farby textu aj **podfarbenie**:
  - jedna diéta → obe farbou tej diéty,
  - kombinácia dvoch → text hlavnej (prvej), podfarbenie sekundárnej,
  - kombinácia 3+ → text prvej, podfarbenie pevnou oranžovou (farba jednej z troch a viac zložiek by pôsobila náhodne).
- Oba renderery (`GramageTable.tsx` aj `gramage_table_html.py`) vedia vykresliť `color` aj `background-color` v jednom `style` atribúte.
- Tlačový `gramage-pdf.css`: plná mriežka (`border`) medzi bunkami namiesto spoliehania sa len na `meal-sep` a farebné pásy; zebra pruh teraz vynecháva diétne riadky, aby neprekryl ich nové podfarbenie.

## Testy

- Backend: nové testy pre schedule sync (`_sync_british_school_scrape_schedule`, exclude logika), task parametre (`connection_id`/`exclude_connection_ids`/`target_next_workday`), farby/pozadie v `gramage_table_spec.py`, a HTML render štýlov.
- Frontend: nové testy pre `dashboardMaxDate` (noon unlock, víkend/sviatok, Sun→Mon zhoda s cron maskou).
- `black --check`, `isort --check-only`, `mypy api`, `npx tsc --noEmit`, `npm run lint`, `npx vitest run` — všetko zelené.
- Plný backend suite lokálne zelený okrem 5 preexistujúcich zlyhaní (chýbajúci `weasyprint` v lokálnom venv + jeden flaky cache test s kolidujúcou testovacou DB) — nesúvisia s týmto diffom, potvrdené aj mimo neho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)